### PR TITLE
refactor(mm-search): replace redirects with middleware

### DIFF
--- a/packages/mirror-media-search/middleware.js
+++ b/packages/mirror-media-search/middleware.js
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { URL_MIRROR_MEDIA } from './config'
+
+export function middleware(req) {
+  console.log(
+    JSON.stringify({
+      severity: 'DEBUG',
+      message: `redirect to mirror media with invalid path ${req.url}`,
+    })
+  )
+  return NextResponse.redirect(URL_MIRROR_MEDIA)
+}
+
+// since there is only search page, redirect other pages back to mirror media
+export const config = {
+  matcher: [
+    '/search',
+    '/((?!api|static|favicon.ico|_next|images|sw|search).*)',
+  ],
+}

--- a/packages/mirror-media-search/next.config.js
+++ b/packages/mirror-media-search/next.config.js
@@ -10,20 +10,6 @@ const nextConfig = {
 
     return config
   },
-  async redirects() {
-    return [
-      {
-        source: '/search',
-        destination: process.env.URL_MIRROR_MEDIA,
-        permanent: true,
-      },
-      {
-        source: '/((?!api|static|favicon.ico|_next|images|sw|search).*)',
-        destination: process.env.URL_MIRROR_MEDIA,
-        permanent: true,
-      },
-    ]
-  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Since using process.env.variables in next.config.js will expose the sensitive data to the build and there will be some additional setting due to running docker build and yarn build needs the environment variable. It's simpler just to put the redirect logic in the middleware.