### PR TITLE
feat(mm-next): add custom theme type, add `color` in custom theme

### DIFF
--- a/packages/mirror-media-next/styles/theme/color.js
+++ b/packages/mirror-media-next/styles/theme/color.js
@@ -1,0 +1,24 @@
+const brandColor = {
+  darkBlue: '#054F77',
+  lightBlue: '#61B8C6',
+  black: '#000000',
+  white: '#ffffff',
+  gray: '#555555',
+}
+const sectionsColor = {
+  member: '#e51731',
+  news: '#61B8C6',
+  entertainment: '#D43E96',
+  businessmoney: '#07B53B',
+  people: '#efa256', //not updated yet
+  videohub: '#B9B9B9',
+  international: '#911f27', //not updated yet
+  foodtravel: '#eac151', //not updated yet
+  mafalda: '#8F39CE',
+  culture: '#A8CF68',
+  carandwatch: '#1877F2',
+  external: '#30bac8', //not updated yet
+  mirrorcolumn: '#B79479',
+}
+
+export const color = { brandColor, sectionsColor }

--- a/packages/mirror-media-next/styles/theme/index.js
+++ b/packages/mirror-media-next/styles/theme/index.js
@@ -1,5 +1,9 @@
-import { breakpoint } from './media'
+//REMINDER: If object `theme` has been edited, please adjust corresponding jsDoc typedef.
+//corresponding jsDoc typedef is located at '../type/theme.js'
 
+import { breakpoint } from './media'
+import { color } from './color'
 export const theme = {
   breakpoint,
+  color,
 }

--- a/packages/mirror-media-next/type/theme.js
+++ b/packages/mirror-media-next/type/theme.js
@@ -1,0 +1,42 @@
+export default {}
+
+/**
+ * @typedef {Object} ThemeBreakpoint
+ * @property {String} xs
+ * @property {String} sm
+ * @property {String} md
+ * @property {String} lg
+ * @property {String} xl
+ * @property {String} xxl
+ */
+
+/**
+ * @typedef {Object} ThemeColors
+ * @property {Object} brandColor
+ * @property {String} brandColor.darkBlue
+ * @property {String} brandColor.lightBlue
+ * @property {String} brandColor.black
+ * @property {String} brandColor.white
+ * @property {String} brandColor.gray
+ *
+ * @property {Object} sectionsColor
+ * @property {String} sectionsColor.member
+ * @property {String} sectionsColor.news
+ * @property {String} sectionsColor.entertainment
+ * @property {String} sectionsColor.businessmoney
+ * @property {String} sectionsColor.people
+ * @property {String} sectionsColor.videohub
+ * @property {String} sectionsColor.international
+ * @property {String} sectionsColor.foodtravel
+ * @property {String} sectionsColor.mafalda
+ * @property {String} sectionsColor.culture
+ * @property {String} sectionsColor.carandwatch
+ * @property {String} sectionsColor.external
+ * @property {String} sectionsColor.mirrorcolumn
+ */
+
+/**
+ * @typedef Theme
+ * @property {ThemeBreakpoint} breakpoint
+ * @property  {ThemeColors} color
+ */


### PR DESCRIPTION
## Change
1. 新增`styles/theme/color.js`，用於放顏色相關的設定，目前分為brandColor與sectionsColor兩個物件，其分別為網站常用的品牌代表色，以及sections對應的代表色。
2. 新增styled-component的custom theme的typedef。 