### PR TITLE
refactor(mm-next): update config and adjust related code

### DIFF
--- a/packages/mirror-media-next/config/index.js
+++ b/packages/mirror-media-next/config/index.js
@@ -3,10 +3,11 @@ const URL_MIRROR_MEDIA =
 
 // The following variables are from environment variables
 
-const ENV = process.env.ENV || 'local'
-const API_PROTOCOL = process.env.API_PROTOCOL || 'http'
-const RESTFUL_API_HOST = process.env.RESTFUL_API_HOST || 'no-api-host'
-const API_PORT = process.env.API_PORT || '8080'
+const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
+const API_PROTOCOL = process.env.NEXT_PUBLIC_API_PROTOCOL || 'http'
+const RESTFUL_API_HOST =
+  process.env.NEXT_PUBLIC_RESTFUL_API_HOST || 'no-api-host'
+const API_PORT = process.env.NEXT_PUBLIC_API_PORT || '8080'
 
 // The following variables are given values according to different `ENV`
 let API_TIMEOUT = 5000
@@ -14,53 +15,31 @@ let URL_STATIC_COMBO_SECTIONS =
   'https://storage.googleapis.com/statics.mirrormedia.mg/json/sections.json'
 let URL_STATIC_COMBO_TOPICS = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/combo?endpoint=topics`
 let URL_K3_FLASH_NEWS = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/getposts?where={"categories":{"$in":["5979ac0de531830d00e330a7","5979ac33e531830d00e330a9","57e1e16dee85930e00cad4ec","57e1e200ee85930e00cad4f3"]},"isAudioSiteOnly":false}&clean=content&max_results=10&page=1&sort=-publishedDate`
-let URL_STATIC_POST_EXTERNALS_01 = ''
-let URL_STATIC_POST_EXTERNALS_02 = ''
-let URL_STATIC_POST_EXTERNALS_03 = ''
-let URL_STATIC_POST_EXTERNALS_04 = ''
-
+let URL_STATIC_POST_EXTERNAL = ''
 switch (ENV) {
   case 'prod':
     API_TIMEOUT = 1500
-    URL_STATIC_POST_EXTERNALS_01 =
-      'https://storage.googleapis.com/statics.mirrormedia.mg/json/post_external01.json'
-    URL_STATIC_POST_EXTERNALS_02 =
-      'https://storage.googleapis.com/statics.mirrormedia.mg/json/post_external02.json'
-    URL_STATIC_POST_EXTERNALS_03 =
-      'https://storage.googleapis.com/statics.mirrormedia.mg/json/post_external03.json'
-    URL_STATIC_POST_EXTERNALS_04 =
-      'https://storage.googleapis.com/statics.mirrormedia.mg/json/post_external04.json'
+
+    URL_STATIC_POST_EXTERNAL =
+      'https://storage.googleapis.com/statics.mirrormedia.mg/json/post_external'
   case 'staging':
     API_TIMEOUT = 1500
-    URL_STATIC_POST_EXTERNALS_01 =
-      'https://storage.googleapis.com/statics.mirrormedia.mg/json/post_external01.json'
-    URL_STATIC_POST_EXTERNALS_02 =
-      'https://storage.googleapis.com/statics.mirrormedia.mg/json/post_external02.json'
-    URL_STATIC_POST_EXTERNALS_03 =
-      'https://storage.googleapis.com/statics.mirrormedia.mg/json/post_external03.json'
-    URL_STATIC_POST_EXTERNALS_04 =
-      'https://storage.googleapis.com/statics.mirrormedia.mg/json/post_external04.json'
+    URL_STATIC_POST_EXTERNAL =
+      'https://storage.googleapis.com/statics.mirrormedia.mg/json/post_external'
+
     break
   case 'dev':
     API_TIMEOUT = 5000
-    URL_STATIC_POST_EXTERNALS_01 =
-      'https://storage.googleapis.com/statics.mirrormedia.mg/dev/post_external01.json'
-    URL_STATIC_POST_EXTERNALS_02 =
-      'https://storage.googleapis.com/statics.mirrormedia.mg/dev/post_external02.json'
-    URL_STATIC_POST_EXTERNALS_03 =
-      'https://storage.googleapis.com/statics.mirrormedia.mg/dev/post_external03.json'
-    URL_STATIC_POST_EXTERNALS_04 =
-      'https://storage.googleapis.com/statics.mirrormedia.mg/dev/post_external04.json'
+    URL_STATIC_POST_EXTERNAL =
+      'https://storage.googleapis.com/statics.mirrormedia.mg/dev/post_external'
+
     break
   default:
     API_TIMEOUT = 5000
     URL_STATIC_COMBO_SECTIONS = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/json/sections.json`
     URL_STATIC_COMBO_TOPICS = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/api/v2/combo?endpoint=topics`
     URL_K3_FLASH_NEWS = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/api/v2/getposts?where={"categories":{"$in":["5979ac0de531830d00e330a7","5979ac33e531830d00e330a9","57e1e16dee85930e00cad4ec","57e1e200ee85930e00cad4f3"]},"isAudioSiteOnly":false}&clean=content&max_results=10&page=1&sort=-publishedDate`
-    URL_STATIC_POST_EXTERNALS_01 = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/json/post_external01.json`
-    URL_STATIC_POST_EXTERNALS_02 = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/json/post_external02.json`
-    URL_STATIC_POST_EXTERNALS_03 = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/json/post_external03.json`
-    URL_STATIC_POST_EXTERNALS_04 = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/json/post_external04.json`
+    URL_STATIC_POST_EXTERNAL = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/json/post_external`
 }
 
 export {
@@ -72,8 +51,5 @@ export {
   RESTFUL_API_HOST,
   API_PORT,
   API_TIMEOUT,
-  URL_STATIC_POST_EXTERNALS_01,
-  URL_STATIC_POST_EXTERNALS_02,
-  URL_STATIC_POST_EXTERNALS_03,
-  URL_STATIC_POST_EXTERNALS_04,
+  URL_STATIC_POST_EXTERNAL,
 }

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -10,7 +10,7 @@ import {
   API_TIMEOUT,
   URL_STATIC_COMBO_TOPICS,
   URL_K3_FLASH_NEWS,
-  URL_STATIC_POST_EXTERNALS_01,
+  URL_STATIC_POST_EXTERNAL,
 } from '../config'
 
 import FlashNews from '../components/flash-news'
@@ -162,7 +162,7 @@ export async function getServerSideProps() {
       }),
       axios({
         method: 'get',
-        url: URL_STATIC_POST_EXTERNALS_01,
+        url: `${URL_STATIC_POST_EXTERNAL}01.json`,
         timeout: API_TIMEOUT,
       }),
     ])


### PR DESCRIPTION
由於首頁最新文章需在client side抓取複數endpoint的資料，而每個endpoint在不同環境皆有所不同，並且由環境變數所決定。

然而nextjs的設計，如果環境變數不加上`NEXT_PUBLIC_`前綴的話，是無法在client side取得該環境變數。

這邊則調整使用環境變數的`config/index.js`檔，將使用的環境變數接加上前綴。