### PR TITLE
chore(mm-next): set webpack loader for `gql` file and apollo fetch policy

### DIFF
--- a/packages/mirror-media-next/apollo/apollo-client.js
+++ b/packages/mirror-media-next/apollo/apollo-client.js
@@ -5,6 +5,11 @@ import { API_HOST } from '../config'
 const client = new ApolloClient({
   uri: `https://${API_HOST}/api/graphql`,
   cache: new InMemoryCache(),
+  defaultOptions: {
+    watchQuery: {
+      fetchPolicy: 'no-cache',
+    },
+  },
 })
 
 export default client

--- a/packages/mirror-media-next/next.config.js
+++ b/packages/mirror-media-next/next.config.js
@@ -17,13 +17,25 @@ const nextConfig = {
     ],
   },
   webpack(config) {
-    config.module.rules.push({
-      test: /\.svg$/,
-      use: ['@svgr/webpack'],
-    })
+    config.module.rules.push(
+      {
+        test: /\.svg$/,
+        use: ['@svgr/webpack'],
+      },
+      {
+        test: /\.(graphql|gql)$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'graphql-tag/loader',
+          },
+        ],
+      }
+    )
 
     return config
   },
+
   output: 'standalone',
 }
 


### PR DESCRIPTION
- 於`next.config.js`中設定副檔名為`.gql`的loader
- 調整`apollo-client`設定，並預設fetchPolicy為`'no-cache'`。