### PR TITLE
refactor(mm-next): add `/utils`, move function of transform raw data content to it

### DIFF
--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -12,7 +12,7 @@ import {
   URL_K3_FLASH_NEWS,
   URL_STATIC_POST_EXTERNAL,
 } from '../config'
-
+import { transformRawDataToArticleInfo } from '../utils'
 import FlashNews from '../components/flash-news'
 import NavTopics from '../components/nav-topics'
 import SubscribeMagazine from '../components/subscribe-magazine'
@@ -32,32 +32,6 @@ const IndexContainer = styled.main`
 const IndexTop = styled.div`
   display: flex;
 `
-/**
- * Get path of article base on different article style, and whether is external article.
- * @param {String} slug
- * @param {import('../type/editor-choice.typedef').ArticleStyle} style
- * @param {Object |''} partner
- * @returns {String}
- */
-const getArticleHref = (slug, style, partner) => {
-  if (partner) {
-    return `/external/${slug}/`
-  }
-  if (style === 'campaign') {
-    return `/campaigns/${slug}`
-  } else if (style === 'projects') {
-    return `/projects/${slug}/`
-  }
-  /**
-   * TODO: condition `isPremiumMember` is whether user is log in and is premium member,
-   * We haven't migrate membership system yet, so remove this condition temporally.
-   */
-  // else if (isPremiumMember) {
-  //   return `pre/story/${slug}/`
-  // }
-
-  return `/story/${slug}/`
-}
 
 /**
  *
@@ -79,30 +53,7 @@ export default function Home({
       href: `/story/${slug}`,
     }
   })
-  const editorChoice = editorChoicesData.map((article) => {
-    const {
-      slug = '',
-      title = '',
-      heroImage,
-      sections,
-      partner,
-      style,
-    } = article
-    const [section] = sections
-
-    const { mobile = {}, tablet = {} } = heroImage?.image
-      ? heroImage?.image?.resizedTargets
-      : {}
-    return {
-      title,
-      slug,
-      href: getArticleHref(slug, style, partner),
-      imgSrcTablet: mobile?.url || '/images/default-og-img.png',
-      imgSrcMobile: tablet?.url || '/images/default-og-img.png',
-      sectionTitle: section?.title || '',
-      sectionName: section?.name || '',
-    }
-  })
+  const editorChoice = transformRawDataToArticleInfo(editorChoicesData)
   const topics = useMemo(
     () => topicsData.filter((topic) => topic.isFeatured).slice(0, 9) ?? [],
     [topicsData]

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -1,0 +1,105 @@
+/**
+ * @typedef {import('../type/raw-data.typedef').RawData} RawData
+ */
+
+/**
+ * Get path of article base on different article style, and whether is external article.
+ * @param {String} slug
+ * @param {import('../type/raw-data.typedef').ArticleStyle} style
+ * @param {Object |''} partner
+ * @returns {String}
+ */
+const getArticleHref = (slug, style, partner) => {
+  if (partner) {
+    return `/external/${slug}/`
+  }
+  if (style === 'campaign') {
+    return `/campaigns/${slug}`
+  } else if (style === 'projects') {
+    return `/projects/${slug}/`
+  }
+  /**
+   * TODO: condition `isPremiumMember` is whether user is log in and is premium member,
+   * We haven't migrate membership system yet, so remove this condition temporally.
+   */
+  // else if (isPremiumMember) {
+  //   return `pre/story/${slug}/`
+  // }
+
+  return `/story/${slug}/`
+}
+
+/**
+ * Get section name based on different condition
+ * @param {import('../type/raw-data.typedef').Section[]} sections
+ * @param {Object | ''} partner
+ * @returns {String | undefined}
+ */
+function getSectionName(sections = [], partner = '') {
+  if (partner) {
+    return 'external'
+  } else if (sections?.some((section) => section.name === 'member')) {
+    return 'member'
+  }
+  return sections[0]?.name
+}
+
+/**
+ * Get section title based on different condition
+ * @param {import('../type/raw-data.typedef').Section[]} sections
+ * @param {Object | ''} partner
+ * @returns {String | undefined}
+ */
+function getSectionTitle(sections = [], partner) {
+  if (partner) {
+    if (partner.name === 'healthnews') {
+      return '生活'
+    } else if (partner.name === 'ebc') {
+      return '時事'
+    } else {
+      return '時事'
+    }
+  }
+
+  if (sections.length > 0) {
+    if (sections.some((section) => section.name === 'member')) {
+      return '會員專區'
+    } else {
+      return sections[0]?.title
+    }
+  }
+  return undefined
+}
+
+/**
+ * Transform the item in the array into a specific data structure, which will be applied to a specific list page
+ * @param {RawData[]} rawData
+ * @returns {Object[]}
+ */
+const transformRawDataToArticleInfo = (rawData) => {
+  return rawData.map((article) => {
+    const {
+      slug = '',
+      title = '',
+      heroImage,
+      sections,
+      partner,
+      style,
+    } = article
+
+    const { mobile = {}, tablet = {} } = heroImage?.image
+      ? heroImage?.image?.resizedTargets
+      : {}
+    return {
+      title,
+      slug,
+      href: getArticleHref(slug, style, partner),
+      imgSrcMobile: mobile?.url || '/images/default-og-img.png',
+      imgSrcTablet: tablet?.url || '/images/default-og-img.png',
+      sectionTitle: getSectionTitle(sections, partner),
+      sectionName: getSectionName(sections, partner),
+    }
+  })
+}
+
+export { transformRawDataToArticleInfo }


### PR DESCRIPTION
新增資料夾`/utils`，用於存放共用的函式。目前僅export一函式為`transformRawDataToArticleInfo`，用途為將打api取得的raw data轉為特定的資料結構，該特定資料結構用於render列表頁的文章卡片元件。

預計將會使用於首頁編輯精選、首頁最新文章、以及section、category等列表頁。