### PR TITLE
feat(404 500) add 404 500 error page UI

### DIFF
--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",
+    "@next/font": "^13.1.2",
     "@svgr/webpack": "^6.3.1",
     "@twreporter/errors": "^1.1.2",
     "axios": "^1.2.0",

--- a/packages/mirror-media-next/pages/404.js
+++ b/packages/mirror-media-next/pages/404.js
@@ -15,7 +15,7 @@ const MsgContainer = styled.div`
   flex-direction: column;
   align-items: center;
   border-bottom: 1px solid #000000;
-  width: 240px;
+  width: 260px;
   padding: 58px 0;
 `
 
@@ -28,8 +28,7 @@ const H1 = styled.h1`
 `
 
 const Text = styled.p`
-  font-family: 'Noto Sans TC';
-  font-weight: 500;
+  font-family: var(--notosansTC-font);
   font-size: 24px;
   color: #000000;
 `
@@ -115,7 +114,6 @@ const HeroImgWrapper = styled.div`
   }
 `
 const PostTitle = styled.p`
-  font-family: 'PingFang TC';
   font-weight: 400;
   font-size: 20px;
   line-height: 150%;

--- a/packages/mirror-media-next/pages/404.js
+++ b/packages/mirror-media-next/pages/404.js
@@ -133,7 +133,6 @@ const PostTitle = styled.p`
   }
 `
 const PostBrief = styled.p`
-  font-family: 'PingFang TC';
   font-weight: 400;
   font-size: 16px;
   line-height: 150%;
