### PR TITLE
feat(mirror-media-search): add ga of pageview and scroll loadmore and click

### DIFF
--- a/packages/mirror-media-search/components/search-result.js
+++ b/packages/mirror-media-search/components/search-result.js
@@ -7,6 +7,7 @@ import useSearchArticles from '../hooks/useSearchArticles'
 import useWindowDimensions from '../hooks/useWindowDimensions'
 import LazyLoadImage from './shared/lazy-load-image.js'
 import Loader from './shared/loader'
+import { logGAEvent } from '../utils/programmable-search/analytics'
 
 const SearchResultWrapper = styled.div`
   position: relative;
@@ -154,6 +155,28 @@ export default function SearchResult({ searchResult }) {
     displayingArticles = hasMore ? articles.slice(0, end) : articles
   }
 
+  const handleOnClickSearchAeticleWrapper = (index) => {
+    if (index > 8) return
+    const device =
+      width >= mediaSize.xxl
+        ? 'desktop'
+        : width >= mediaSize.md
+        ? 'tablet'
+        : 'mobile'
+    const order = [
+      'first',
+      'second',
+      'third',
+      'fourth',
+      'fifth',
+      'sixth',
+      'seventh',
+      'eighth',
+      'ninth',
+    ][index]
+    logGAEvent('click', `${searchTerms}-${order}-post-${device}`)
+  }
+
   return (
     <SearchResultWrapper>
       <SearchTitle>&#8220; {searchTerms} &#8221;</SearchTitle>
@@ -162,6 +185,7 @@ export default function SearchResult({ searchResult }) {
           const lastOne = index === displayingArticles.length - 1
           return (
             <SearchArticleWraper
+              onClick={() => handleOnClickSearchAeticleWrapper(index)}
               key={article.title}
               href={article.link}
               alt={article.title}

--- a/packages/mirror-media-search/config/index.js
+++ b/packages/mirror-media-search/config/index.js
@@ -24,6 +24,7 @@ const PROGRAMABLE_SEARCH_ENGINE_ID =
   process.env.PROGRAMABLE_SEARCH_ENGINE_ID || 'SEARCH_ENGINE_ID'
 const PROGRAMABLE_SEARCH_API_KEY =
   process.env.PROGRAMABLE_SEARCH_API_KEY || 'API_KEY'
+let GA_TRACKING_ID
 
 // The following variables are given values according to different `ENV`
 let API_TIMEOUT = 5000
@@ -31,15 +32,19 @@ let API_TIMEOUT = 5000
 switch (ENV) {
   case 'prod':
     API_TIMEOUT = 1500
+    GA_TRACKING_ID = process.env.GOOGLE_ANALYTICS_TRACKING_ID ?? 'UA-83609754-1'
     break
   case 'staging':
     API_TIMEOUT = 1500
+    GA_TRACKING_ID = process.env.GOOGLE_ANALYTICS_TRACKING_ID ?? 'UA-83609754-1'
     break
   case 'dev':
     API_TIMEOUT = 5000
+    GA_TRACKING_ID = process.env.GOOGLE_ANALYTICS_TRACKING_ID ?? 'UA-83609754-2'
     break
   default:
     API_TIMEOUT = 5000
+    GA_TRACKING_ID = process.env.GOOGLE_ANALYTICS_TRACKING_ID ?? 'UA-83609754-2'
 }
 
 export {
@@ -58,4 +63,5 @@ export {
   PROGRAMABLE_SEARCH_ENGINE_ID,
   PROGRAMABLE_SEARCH_API_KEY,
   CORS_ORIGINS,
+  GA_TRACKING_ID,
 }

--- a/packages/mirror-media-search/hooks/useSearchArticles.js
+++ b/packages/mirror-media-search/hooks/useSearchArticles.js
@@ -5,6 +5,7 @@ import {
   PROGRAMABLE_SEARCH_LIMIT_START,
   PROGRAMABLE_SEARCH_NUM,
 } from '../utils/programmable-search/const'
+import { logGAEvent } from '../utils/programmable-search/analytics'
 
 export default function useSearchArticles({ items: initialArticles, queries }) {
   const [searchTerms] = useState(queries.request[0].exactTerms)
@@ -12,6 +13,7 @@ export default function useSearchArticles({ items: initialArticles, queries }) {
   const [hasMore, setHasMore] = useState(!!queries.nextPage)
   const [articles, setArticles] = useState(initialArticles)
   const [isLoading, setIsLoading] = useState(false)
+  const [loadMoreTimes, setLoadMoreTimes] = useState(0)
 
   useEffect(() => {
     async function search(searchTerms, startIndex) {
@@ -58,9 +60,19 @@ export default function useSearchArticles({ items: initialArticles, queries }) {
     }
   }, [hasMore, searchTerms, startIndex])
 
+  useEffect(() => {
+    if (loadMoreTimes) {
+      logGAEvent('scroll', `${searchTerms}-loadmore-${loadMoreTimes}`)
+    }
+  }, [loadMoreTimes, searchTerms])
+
   const loadMore = useCallback(() => {
-    if (hasMore)
+    if (hasMore) {
       setStartIndex((startIndex) => startIndex + PROGRAMABLE_SEARCH_NUM)
+      setLoadMoreTimes((prev) => {
+        return prev + 1
+      })
+    }
   }, [hasMore])
 
   return { articles, loadMore, isLoading, hasMore }

--- a/packages/mirror-media-search/package.json
+++ b/packages/mirror-media-search/package.json
@@ -8,8 +8,8 @@
     "start": "next start",
     "lint": "next lint"
   },
-  "engines" : { 
-    "node" : ">=14.0.0 <17.0.0"
+  "engines": {
+    "node": ">=14.0.0 <17.0.0"
   },
   "dependencies": {
     "@svgr/webpack": "^6.3.1",
@@ -19,6 +19,7 @@
     "next": "^13.0.7",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-ga": "^3.3.1",
     "styled-components": "5.3.5",
     "yup": "^0.32.11"
   },

--- a/packages/mirror-media-search/pages/_app.js
+++ b/packages/mirror-media-search/pages/_app.js
@@ -19,14 +19,6 @@ function MyApp({ Component, pageProps }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  useEffect(() => {
-    // Listen for page changes after a navigation or when the query changes
-    router.events.on('routeChangeComplete', logPageView)
-    return () => {
-      router.events.off('routeChangeComplete', logPageView)
-    }
-  }, [router.events])
-
   return (
     <>
       <Head>

--- a/packages/mirror-media-search/utils/programmable-search/analytics.js
+++ b/packages/mirror-media-search/utils/programmable-search/analytics.js
@@ -1,0 +1,29 @@
+import ReactGA from 'react-ga'
+import { GA_TRACKING_ID } from '../../config'
+
+export const initGA = () => {
+  // console.log('GA init')
+  ReactGA.initialize(GA_TRACKING_ID)
+}
+
+export const logPageView = () => {
+  // console.log(`Logging pageview for ${window.location.pathname}`)
+  ReactGA.set({ page: window.location.pathname })
+  ReactGA.pageview(window.location.pathname)
+}
+
+export const logGAEvent = (action = '', label = '') => {
+  if (action) {
+    ReactGA.event({
+      action,
+      label,
+      category: 'search',
+    })
+  }
+}
+
+export const logException = (description = '', fatal = false) => {
+  if (description) {
+    ReactGA.exception({ description, fatal })
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4925,6 +4925,11 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-ga@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.1.tgz#d8e1f4e05ec55ed6ff944dcb14b99011dfaf9504"
+  integrity sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==
+
 react-infinite-scroller@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz#8b80233226dc753a597a0eb52621247f49b15f18"


### PR DESCRIPTION
（只是剛好今天輪值班順手發起來，打擾到大家很抱歉，可以等復工再看就好，感謝！）

## 描述
- 新增週刊搜尋的 GA。
- 使用 `react-ga` ，並參考 [政見追蹤平台的寫法](https://github.com/readr-media/Sachiel/tree/dev/packages/politics-tracker)。
- 主要為埋設 pageview、click 和 scroll 三種，詳細文件可參考 [鏡週刊 GA](https://paper.dropbox.com/doc/GA--BxRGuLQOH5Xv5G29IKRnH3tRAg-fMq1H8GD6muBE3nsqYvmH)。