### PR TITLE
feat(mm-next): add CORS setting in mock server

### DIFF
--- a/packages/mirror-media-next/mocks/server.js
+++ b/packages/mirror-media-next/mocks/server.js
@@ -1,8 +1,11 @@
 const express = require('express')
 const path = require('path')
 const querystring = require('querystring')
+const cors = require('cors')
 
 const app = express()
+
+app.use(cors())
 
 app.get('/json/:filename', (req, res) => {
   const filepath = path.resolve(__dirname, `./statics.mirrormedia.mg/json/${req.params.filename}`)

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@svgr/webpack": "^6.3.1",
     "axios": "^0.27.2",
+    "cors": "^2.8.5",
     "next": "12.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
由於部分頁面需要在client side向mock server發出get請求，若無設定cors，而會有CORS問題。
解決方法為使用套件express官方套件[cors](https://github.com/expressjs/cors)，並在mock server上使用該套件。
該套件的CORS設定，預設為全開放：
```
{
  "origin": "*",
  "methods": "GET,HEAD,PUT,PATCH,POST,DELETE",
  "preflightContinue": false,
  "optionsSuccessStatus": 204
}
```
暫不調整CORS設定，若有另外需調整之處，再另發PR處理。