@@ -167,7 +166,6 @@ export default function Custom404() {
   const bullShitBrief =
     '我以為我了解早餐，但我真的了解早餐嗎？仔細想想，我對早餐的理解只是皮毛而已。由於，每個人的一生中，幾乎可說碰到早餐這件事，是必然會發生的。早餐的出現，必將帶領人類走向更高的巔峰。當你搞懂後就會明白了。世界上若沒有早餐，對於人類的改變可想而知。'
 
-  console.log(posts)
   return (
     <PageWrapper>
       <MsgContainer>
@@ -177,20 +175,30 @@ export default function Custom404() {
       <Title>熱門會員文章</Title>
       <JoinMemberBtn>加入會員</JoinMemberBtn>
       <PostsContainer>
-        {posts?.slice(0, 3).map((post, index) => (
-          <PostCard key={index} onClick={() => window.open(`${post?.slug}`)}>
-            <HeroImgWrapper>
-              <Image
-                src={post?.heroImage?.image?.resizedTargets?.desktop?.url}
-                alt={post?.heroImage?.description}
-                width={323}
-                height={159}
-              />
-            </HeroImgWrapper>
-            <PostTitle>{post?.title}</PostTitle>
-            <PostBrief>{bullShitBrief}</PostBrief>
-          </PostCard>
-        ))}
+        {posts?.slice(0, 3).map((post, index) => {
+          const imgUrl = post?.heroImage?.image?.resizedTargets?.desktop?.url
+          const defaultImg = '/images/default-og-img.png'
+          return (
+            <PostCard key={index}>
+              <a
+                href={`${post?.slug}`}
+                target="_blank"
+                rel="noreferrer noopenner"
+              >
+                <HeroImgWrapper>
+                  <Image
+                    src={imgUrl || defaultImg}
+                    alt={post?.heroImage?.description}
+                    width={323}
+                    height={159}
+                  />
+                </HeroImgWrapper>
+                <PostTitle>{post?.title}</PostTitle>
+                <PostBrief>{bullShitBrief}</PostBrief>
+              </a>
+            </PostCard>
+          )
+        })}
       </PostsContainer>
     </PageWrapper>
   )

--- a/packages/mirror-media-next/pages/404.js
+++ b/packages/mirror-media-next/pages/404.js
@@ -1,0 +1,197 @@
+import { useEffect, useState } from 'react'
+import styled from 'styled-components'
+import axios from 'axios'
+import Image from 'next/image'
+
+const PageWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-bottom: 46px;
+`
+
+const MsgContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-bottom: 1px solid #000000;
+  width: 240px;
+  padding: 58px 0;
+`
+
+const H1 = styled.h1`
+  font-family: 'Helvetica Neue';
+  font-weight: 400;
+  font-size: 128px;
+  line-height: 128px;
+  color: #054f77;
+`
+
+const Text = styled.p`
+  font-family: 'Noto Sans TC';
+  font-weight: 500;
+  font-size: 24px;
+  color: #000000;
+`
+
+const Title = styled.p`
+  font-style: normal;
+  font-weight: 500;
+  font-size: 20px;
+  color: #054f77;
+  padding: 28px 0 8px;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    font-weight: 700;
+    font-size: 28px;
+    padding: 41px 0 12px;
+  }
+`
+const JoinMemberBtn = styled.button`
+  width: 78px;
+  height: 30px;
+  left: 564px;
+  top: 484px;
+  background: #054f77;
+  border-radius: 38px;
+  color: #ffffff;
+  font-weight: 500;
+  font-size: 14px;
+  margin-bottom: 12px;
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin-bottom: 16px;
+  }
+
+  :hover {
+    cursor: pointer;
+    background-color: #0d6b9e;
+    transition: 0.1s ease-in;
+  }
+
+  :active {
+    background-color: #ffffff;
+    border: 1px solid #054f77;
+    color: #054f77;
+    transition: 0.1s ease-in;
+  }
+
+  :focus {
+    outline: 0;
+  }
+`
+const PostsContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    flex-direction: row;
+  }
+`
+const PostCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-bottom: 12px;
+
+  :hover {
+    cursor: pointer;
+  }
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    :not(:last-child) {
+      margin-right: 28px;
+    }
+  }
+`
+const HeroImgWrapper = styled.div`
+  width: 284px;
+  height: 139px;
+  border-radius: 53px;
+  overflow: hidden;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    width: 323px;
+    height: 159px;
+  }
+`
+const PostTitle = styled.p`
+  font-family: 'PingFang TC';
+  font-weight: 400;
+  font-size: 20px;
+  line-height: 150%;
+  color: #4a4a4a;
+  width: 272px;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+  padding-top: 12px;
+
+  :hover {
+    text-decoration: underline #4a4a4a 1.2px;
+    text-underline-offset: 5px;
+  }
+`
+const PostBrief = styled.p`
+  font-family: 'PingFang TC';
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 150%;
+  color: #9b9b9b;
+  width: 272px;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  padding-top: 8px;
+`
+
+export default function Custom404() {
+  //fetch mock data for UI development, not for production
+  const [posts, setPosts] = useState([])
+
+  useEffect(() => {
+    const fetchPost = async () => {
+      try {
+        const response = await axios(
+          'https://dev.mirrormedia.mg/json/popularlist.json'
+        )
+        setPosts(response?.data?.report)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    fetchPost()
+  }, [])
+
+  const bullShitBrief =
+    '我以為我了解早餐，但我真的了解早餐嗎？仔細想想，我對早餐的理解只是皮毛而已。由於，每個人的一生中，幾乎可說碰到早餐這件事，是必然會發生的。早餐的出現，必將帶領人類走向更高的巔峰。當你搞懂後就會明白了。世界上若沒有早餐，對於人類的改變可想而知。'
+
+  console.log(posts)
+  return (
+    <PageWrapper>
+      <MsgContainer>
+        <H1>404</H1>
+        <Text>抱歉！找不到這個網址</Text>
+      </MsgContainer>
+      <Title>熱門會員文章</Title>
+      <JoinMemberBtn>加入會員</JoinMemberBtn>
+      <PostsContainer>
+        {posts?.slice(0, 3).map((post, index) => (
+          <PostCard key={index} onClick={() => window.open(`${post?.slug}`)}>
+            <HeroImgWrapper>
+              <Image
+                src={post?.heroImage?.image?.resizedTargets?.desktop?.url}
+                alt={post?.heroImage?.description}
+                width={323}
+                height={159}
+              />
+            </HeroImgWrapper>
+            <PostTitle>{post?.title}</PostTitle>
+            <PostBrief>{bullShitBrief}</PostBrief>
+          </PostCard>
+        ))}
+      </PostsContainer>
+    </PageWrapper>
+  )
+}

--- a/packages/mirror-media-next/pages/500.js
+++ b/packages/mirror-media-next/pages/500.js
@@ -16,7 +16,7 @@ const MsgContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 240px;
+  width: 260px;
   margin-top: 140px;
 `
 
@@ -29,7 +29,7 @@ const H1 = styled.h1`
 `
 
 const Text = styled.p`
-  font-family: 'Noto Sans TC';
+  font-family: var(--notosansTC-font);
   font-weight: 500;
   font-size: 24px;
   color: #61b8c6;

--- a/packages/mirror-media-next/pages/500.js
+++ b/packages/mirror-media-next/pages/500.js
@@ -1,0 +1,47 @@
+import styled from 'styled-components'
+
+const Page = styled.div`
+  height: calc(100vh - 119.5px);
+  background-color: #f2f2f2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    height: calc(100vh - 146px);
+  }
+`
+
+const MsgContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 240px;
+  margin-top: 140px;
+`
+
+const H1 = styled.h1`
+  font-family: 'Helvetica Neue';
+  font-weight: 400;
+  font-size: 128px;
+  line-height: 120%;
+  color: #61b8c6;
+`
+
+const Text = styled.p`
+  font-family: 'Noto Sans TC';
+  font-weight: 500;
+  font-size: 24px;
+  color: #61b8c6;
+`
+
+export default function Custom500() {
+  return (
+    <Page>
+      <MsgContainer>
+        <H1>500</H1>
+        <Text>這個網頁無法正常運作</Text>
+      </MsgContainer>
+    </Page>
+  )
+}

--- a/packages/mirror-media-next/pages/_app.js
+++ b/packages/mirror-media-next/pages/_app.js
@@ -9,13 +9,6 @@ import {
   URL_STATIC_COMBO_TOPICS,
   API_TIMEOUT,
 } from '../config'
-import { Noto_Sans_TC } from '@next/font/google'
-
-const notosansTC = Noto_Sans_TC({
-  weight: ['500'], //variable font 不會有weight
-  style: ['normal'],
-  subsets: ['latin'], //default
-})
 
 /**
  *
@@ -30,15 +23,6 @@ const notosansTC = Noto_Sans_TC({
 function MyApp({ Component, pageProps, sectionsData = [], topicsData = [] }) {
   return (
     <>
-      <style jsx global>{`
-        //can use in single page
-        :root {
-          --notosansTC-font: ${notosansTC.style.fontFamily};
-        }
-        html {
-          font-family: PingFang TC, ${notosansTC.style.fontFamily};
-        }
-      `}</style>
       <GlobalStyles />
       <ThemeProvider theme={theme}>
         <Layout sectionsData={sectionsData} topicsData={topicsData} />

--- a/packages/mirror-media-next/pages/_app.js
+++ b/packages/mirror-media-next/pages/_app.js
@@ -9,6 +9,13 @@ import {
   URL_STATIC_COMBO_TOPICS,
   API_TIMEOUT,
 } from '../config'
+import { Noto_Sans_TC } from '@next/font/google'
+
+const notosansTC = Noto_Sans_TC({
+  weight: ['500'], //variable font 不會有weight
+  style: ['normal'],
+  subsets: ['latin'], //default
+})
 
 /**
  *
@@ -19,9 +26,19 @@ import {
  * @param {Object[]} props.topicsData
  * @returns {React.ReactElement}
  */
+
 function MyApp({ Component, pageProps, sectionsData = [], topicsData = [] }) {
   return (
     <>
+      <style jsx global>{`
+        //can use in single page
+        :root {
+          --notosansTC-font: ${notosansTC.style.fontFamily};
+        }
+        html {
+          font-family: PingFang TC, ${notosansTC.style.fontFamily};
+        }
+      `}</style>
       <GlobalStyles />
       <ThemeProvider theme={theme}>
         <Layout sectionsData={sectionsData} topicsData={topicsData} />

--- a/packages/mirror-media-next/pages/_document.js
+++ b/packages/mirror-media-next/pages/_document.js
@@ -35,18 +35,7 @@ export default class MyDocument extends Document {
   render() {
     return (
       <Html lang="en">
-        <Head>
-          <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link
-            rel="preconnect"
-            href="https://fonts.gstatic.com"
-            crossOrigin="true"
-          />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@500;700&display=swap"
-            rel="stylesheet"
-          />
-        </Head>
+        <Head />
         <body>
           <Main />
           <NextScript />

--- a/packages/mirror-media-next/pages/_document.js
+++ b/packages/mirror-media-next/pages/_document.js
@@ -35,7 +35,18 @@ export default class MyDocument extends Document {
   render() {
     return (
       <Html lang="en">
-        <Head />
+        <Head>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="true"
+          />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@500;700&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
         <body>
           <Main />
           <NextScript />

--- a/packages/mirror-media-next/styles/global-styles.js
+++ b/packages/mirror-media-next/styles/global-styles.js
@@ -1,14 +1,10 @@
 import { createGlobalStyle } from 'styled-components'
-import { Noto_Sans_TC, Noto_Serif_TC, Oswald } from '@next/font/google'
+import { Noto_Sans_TC, Oswald } from '@next/font/google'
 
 const oswald = Oswald({
   subsets: ['latin'],
 })
 const notosansTC = Noto_Sans_TC({
-  subsets: ['latin'],
-  weight: ['500'],
-})
-const notoserifTC = Noto_Serif_TC({
   subsets: ['latin'],
   weight: ['500'],
 })
@@ -28,12 +24,11 @@ export const GlobalStyles = createGlobalStyle`
 :root{
       --oswald-font : ${oswald.style.fontFamily};
       --notosansTC-font : ${notosansTC.style.fontFamily};
-      --notoserifTC-font : ${notoserifTC.style.fontFamily};
    }
 
  //default font family  
  html {
-  font-family: PingFang TC, ${notosansTC.style.fontFamily}, ${notoserifTC.style.fontFamily} , system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; 
+  font-family: PingFang TC, ${notosansTC.style.fontFamily}, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; 
   line-height: 1.15; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
 }

--- a/packages/mirror-media-next/styles/global-styles.js
+++ b/packages/mirror-media-next/styles/global-styles.js
@@ -1,4 +1,17 @@
 import { createGlobalStyle } from 'styled-components'
+import { Noto_Sans_TC, Noto_Serif_TC, Oswald } from '@next/font/google'
+
+const oswald = Oswald({
+  subsets: ['latin'],
+})
+const notosansTC = Noto_Sans_TC({
+  subsets: ['latin'],
+  weight: ['500'],
+})
+const notoserifTC = Noto_Serif_TC({
+  subsets: ['latin'],
+  weight: ['500'],
+})
 
 export const GlobalStyles = createGlobalStyle`
 /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
@@ -11,7 +24,16 @@ export const GlobalStyles = createGlobalStyle`
  * 2. Prevent adjustments of font size after orientation changes in iOS.
  */
 
+//add css variable if needed
+:root{
+      --oswald-font : ${oswald.style.fontFamily};
+      --notosansTC-font : ${notosansTC.style.fontFamily};
+      --notoserifTC-font : ${notoserifTC.style.fontFamily};
+   }
+
+ //default font family  
  html {
+  font-family: PingFang TC, ${notosansTC.style.fontFamily}, ${notoserifTC.style.fontFamily} , system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; 
   line-height: 1.15; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1132,6 +1132,11 @@
   dependencies:
     glob "7.1.7"
 
+"@next/font@^13.1.2":
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/@next/font/-/font-13.1.2.tgz#ee809ca03113d0e73495ac5d0e2a978885d0d97e"
+  integrity sha512-NXGXGFGiOKEnvBIHq9cdFTKbHO2/4B3Zd9K27M7j1DioIQVar7oVRqZMYs0h3XMVEZLwjjkdAtqRPCzzd3RtXg==
+
 "@next/swc-android-arm-eabi@13.0.7":
   version "13.0.7"
   resolved "https://registry.yarnpkg.com/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.7.tgz#ddbf3d092d22f17238aa34072f5dcb8129d8b23e"


### PR DESCRIPTION
- 此PR中fetch mock data主要作為切版用途，故未加上js doc，之後使用正式資料會再補上。
- 但有碰的一個問題，在[NEXT.js文件](https://nextjs.org/docs/advanced-features/custom-error-page#404-page)中，明明寫著：`Note: You can use getStaticProps inside this page if you need to fetch data at build time.` 但實際要在getStaticProps fetch資料時，卻會碰的[這樣的錯誤](https://github.com/vercel/next.js/issues/10919)，令人感到很疑惑，所以最後是用useEffect在client side取得mock data。
- 此PR主要為驗收UI之用，故將檔案分成404.js與500.js兩個，之後會再整合在`pages/_error.js`中。