### PR TITLE
refactor(mm-next): handle error at `getServersideProps`, not at `apollo-link

### DIFF
--- a/packages/mirror-media-next/apollo/apollo-client.js
+++ b/packages/mirror-media-next/apollo/apollo-client.js
@@ -1,61 +1,9 @@
-// We use apollo/link to print log when error occur at executing GraphQL operations,
-// see docs to get more information:
-// https://www.apollographql.com/docs/react/data/error-handling/#advanced-error-handling-with-apollo-link
+import { ApolloClient, InMemoryCache } from '@apollo/client'
 
-import { ApolloClient, HttpLink, InMemoryCache, from } from '@apollo/client'
-import { onError } from '@apollo/client/link/error'
-
-import { API_HOST, GCP_PROJECT_ID } from '../config'
-
-const httpLink = new HttpLink({ uri: `https://${API_HOST}/api/graphql` })
-
-const errorLink = onError(
-  ({ graphQLErrors, networkError, operation, forward }) => {
-    const { response } = operation.getContext()
-
-    const { headers } = response
-    const traceHeader = headers.get('X-Cloud-Trace-Context')
-
-    let globalLogFields = {}
-    if (headers && traceHeader) {
-      const [trace] = traceHeader.split('/')
-      globalLogFields[
-        'logging.googleapis.com/trace'
-      ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-    }
-
-    let debugPayload = {
-      graphQLOperationName: operation.operationName,
-      graphQLErrors: [],
-      networkError: '',
-    }
-
-    if (graphQLErrors)
-      graphQLErrors.forEach(({ message, locations, path }) => {
-        debugPayload.graphQLErrors.push({
-          Message: message,
-          Location: JSON.stringify(locations),
-          Path: `${path}`,
-        })
-      })
-
-    if (networkError) {
-      debugPayload.networkError = `${networkError}`
-    }
-    console.error(
-      JSON.stringify({
-        severity: 'ERROR',
-        message: `[Error] Fetch graphQL failed`,
-        debugPayload,
-        ...globalLogFields,
-      })
-    )
-    return forward(operation)
-  }
-)
+import { API_HOST } from '../config'
 
 const client = new ApolloClient({
-  link: from([errorLink, httpLink]),
+  uri: `https://${API_HOST}/api/graphql`,
   cache: new InMemoryCache(),
 })
 


### PR DESCRIPTION
原先打算使用`apollo-link`處理錯誤，並將錯誤的詳細資料印出來。但這樣會導致`apollo-link`與執行 apollo `client.query`的程式碼皆會印出error log，除了有多餘的log外，且就目前測試的結果，由於`apollo-link`的onError函式是於response才會執行，且無法透過其他ApolloLink取得request header，所以兩邊（`apollo-link`與執行 apollo `client.query`）無法取得相同的`req.header`。
因此經討論後，決定皆僅在 **「執行apollo `client.query`的程式碼**」處理錯誤。

另外由於現階段為axios與apollo並存，且兩個回傳的錯誤訊息不同，所以將首頁的getServersideProps分為兩個`try...catch`，分別執行使用`axios`及`apollo`的請求。

由於需要先上測試機測試error log是否如預期，該PR先merge，但也麻煩協助code review的同仁在抽空review及給予意見，感謝。