### PR TITLE
feat(mm-next): add article list pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,7 @@ next-env.d.ts
 .yarn-integrity
 
 # dotenv environment variables file
-.env
+.env*
 .env.test
 .env*.local
 

--- a/packages/mirror-media-next/apollo/query/categroies.js
+++ b/packages/mirror-media-next/apollo/query/categroies.js
@@ -1,0 +1,18 @@
+import { gql } from '@apollo/client'
+
+const fetchCategorySections = gql`
+  query ($categorySlug: String) {
+    category(where: { slug: $categorySlug }) {
+      id
+      name
+      slug
+      sections {
+        id
+        name
+        slug
+      }
+    }
+  }
+`
+
+export { fetchCategorySections }

--- a/packages/mirror-media-next/apollo/query/contact.js
+++ b/packages/mirror-media-next/apollo/query/contact.js
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client'
+
+const fetchContact = gql`
+  query ($where: ContactWhereUniqueInput!) {
+    contact(where: $where) {
+      id
+      name
+    }
+  }
+`
+export { fetchContact }

--- a/packages/mirror-media-next/apollo/query/posts.js
+++ b/packages/mirror-media-next/apollo/query/posts.js
@@ -4,18 +4,38 @@ const fetchPostsByCategory = gql`
   query (
     $take: Int
     $skip: Int
-    $orderBy: [PostOrderByInput!]
+    $orderBy: [PostOrderByInput!]!
     $filter: PostWhereInput!
   ) {
-    postsCount
+    postsCount(where: $filter)
     posts(take: $take, skip: $skip, orderBy: $orderBy, where: $filter) {
       id
       title
+      brief
       sections {
+        slug
         name
       }
       publishedDate
       state
+      categories {
+        slug
+        name
+      }
+      heroImage {
+        imageFile {
+          width
+          height
+        }
+        resized {
+          original
+          w480
+          w800
+          w1200
+          w1600
+          w2400
+        }
+      }
     }
   }
 `

--- a/packages/mirror-media-next/apollo/query/posts.js
+++ b/packages/mirror-media-next/apollo/query/posts.js
@@ -1,0 +1,23 @@
+import { gql } from '@apollo/client'
+
+const fetchPostsByCategory = gql`
+  query (
+    $take: Int
+    $skip: Int
+    $orderBy: [PostOrderByInput!]
+    $filter: PostWhereInput!
+  ) {
+    postsCount
+    posts(take: $take, skip: $skip, orderBy: $orderBy, where: $filter) {
+      id
+      title
+      sections {
+        name
+      }
+      publishedDate
+      state
+    }
+  }
+`
+
+export { fetchPostsByCategory }

--- a/packages/mirror-media-next/apollo/query/posts.js
+++ b/packages/mirror-media-next/apollo/query/posts.js
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 
-const fetchPostsByCategory = gql`
+const fetchPosts = gql`
   query (
     $take: Int
     $skip: Int
@@ -41,4 +41,4 @@ const fetchPostsByCategory = gql`
   }
 `
 
-export { fetchPostsByCategory }
+export { fetchPosts }

--- a/packages/mirror-media-next/apollo/query/posts.js
+++ b/packages/mirror-media-next/apollo/query/posts.js
@@ -10,6 +10,7 @@ const fetchPostsByCategory = gql`
     postsCount(where: $filter)
     posts(take: $take, skip: $skip, orderBy: $orderBy, where: $filter) {
       id
+      slug
       title
       brief
       sections {

--- a/packages/mirror-media-next/apollo/query/sections.js
+++ b/packages/mirror-media-next/apollo/query/sections.js
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client'
+
+const fetchSection = gql`
+  query ($where: SectionWhereUniqueInput!) {
+    section(where: $where) {
+      id
+      name
+      slug
+    }
+  }
+`
+
+export { fetchSection }

--- a/packages/mirror-media-next/apollo/query/tags.js
+++ b/packages/mirror-media-next/apollo/query/tags.js
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client'
+
+const fetchTag = gql`
+  query ($where: TagWhereUniqueInput!) {
+    tag(where: $where) {
+      id
+      name
+      slug
+    }
+  }
+`
+
+export { fetchTag }

--- a/packages/mirror-media-next/components/InifiniteScrollList.js
+++ b/packages/mirror-media-next/components/InifiniteScrollList.js
@@ -1,0 +1,55 @@
+import React, { useState } from 'react'
+import InfiniteScroll from 'react-infinite-scroller'
+
+// force page index start from 1 to prevent counting miscalculation
+const INITIAL_PAGE = 1
+
+export default function InfiniteScrollList({
+  initialList,
+  renderPageSize,
+  pageCount,
+  fetchListInPage = () => {},
+  propsIS,
+  children,
+}) {
+  const [list, setList] = useState(initialList)
+  const [renderCount, setRenderCount] = useState(renderPageSize)
+  const [page, setPage] = useState(INITIAL_PAGE)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const renderList = list.slice(0, renderCount)
+
+  function handleLoadMore() {
+    console.log('handleLoadMore', list.length, renderCount, page)
+    if (isLoading) {
+      return
+    }
+
+    if (list.length === renderCount && page === pageCount) {
+      return
+    }
+
+    if (page !== pageCount && list.length - renderCount <= renderPageSize) {
+      const newPage = page + 1
+      setIsLoading(true)
+      fetchListInPage(newPage).then((newList) => {
+        if (newList && newList.length) {
+          setPage(newPage)
+          setList((oldList) => [...oldList, ...newList])
+          setIsLoading(false)
+        }
+      })
+    }
+    setRenderCount((preVal) => (preVal += renderPageSize))
+  }
+
+  return (
+    <InfiniteScroll
+      {...propsIS}
+      loadMore={handleLoadMore}
+      hasMore={!(list.length === renderCount && page === pageCount)}
+    >
+      {children(renderList)}
+    </InfiniteScroll>
+  )
+}

--- a/packages/mirror-media-next/components/article-list-item.js
+++ b/packages/mirror-media-next/components/article-list-item.js
@@ -91,7 +91,7 @@ const ItemBrief = styled.div`
 /**
  * @param {Object} props
  * @param {import('../type/shared/article').Article} props.item
- * @param {import('../type/shared/category').CategorySection} props.section
+ * @param {import('../type/category').CategorySection} props.section
  * @returns {React.ReactElement}
  */
 export default function ArticleListItem({ item, section }) {

--- a/packages/mirror-media-next/components/article-list-item.js
+++ b/packages/mirror-media-next/components/article-list-item.js
@@ -89,7 +89,7 @@ const ItemBrief = styled.div`
 
 export default function ArticleListItem({ item, sections }) {
   return (
-    <ItemWrapper>
+    <ItemWrapper href={`/story/${item.slug}`} target="_blank">
       <ImageContainer>
         <CustomNextImage src={item.heroImage?.resized?.w800} />
         <ItemSection sectionName={sections?.slug}>{sections?.name}</ItemSection>

--- a/packages/mirror-media-next/components/article-list-item.js
+++ b/packages/mirror-media-next/components/article-list-item.js
@@ -1,4 +1,103 @@
-export default function ArticleListItem({ item }) {
-  console.log(item)
-  return <div>{item.title}</div>
+import styled from 'styled-components'
+
+import CustomNextImage from './custom-next-image'
+
+const ItemWrapper = styled.a`
+  display: block;
+  position: relative;
+  width: 100%;
+  margin: 0 auto;
+  font-size: 18px;
+`
+
+const ImageContainer = styled.div`
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1.5;
+`
+
+const ItemSection = styled.div`
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  padding: 8px;
+  color: white;
+  font-size: 16px;
+  font-weight: 300;
+  background-color: ${
+    /**
+     * @param {Object} props
+     * @param {String } props.sectionName
+     * @param {Theme} [props.theme]
+     */
+    ({ sectionName, theme }) =>
+      sectionName && theme.color.sectionsColor[sectionName]
+        ? theme.color.sectionsColor[sectionName]
+        : theme.color.brandColor.lightBlue
+  };
+  ${({ theme }) => theme.breakpoint.md} {
+    font-size: 18px;
+    font-weight: 600;
+  }
+`
+
+const ItemDetail = styled.div`
+  margin: 20px 20px 36px 20px;
+  ${({ theme }) => theme.breakpoint.md} {
+    margin: 20px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 8px 8px 24px 8px;
+  }
+`
+
+const ItemTitle = styled.div`
+  color: #054f77;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    height: 4.2em;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    font-size: 18px;
+    font-weight: 600;
+  }
+`
+
+const ItemBrief = styled.div`
+  font-size: 16px;
+  color: #979797;
+  margin-top: 20px;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin-top: 16px;
+  }
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin-top: 20px;
+    -webkit-line-clamp: 4;
+  }
+`
+
+export default function ArticleListItem({ item, sections }) {
+  return (
+    <ItemWrapper>
+      <ImageContainer>
+        <CustomNextImage src={item.heroImage?.resized?.w800} />
+        <ItemSection sectionName={sections?.slug}>{sections?.name}</ItemSection>
+      </ImageContainer>
+      <ItemDetail>
+        <ItemTitle>{item.title}</ItemTitle>
+        <ItemBrief>{item.brief?.blocks[0]?.text}</ItemBrief>
+      </ItemDetail>
+    </ItemWrapper>
+  )
 }

--- a/packages/mirror-media-next/components/article-list-item.js
+++ b/packages/mirror-media-next/components/article-list-item.js
@@ -91,15 +91,20 @@ const ItemBrief = styled.div`
 /**
  * @param {Object} props
  * @param {import('../type/shared/article').Article} props.item
- * @param {import('../type/category').CategorySection} props.section
+ * @param {import('../type/category').CategorySection} [props.section]
  * @returns {React.ReactElement}
  */
 export default function ArticleListItem({ item, section }) {
+  const itemSection =
+    section || item.sections.find((section) => section.slug !== 'member')
+
   return (
     <ItemWrapper href={`/story/${item.slug}`} target="_blank">
       <ImageContainer>
         <CustomNextImage src={item.heroImage?.resized?.w800} />
-        <ItemSection sectionName={section?.slug}>{section?.name}</ItemSection>
+        <ItemSection sectionName={itemSection?.slug}>
+          {itemSection?.name}
+        </ItemSection>
       </ImageContainer>
       <ItemDetail>
         <ItemTitle>{item.title}</ItemTitle>

--- a/packages/mirror-media-next/components/article-list-item.js
+++ b/packages/mirror-media-next/components/article-list-item.js
@@ -38,6 +38,7 @@ const ItemSection = styled.div`
   ${({ theme }) => theme.breakpoint.md} {
     font-size: 18px;
     font-weight: 600;
+    padding: 4px 20px;
   }
 `
 

--- a/packages/mirror-media-next/components/article-list-item.js
+++ b/packages/mirror-media-next/components/article-list-item.js
@@ -87,12 +87,18 @@ const ItemBrief = styled.div`
   }
 `
 
-export default function ArticleListItem({ item, sections }) {
+/**
+ * @param {Object} props
+ * @param {import('../type/shared/article').Article} props.item
+ * @param {import('../type/shared/category').CategorySection} props.section
+ * @returns {React.ReactElement}
+ */
+export default function ArticleListItem({ item, section }) {
   return (
     <ItemWrapper href={`/story/${item.slug}`} target="_blank">
       <ImageContainer>
         <CustomNextImage src={item.heroImage?.resized?.w800} />
-        <ItemSection sectionName={sections?.slug}>{sections?.name}</ItemSection>
+        <ItemSection sectionName={section?.slug}>{section?.name}</ItemSection>
       </ImageContainer>
       <ItemDetail>
         <ItemTitle>{item.title}</ItemTitle>

--- a/packages/mirror-media-next/components/article-list-item.js
+++ b/packages/mirror-media-next/components/article-list-item.js
@@ -1,0 +1,4 @@
+export default function ArticleListItem({ item }) {
+  console.log(item)
+  return <div>{item.title}</div>
+}

--- a/packages/mirror-media-next/components/article-list-item.js
+++ b/packages/mirror-media-next/components/article-list-item.js
@@ -102,9 +102,11 @@ export default function ArticleListItem({ item, section }) {
     <ItemWrapper href={`/story/${item.slug}`} target="_blank">
       <ImageContainer>
         <CustomNextImage src={item.heroImage?.resized?.w800} />
-        <ItemSection sectionName={itemSection?.slug}>
-          {itemSection?.name}
-        </ItemSection>
+        {itemSection && (
+          <ItemSection sectionName={itemSection?.slug}>
+            {itemSection?.name}
+          </ItemSection>
+        )}
       </ImageContainer>
       <ItemDetail>
         <ItemTitle>{item.title}</ItemTitle>

--- a/packages/mirror-media-next/components/article-list-items.js
+++ b/packages/mirror-media-next/components/article-list-items.js
@@ -19,7 +19,7 @@ const ItemContainer = styled.div`
 /**
  * @param {Object} props
  * @param {import('../type/shared/article').Article[]} props.renderList
- * @param {import('../type/shared/category').CategorySection} props.section
+ * @param {import('../type/category').CategorySection} props.section
  * @returns {React.ReactElement}
  */
 export default function ArticleListItems({ renderList, section }) {

--- a/packages/mirror-media-next/components/article-list-items.js
+++ b/packages/mirror-media-next/components/article-list-items.js
@@ -2,19 +2,25 @@ import styled from 'styled-components'
 import ArticleListItem from './article-list-item'
 
 const ItemContainer = styled.div`
+  display: grid;
+  grid-template-columns: 320px;
+  justify-content: center;
+
   ${({ theme }) => theme.breakpoint.md} {
-    display: grid;
-    gap: 12px;
-    grid-template-columns: repeat(auto-fill, 244px);
-    justify-content: center;
+    grid-template-columns: repeat(2, 320px);
+    gap: 20px 32px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    grid-template-columns: repeat(4, 220px);
+    gap: 36px 48px;
   }
 `
 
-export default function ArticleListItems({ renderList }) {
+export default function ArticleListItems({ renderList, sections }) {
   return (
     <ItemContainer>
       {renderList.map((item) => (
-        <ArticleListItem key={item.id} item={item} />
+        <ArticleListItem key={item.id} item={item} sections={sections} />
       ))}
     </ItemContainer>
   )

--- a/packages/mirror-media-next/components/article-list-items.js
+++ b/packages/mirror-media-next/components/article-list-items.js
@@ -16,11 +16,17 @@ const ItemContainer = styled.div`
   }
 `
 
-export default function ArticleListItems({ renderList, sections }) {
+/**
+ * @param {Object} props
+ * @param {import('../type/shared/article').Article[]} props.renderList
+ * @param {import('../type/shared/category').CategorySection} props.section
+ * @returns {React.ReactElement}
+ */
+export default function ArticleListItems({ renderList, section }) {
   return (
     <ItemContainer>
       {renderList.map((item) => (
-        <ArticleListItem key={item.id} item={item} sections={sections} />
+        <ArticleListItem key={item.id} item={item} section={section} />
       ))}
     </ItemContainer>
   )

--- a/packages/mirror-media-next/components/article-list-items.js
+++ b/packages/mirror-media-next/components/article-list-items.js
@@ -1,0 +1,21 @@
+import styled from 'styled-components'
+import ArticleListItem from './article-list-item'
+
+const ItemContainer = styled.div`
+  ${({ theme }) => theme.breakpoint.md} {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fill, 244px);
+    justify-content: center;
+  }
+`
+
+export default function ArticleListItems({ renderList }) {
+  return (
+    <ItemContainer>
+      {renderList.map((item) => (
+        <ArticleListItem key={item.id} item={item} />
+      ))}
+    </ItemContainer>
+  )
+}

--- a/packages/mirror-media-next/components/article-list-items.js
+++ b/packages/mirror-media-next/components/article-list-items.js
@@ -19,7 +19,7 @@ const ItemContainer = styled.div`
 /**
  * @param {Object} props
  * @param {import('../type/shared/article').Article[]} props.renderList
- * @param {import('../type/category').CategorySection} props.section
+ * @param {import('../type/category').CategorySection} [props.section]
  * @returns {React.ReactElement}
  */
 export default function ArticleListItems({ renderList, section }) {

--- a/packages/mirror-media-next/components/author-articles.js
+++ b/packages/mirror-media-next/components/author-articles.js
@@ -1,0 +1,81 @@
+import styled from 'styled-components'
+import client from '../apollo/apollo-client'
+
+import InfiniteScrollList from './InifiniteScrollList'
+import Image from 'next/legacy/image'
+import LoadingPage from '../public/images/loading_page.gif'
+import ArticleListItems from './article-list-items'
+import { fetchPosts } from '../apollo/query/posts'
+
+const Loading = styled.div`
+  margin: 20px auto 0;
+  padding: 0 0 20px;
+  text-align: center;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 64px auto 0;
+    padding: 0 0 64px;
+  }
+`
+
+/**
+ *
+ * @param {Object} props
+ * @param {Number} props.postsCount
+ * @param {import('../type/shared/article').Article[]} props.posts
+ * @param {import('../type/author').Author} props.author
+ * @param {Number} props.renderPageSize
+ * @returns {React.ReactElement}
+ */
+export default function AuthorArticles({
+  postsCount,
+  posts,
+  author,
+  renderPageSize,
+}) {
+  async function fetchPostsFromPage(page) {
+    try {
+      const response = await client.query({
+        query: fetchPosts,
+        variables: {
+          take: renderPageSize * 2,
+          skip: page * renderPageSize * 2,
+          orderBy: { publishedDate: 'desc' },
+          filter: {
+            state: { equals: 'published' },
+            OR: [
+              { writers: { some: { id: { equals: author.id } } } },
+              { photographers: { some: { id: { equals: author.id } } } },
+            ],
+          },
+        },
+      })
+      console.log(response, page, renderPageSize, author.id)
+      return response.data.posts
+    } catch (error) {
+      console.error(error)
+    }
+    return
+  }
+
+  const loader = (
+    <Loading key={0}>
+      <Image src={LoadingPage} alt="loading page"></Image>
+    </Loading>
+  )
+
+  return (
+    <InfiniteScrollList
+      propsIS={{
+        threshold: 150,
+        loader,
+      }}
+      initialList={posts}
+      renderPageSize={renderPageSize}
+      pageCount={Math.ceil(postsCount / renderPageSize)}
+      fetchListInPage={fetchPostsFromPage}
+    >
+      {(renderList) => <ArticleListItems renderList={renderList} />}
+    </InfiniteScrollList>
+  )
+}

--- a/packages/mirror-media-next/components/category-articles.js
+++ b/packages/mirror-media-next/components/category-articles.js
@@ -1,0 +1,64 @@
+import styled from 'styled-components'
+import client from '../apollo/apollo-client'
+
+import InfiniteScrollList from './InifiniteScrollList'
+import Image from 'next/image'
+import LoadingPage from '../public/images/loading_page.gif'
+import ArticleListItems from './article-list-items'
+import { fetchPostsByCategory } from '../apollo/query/posts'
+
+const Loading = styled.div`
+  margin: 20px auto 0;
+  padding: 0 0 20px;
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 64px auto 0;
+    padding: 0 0 64px;
+  }
+`
+
+export default function ArticleList({
+  postsCount,
+  posts,
+  category,
+  renderPageSize,
+}) {
+  async function fetchPostsFromPage(page) {
+    try {
+      const response = await client.query({
+        query: fetchPostsByCategory,
+        variables: {
+          take: renderPageSize,
+          skip: page * renderPageSize,
+          orderBy: { publishedDate: 'desc' },
+          filter: {
+            state: { equals: 'published' },
+            categories: { some: { slug: { equals: category.slug } } },
+          },
+        },
+      })
+      return response.value.data.posts
+    } catch (error) {}
+    return
+  }
+
+  const loader = (
+    <Loading key={0}>
+      <Image src={LoadingPage} alt="loading page"></Image>
+    </Loading>
+  )
+
+  return (
+    <InfiniteScrollList
+      propsIS={{
+        threshold: 150,
+        loader,
+      }}
+      initialList={posts}
+      renderPageSize={renderPageSize}
+      pageCount={Math.ceil(postsCount / renderPageSize)}
+      fetchListInPage={fetchPostsFromPage}
+    >
+      {(renderList) => <ArticleListItems renderList={renderList} />}
+    </InfiniteScrollList>
+  )
+}

--- a/packages/mirror-media-next/components/category-articles.js
+++ b/packages/mirror-media-next/components/category-articles.js
@@ -23,7 +23,7 @@ const Loading = styled.div`
  * @param {Object} props
  * @param {Number} props.postsCount
  * @param {import('../type/shared/article').Article[]} props.posts
- * @param {import('../type/shared/category').Category} props.category
+ * @param {import('../type/category').Category} props.category
  * @param {Number} props.renderPageSize
  * @returns {React.ReactElement}
  */

--- a/packages/mirror-media-next/components/category-articles.js
+++ b/packages/mirror-media-next/components/category-articles.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import client from '../apollo/apollo-client'
 
 import InfiniteScrollList from './InifiniteScrollList'
-import Image from 'next/image'
+import Image from 'next/legacy/image'
 import LoadingPage from '../public/images/loading_page.gif'
 import ArticleListItems from './article-list-items'
 import { fetchPostsByCategory } from '../apollo/query/posts'
@@ -10,6 +10,8 @@ import { fetchPostsByCategory } from '../apollo/query/posts'
 const Loading = styled.div`
   margin: 20px auto 0;
   padding: 0 0 20px;
+  text-align: center;
+
   ${({ theme }) => theme.breakpoint.xl} {
     margin: 64px auto 0;
     padding: 0 0 64px;
@@ -27,8 +29,8 @@ export default function ArticleList({
       const response = await client.query({
         query: fetchPostsByCategory,
         variables: {
-          take: renderPageSize,
-          skip: page * renderPageSize,
+          take: renderPageSize * 2,
+          skip: page * renderPageSize * 2,
           orderBy: { publishedDate: 'desc' },
           filter: {
             state: { equals: 'published' },
@@ -36,7 +38,7 @@ export default function ArticleList({
           },
         },
       })
-      return response.value.data.posts
+      return response.data.posts
     } catch (error) {}
     return
   }
@@ -58,7 +60,12 @@ export default function ArticleList({
       pageCount={Math.ceil(postsCount / renderPageSize)}
       fetchListInPage={fetchPostsFromPage}
     >
-      {(renderList) => <ArticleListItems renderList={renderList} />}
+      {(renderList) => (
+        <ArticleListItems
+          renderList={renderList}
+          sections={category.sections}
+        />
+      )}
     </InfiniteScrollList>
   )
 }

--- a/packages/mirror-media-next/components/category-articles.js
+++ b/packages/mirror-media-next/components/category-articles.js
@@ -18,6 +18,15 @@ const Loading = styled.div`
   }
 `
 
+/**
+ *
+ * @param {Object} props
+ * @param {Number} props.postsCount
+ * @param {import('../type/shared/article').Article[]} props.posts
+ * @param {import('../type/shared/category').Category} props.category
+ * @param {Number} props.renderPageSize
+ * @returns {React.ReactElement}
+ */
 export default function ArticleList({
   postsCount,
   posts,
@@ -61,10 +70,7 @@ export default function ArticleList({
       fetchListInPage={fetchPostsFromPage}
     >
       {(renderList) => (
-        <ArticleListItems
-          renderList={renderList}
-          sections={category.sections}
-        />
+        <ArticleListItems renderList={renderList} section={category.sections} />
       )}
     </InfiniteScrollList>
   )

--- a/packages/mirror-media-next/components/category-articles.js
+++ b/packages/mirror-media-next/components/category-articles.js
@@ -5,7 +5,7 @@ import InfiniteScrollList from './InifiniteScrollList'
 import Image from 'next/legacy/image'
 import LoadingPage from '../public/images/loading_page.gif'
 import ArticleListItems from './article-list-items'
-import { fetchPostsByCategory } from '../apollo/query/posts'
+import { fetchPosts } from '../apollo/query/posts'
 
 const Loading = styled.div`
   margin: 20px auto 0;
@@ -27,7 +27,7 @@ const Loading = styled.div`
  * @param {Number} props.renderPageSize
  * @returns {React.ReactElement}
  */
-export default function ArticleList({
+export default function CategoryArticles({
   postsCount,
   posts,
   category,
@@ -36,7 +36,7 @@ export default function ArticleList({
   async function fetchPostsFromPage(page) {
     try {
       const response = await client.query({
-        query: fetchPostsByCategory,
+        query: fetchPosts,
         variables: {
           take: renderPageSize * 2,
           skip: page * renderPageSize * 2,

--- a/packages/mirror-media-next/components/section-articles.js
+++ b/packages/mirror-media-next/components/section-articles.js
@@ -1,0 +1,77 @@
+import styled from 'styled-components'
+import client from '../apollo/apollo-client'
+
+import InfiniteScrollList from './InifiniteScrollList'
+import Image from 'next/legacy/image'
+import LoadingPage from '../public/images/loading_page.gif'
+import ArticleListItems from './article-list-items'
+import { fetchPosts } from '../apollo/query/posts'
+
+const Loading = styled.div`
+  margin: 20px auto 0;
+  padding: 0 0 20px;
+  text-align: center;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 64px auto 0;
+    padding: 0 0 64px;
+  }
+`
+
+/**
+ *
+ * @param {Object} props
+ * @param {Number} props.postsCount
+ * @param {import('../type/shared/article').Article[]} props.posts
+ * @param {import('../type/shared/section').Section} props.section
+ * @param {Number} props.renderPageSize
+ * @returns {React.ReactElement}
+ */
+export default function SectionArticles({
+  postsCount,
+  posts,
+  section,
+  renderPageSize,
+}) {
+  async function fetchPostsFromPage(page) {
+    try {
+      const response = await client.query({
+        query: fetchPosts,
+        variables: {
+          take: renderPageSize * 2,
+          skip: page * renderPageSize * 2,
+          orderBy: { publishedDate: 'desc' },
+          filter: {
+            state: { equals: 'published' },
+            sections: { some: { slug: { equals: section.slug } } },
+          },
+        },
+      })
+      return response.data.posts
+    } catch (error) {}
+    return
+  }
+
+  const loader = (
+    <Loading key={0}>
+      <Image src={LoadingPage} alt="loading page"></Image>
+    </Loading>
+  )
+
+  return (
+    <InfiniteScrollList
+      propsIS={{
+        threshold: 150,
+        loader,
+      }}
+      initialList={posts}
+      renderPageSize={renderPageSize}
+      pageCount={Math.ceil(postsCount / renderPageSize)}
+      fetchListInPage={fetchPostsFromPage}
+    >
+      {(renderList) => (
+        <ArticleListItems renderList={renderList} section={section} />
+      )}
+    </InfiniteScrollList>
+  )
+}

--- a/packages/mirror-media-next/components/section-articles.js
+++ b/packages/mirror-media-next/components/section-articles.js
@@ -23,7 +23,7 @@ const Loading = styled.div`
  * @param {Object} props
  * @param {Number} props.postsCount
  * @param {import('../type/shared/article').Article[]} props.posts
- * @param {import('../type/shared/section').Section} props.section
+ * @param {import('../type/section').Section} props.section
  * @param {Number} props.renderPageSize
  * @returns {React.ReactElement}
  */

--- a/packages/mirror-media-next/components/tag-articles.js
+++ b/packages/mirror-media-next/components/tag-articles.js
@@ -1,0 +1,75 @@
+import styled from 'styled-components'
+import client from '../apollo/apollo-client'
+
+import InfiniteScrollList from './InifiniteScrollList'
+import Image from 'next/legacy/image'
+import LoadingPage from '../public/images/loading_page.gif'
+import ArticleListItems from './article-list-items'
+import { fetchPosts } from '../apollo/query/posts'
+
+const Loading = styled.div`
+  margin: 20px auto 0;
+  padding: 0 0 20px;
+  text-align: center;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 64px auto 0;
+    padding: 0 0 64px;
+  }
+`
+
+/**
+ *
+ * @param {Object} props
+ * @param {Number} props.postsCount
+ * @param {import('../type/shared/article').Article[]} props.posts
+ * @param {import('../type/tag').Tag} props.tag
+ * @param {Number} props.renderPageSize
+ * @returns {React.ReactElement}
+ */
+export default function TagArticles({
+  postsCount,
+  posts,
+  tag,
+  renderPageSize,
+}) {
+  async function fetchPostsFromPage(page) {
+    try {
+      const response = await client.query({
+        query: fetchPosts,
+        variables: {
+          take: renderPageSize * 2,
+          skip: page * renderPageSize * 2,
+          orderBy: { publishedDate: 'desc' },
+          filter: {
+            state: { equals: 'published' },
+            tags: { some: { slug: { equals: tag.slug } } },
+          },
+        },
+      })
+      return response.data.posts
+    } catch (error) {}
+    return
+  }
+
+  const loader = (
+    <Loading key={0}>
+      <Image src={LoadingPage} alt="loading page"></Image>
+    </Loading>
+  )
+
+  return (
+    <InfiniteScrollList
+      propsIS={{
+        threshold: 150,
+        loader,
+      }}
+      initialList={posts}
+      renderPageSize={renderPageSize}
+      pageCount={Math.ceil(postsCount / renderPageSize)}
+      fetchListInPage={fetchPostsFromPage}
+    >
+      {(renderList) => <ArticleListItems renderList={renderList} />}
+    </InfiniteScrollList>
+  )
+}

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -1,0 +1,150 @@
+import errors from '@twreporter/errors'
+import styled from 'styled-components'
+
+import client from '../../apollo/apollo-client'
+import { fetchContact } from '../../apollo/query/contact'
+import { fetchPosts } from '../../apollo/query/posts'
+import AuthorArticles from '../../components/author-articles'
+
+const AuthorContainer = styled.main`
+  width: 320px;
+  margin: 0 auto;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    width: 672px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    width: 1024px;
+    padding: 0;
+  }
+`
+
+const AuthorTitle = styled.h1`
+  display: inline-block;
+  margin: 16px 0 16px 16px;
+  padding: 4px 16px;
+  font-size: 16px;
+  line-height: 1.15;
+  font-weight: 500;
+  color: black;
+  ${({ theme }) => theme.breakpoint.md} {
+    margin: 18px 0 20px;
+    font-size: 28px;
+    font-weight: 600;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 24px 0 28px;
+  }
+`
+
+const RENDER_PAGE_SIZE = 12
+
+/**
+ * @param {Object} props
+ * @param {import('../../type/shared/article').Article[]} props.posts
+ * @param {import('../../type/author').Author} props.author
+ * @param {Number} props.postsCount
+ * @returns {React.ReactElement}
+ */
+export default function Author({ postsCount, posts, author }) {
+  return (
+    <AuthorContainer>
+      <AuthorTitle>{author?.name}</AuthorTitle>
+      <AuthorArticles
+        postsCount={postsCount}
+        posts={posts}
+        author={author}
+        renderPageSize={RENDER_PAGE_SIZE}
+      />
+    </AuthorContainer>
+  )
+}
+
+/**
+ * @type {import('next').GetServerSideProps}
+ */
+export async function getServerSideProps({ query, req }) {
+  const authorId = query.id
+  const traceHeader = req.headers?.['x-cloud-trace-context']
+  let globalLogFields = {}
+  if (traceHeader && !Array.isArray(traceHeader)) {
+    const [trace] = traceHeader.split('/')
+    globalLogFields[
+      'logging.googleapis.com/trace'
+    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
+  }
+
+  const responses = await Promise.allSettled([
+    client.query({
+      query: fetchPosts,
+      variables: {
+        take: RENDER_PAGE_SIZE * 2,
+        skip: 0,
+        orderBy: { publishedDate: 'desc' },
+        filter: {
+          state: { equals: 'published' },
+          OR: [
+            { writers: { some: { id: { equals: authorId } } } },
+            { photographers: { some: { id: { equals: authorId } } } },
+          ],
+        },
+      },
+    }),
+    client.query({
+      query: fetchContact,
+      variables: {
+        where: { id: authorId },
+      },
+    }),
+  ])
+
+  const handledResponses = responses.map((response) => {
+    if (response.status === 'fulfilled') {
+      return response.value.data
+    } else if (response.status === 'rejected') {
+      const { graphQLErrors, clientErrors, networkError } = response.reason
+      const annotatingError = errors.helpers.wrap(
+        response.reason,
+        'UnhandledError',
+        'Error occurs while getting index page data'
+      )
+
+      console.log(
+        JSON.stringify({
+          severity: 'ERROR',
+          message: errors.helpers.printAll(
+            annotatingError,
+            {
+              withStack: true,
+              withPayload: true,
+            },
+            0,
+            0
+          ),
+          debugPayload: {
+            graphQLErrors,
+            clientErrors,
+            networkError,
+          },
+          ...globalLogFields,
+        })
+      )
+      return
+    }
+  })
+
+  /** @type {Number} postsCount */
+  const postsCount = handledResponses[0]?.postsCount || 0
+  /** @type {import('../../type/shared/article').Article[]} */
+  const posts = handledResponses[0]?.posts || []
+  /** @type {import('../../type/author').Author} */
+  const author = handledResponses[1]?.contact || {}
+
+  const props = {
+    postsCount,
+    posts,
+    author,
+  }
+
+  return { props }
+}

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -50,7 +50,7 @@ const RENDER_PAGE_SIZE = 12
 /**
  * @param {Object} props
  * @param {import('../../type/shared/article').Article[]} props.posts
- * @param {import('../../type/shared/category').Category} props.category
+ * @param {import('../../type/category').Category} props.category
  * @param {Number} props.postsCount
  * @returns {React.ReactElement}
  */
@@ -144,7 +144,7 @@ export async function getServerSideProps({ query, req }) {
   const postsCount = handledResponses[0]?.postsCount || 0
   /** @type {import('../../type/shared/article').Article[]} */
   const posts = handledResponses[0]?.posts || []
-  /** @type {import('../../type/shared/category').Category} */
+  /** @type {import('../../type/category').Category} */
   const category = handledResponses[1]?.category || {}
 
   const props = {

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -1,13 +1,38 @@
 import errors from '@twreporter/errors'
+import styled from 'styled-components'
 
 import client from '../../apollo/apollo-client'
 import { fetchPostsByCategory } from '../../apollo/query/posts'
 import { fetchCategorySections } from '../../apollo/query/categroies'
+import CategoryArticles from '../../components/category-articles'
+
+const CategoryContainer = styled.main`
+  ${({ theme }) => theme.breakpoint.md} {
+    padding: 0 48px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 0 auto;
+    max-width: 1024px;
+    padding: 0;
+  }
+`
+
+const RENDER_PAGE_SIZE = 12
 
 export default function Category({ postsCount, posts, category }) {
   console.log(postsCount, posts, category)
 
-  return <div>{category?.name} </div>
+  return (
+    <CategoryContainer>
+      <h1>{category?.name}</h1>
+      <CategoryArticles
+        postsCount={postsCount}
+        posts={posts}
+        category={category?.name}
+        renderPageSize={RENDER_PAGE_SIZE}
+      />
+    </CategoryContainer>
+  )
 }
 
 export async function getServerSideProps({ query, req }) {
@@ -25,7 +50,7 @@ export async function getServerSideProps({ query, req }) {
     client.query({
       query: fetchPostsByCategory,
       variables: {
-        take: 12,
+        take: RENDER_PAGE_SIZE,
         skip: 0,
         orderBy: { publishedDate: 'desc' },
         filter: {

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -47,6 +47,13 @@ const CategoryTitle = styled.h1`
 
 const RENDER_PAGE_SIZE = 12
 
+/**
+ * @param {Object} props
+ * @param {import('../../type/shared/article').Article[]} props.posts
+ * @param {import('../../type/shared/category').Category} props.category
+ * @param {Number} props.postsCount
+ * @returns {React.ReactElement}
+ */
 export default function Category({ postsCount, posts, category }) {
   return (
     <CategoryContainer>
@@ -63,6 +70,9 @@ export default function Category({ postsCount, posts, category }) {
   )
 }
 
+/**
+ * @type {import('next').GetServerSideProps}
+ */
 export async function getServerSideProps({ query, req }) {
   const categorySlug = query.slug
   const traceHeader = req.headers?.['x-cloud-trace-context']
@@ -130,10 +140,17 @@ export async function getServerSideProps({ query, req }) {
     }
   })
 
+  /** @type {Number} postsCount */
+  const postsCount = handledResponses[0]?.postsCount || 0
+  /** @type {import('../../type/shared/article').Article[]} */
+  const posts = handledResponses[0]?.posts || []
+  /** @type {import('../../type/shared/category').Category} */
+  const category = handledResponses[1]?.category || {}
+
   const props = {
-    postsCount: handledResponses[0]?.postsCount || 0,
-    posts: handledResponses[0]?.posts || [],
-    category: handledResponses[1]?.category || {},
+    postsCount,
+    posts,
+    category,
   }
 
   return { props }

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -2,7 +2,7 @@ import errors from '@twreporter/errors'
 import styled from 'styled-components'
 
 import client from '../../apollo/apollo-client'
-import { fetchPostsByCategory } from '../../apollo/query/posts'
+import { fetchPosts } from '../../apollo/query/posts'
 import { fetchCategorySections } from '../../apollo/query/categroies'
 import CategoryArticles from '../../components/category-articles'
 
@@ -86,7 +86,7 @@ export async function getServerSideProps({ query, req }) {
 
   const responses = await Promise.allSettled([
     client.query({
-      query: fetchPostsByCategory,
+      query: fetchPosts,
       variables: {
         take: RENDER_PAGE_SIZE * 2,
         skip: 0,

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -7,28 +7,56 @@ import { fetchCategorySections } from '../../apollo/query/categroies'
 import CategoryArticles from '../../components/category-articles'
 
 const CategoryContainer = styled.main`
+  width: 320px;
+  margin: 0 auto;
+
   ${({ theme }) => theme.breakpoint.md} {
-    padding: 0 48px;
+    width: 672px;
   }
   ${({ theme }) => theme.breakpoint.xl} {
-    margin: 0 auto;
-    max-width: 1024px;
+    width: 1024px;
     padding: 0;
+  }
+`
+const CategoryTitle = styled.h1`
+  margin: 20px 0 16px 16px;
+  font-size: 16px;
+  line-height: 1.15;
+  font-weight: 500;
+  color: ${
+    /**
+     * @param {Object} props
+     * @param {String } props.sectionName
+     * @param {Theme} [props.theme]
+     */
+    ({ sectionName, theme }) =>
+      sectionName && theme.color.sectionsColor[sectionName]
+        ? theme.color.sectionsColor[sectionName]
+        : theme.color.sectionsColor[sectionName]
+  };
+  ${({ theme }) => theme.breakpoint.md} {
+    margin: 20px 0 24px;
+    font-size: 20.8px;
+    font-weight: 600;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 24px 0 28px;
+    font-size: 28px;
   }
 `
 
 const RENDER_PAGE_SIZE = 12
 
 export default function Category({ postsCount, posts, category }) {
-  console.log(postsCount, posts, category)
-
   return (
     <CategoryContainer>
-      <h1>{category?.name}</h1>
+      <CategoryTitle sectionName={category?.sections?.slug}>
+        {category?.name}
+      </CategoryTitle>
       <CategoryArticles
         postsCount={postsCount}
         posts={posts}
-        category={category?.name}
+        category={category}
         renderPageSize={RENDER_PAGE_SIZE}
       />
     </CategoryContainer>
@@ -50,7 +78,7 @@ export async function getServerSideProps({ query, req }) {
     client.query({
       query: fetchPostsByCategory,
       variables: {
-        take: RENDER_PAGE_SIZE,
+        take: RENDER_PAGE_SIZE * 2,
         skip: 0,
         orderBy: { publishedDate: 'desc' },
         filter: {

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -1,0 +1,87 @@
+import errors from '@twreporter/errors'
+
+import client from '../../apollo/apollo-client'
+import { fetchPostsByCategory } from '../../apollo/query/posts'
+import { fetchCategorySections } from '../../apollo/query/categroies'
+
+export default function Category({ postsCount, posts, category }) {
+  console.log(postsCount, posts, category)
+
+  return <div>{category?.name} </div>
+}
+
+export async function getServerSideProps({ query, req }) {
+  const categorySlug = query.slug
+  const traceHeader = req.headers?.['x-cloud-trace-context']
+  let globalLogFields = {}
+  if (traceHeader && !Array.isArray(traceHeader)) {
+    const [trace] = traceHeader.split('/')
+    globalLogFields[
+      'logging.googleapis.com/trace'
+    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
+  }
+
+  const responses = await Promise.allSettled([
+    client.query({
+      query: fetchPostsByCategory,
+      variables: {
+        take: 12,
+        skip: 0,
+        orderBy: { publishedDate: 'desc' },
+        filter: {
+          state: { equals: 'published' },
+          categories: { some: { slug: { equals: categorySlug } } },
+        },
+      },
+    }),
+    client.query({
+      query: fetchCategorySections,
+      variables: {
+        categorySlug,
+      },
+    }),
+  ])
+
+  const handledResponses = responses.map((response) => {
+    if (response.status === 'fulfilled') {
+      return response.value.data
+    } else if (response.status === 'rejected') {
+      const { graphQLErrors, clientErrors, networkError } = response.reason
+      const annotatingError = errors.helpers.wrap(
+        response.reason,
+        'UnhandledError',
+        'Error occurs while getting index page data'
+      )
+
+      console.log(
+        JSON.stringify({
+          severity: 'ERROR',
+          message: errors.helpers.printAll(
+            annotatingError,
+            {
+              withStack: true,
+              withPayload: true,
+            },
+            0,
+            0
+          ),
+          debugPayload: {
+            graphQLErrors,
+            clientErrors,
+            networkError,
+          },
+          ...globalLogFields,
+        })
+      )
+      return
+    }
+  })
+
+  const props = {
+    postsCount: handledResponses[0]?.postsCount || 0,
+    posts: handledResponses[0]?.posts || [],
+    category: handledResponses[1]?.category || {},
+  }
+
+  return { props }
+}

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -1,0 +1,155 @@
+import errors from '@twreporter/errors'
+import styled from 'styled-components'
+
+import client from '../../apollo/apollo-client'
+import { fetchPosts } from '../../apollo/query/posts'
+import { fetchSection } from '../../apollo/query/sections'
+import SectionArticles from '../../components/section-articles'
+
+const SectionContainer = styled.main`
+  width: 320px;
+  margin: 0 auto;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    width: 672px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    width: 1024px;
+    padding: 0;
+  }
+`
+const SectionTitle = styled.h1`
+  margin: 20px 0 16px 16px;
+  font-size: 16px;
+  line-height: 1.15;
+  font-weight: 500;
+  color: ${
+    /**
+     * @param {Object} props
+     * @param {String } props.sectionName
+     * @param {Theme} [props.theme]
+     */
+    ({ sectionName, theme }) =>
+      sectionName && theme.color.sectionsColor[sectionName]
+        ? theme.color.sectionsColor[sectionName]
+        : theme.color.sectionsColor[sectionName]
+  };
+  ${({ theme }) => theme.breakpoint.md} {
+    margin: 20px 0 24px;
+    font-size: 20.8px;
+    font-weight: 600;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 24px 0 28px;
+    font-size: 28px;
+  }
+`
+
+const RENDER_PAGE_SIZE = 12
+
+/**
+ * @param {Object} props
+ * @param {import('../../type/shared/article').Article[]} props.posts
+ * @param {import('../../type/shared/section').Section} props.section
+ * @param {Number} props.postsCount
+ * @returns {React.ReactElement}
+ */
+export default function Section({ postsCount, posts, section }) {
+  return (
+    <SectionContainer>
+      <SectionTitle sectionName={section?.slug}>{section?.name}</SectionTitle>
+      <SectionArticles
+        postsCount={postsCount}
+        posts={posts}
+        section={section}
+        renderPageSize={RENDER_PAGE_SIZE}
+      />
+    </SectionContainer>
+  )
+}
+
+/**
+ * @type {import('next').GetServerSideProps}
+ */
+export async function getServerSideProps({ query, req }) {
+  const sectionSlug = query.slug
+  const traceHeader = req.headers?.['x-cloud-trace-context']
+  let globalLogFields = {}
+  if (traceHeader && !Array.isArray(traceHeader)) {
+    const [trace] = traceHeader.split('/')
+    globalLogFields[
+      'logging.googleapis.com/trace'
+    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
+  }
+
+  const responses = await Promise.allSettled([
+    client.query({
+      query: fetchPosts,
+      variables: {
+        take: RENDER_PAGE_SIZE * 2,
+        skip: 0,
+        orderBy: { publishedDate: 'desc' },
+        filter: {
+          state: { equals: 'published' },
+          categories: { some: { slug: { equals: sectionSlug } } },
+        },
+      },
+    }),
+    client.query({
+      query: fetchSection,
+      variables: {
+        where: { slug: sectionSlug },
+      },
+    }),
+  ])
+
+  const handledResponses = responses.map((response) => {
+    if (response.status === 'fulfilled') {
+      return response.value.data
+    } else if (response.status === 'rejected') {
+      const { graphQLErrors, clientErrors, networkError } = response.reason
+      const annotatingError = errors.helpers.wrap(
+        response.reason,
+        'UnhandledError',
+        'Error occurs while getting index page data'
+      )
+
+      console.log(
+        JSON.stringify({
+          severity: 'ERROR',
+          message: errors.helpers.printAll(
+            annotatingError,
+            {
+              withStack: true,
+              withPayload: true,
+            },
+            0,
+            0
+          ),
+          debugPayload: {
+            graphQLErrors,
+            clientErrors,
+            networkError,
+          },
+          ...globalLogFields,
+        })
+      )
+      return
+    }
+  })
+
+  /** @type {Number} postsCount */
+  const postsCount = handledResponses[0]?.postsCount || 0
+  /** @type {import('../../type/shared/article').Article[]} */
+  const posts = handledResponses[0]?.posts || []
+  /** @type {import('../../type/shared/section').Section} */
+  const section = handledResponses[1]?.section || {}
+
+  const props = {
+    postsCount,
+    posts,
+    section,
+  }
+
+  return { props }
+}

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -50,7 +50,7 @@ const RENDER_PAGE_SIZE = 12
 /**
  * @param {Object} props
  * @param {import('../../type/shared/article').Article[]} props.posts
- * @param {import('../../type/shared/section').Section} props.section
+ * @param {import('../../type/section').Section} props.section
  * @param {Number} props.postsCount
  * @returns {React.ReactElement}
  */
@@ -142,7 +142,7 @@ export async function getServerSideProps({ query, req }) {
   const postsCount = handledResponses[0]?.postsCount || 0
   /** @type {import('../../type/shared/article').Article[]} */
   const posts = handledResponses[0]?.posts || []
-  /** @type {import('../../type/shared/section').Section} */
+  /** @type {import('../../type/section').Section} */
   const section = handledResponses[1]?.section || {}
 
   const props = {

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -32,7 +32,7 @@ const SectionTitle = styled.h1`
     ({ sectionName, theme }) =>
       sectionName && theme.color.sectionsColor[sectionName]
         ? theme.color.sectionsColor[sectionName]
-        : theme.color.sectionsColor[sectionName]
+        : theme.color.brandColor.lightBlue
   };
   ${({ theme }) => theme.breakpoint.md} {
     margin: 20px 0 24px;

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -3,10 +3,10 @@ import styled from 'styled-components'
 
 import client from '../../apollo/apollo-client'
 import { fetchPosts } from '../../apollo/query/posts'
-import { fetchCategorySections } from '../../apollo/query/categroies'
-import CategoryArticles from '../../components/category-articles'
+import { fetchTag } from '../../apollo/query/tags'
+import TagArticles from '../../components/tag-articles'
 
-const CategoryContainer = styled.main`
+const TagContainer = styled.main`
   width: 320px;
   margin: 0 auto;
 
@@ -18,30 +18,26 @@ const CategoryContainer = styled.main`
     padding: 0;
   }
 `
-const CategoryTitle = styled.h1`
-  margin: 20px 0 16px 16px;
+const TagTitle = styled.h1`
+  display: inline-block;
+  margin: 16px 0 16px 16px;
+  padding: 4px 16px;
   font-size: 16px;
   line-height: 1.15;
-  font-weight: 500;
-  color: ${
-    /**
-     * @param {Object} props
-     * @param {String } props.sectionName
-     * @param {Theme} [props.theme]
-     */
-    ({ sectionName, theme }) =>
-      sectionName && theme.color.sectionsColor[sectionName]
-        ? theme.color.sectionsColor[sectionName]
-        : theme.color.brandColor.lightBlue
-  };
+  font-weight: 600;
+  color: white;
+  background-color: black;
+  border-radius: 6px;
   ${({ theme }) => theme.breakpoint.md} {
     margin: 20px 0 24px;
-    font-size: 20.8px;
-    font-weight: 600;
+    padding: 4px 8px;
+    font-size: 28px;
+    font-weight: 500;
+    line-height: 1.4;
+    border-radius: 10px;
   }
   ${({ theme }) => theme.breakpoint.xl} {
     margin: 24px 0 28px;
-    font-size: 28px;
   }
 `
 
@@ -50,23 +46,21 @@ const RENDER_PAGE_SIZE = 12
 /**
  * @param {Object} props
  * @param {import('../../type/shared/article').Article[]} props.posts
- * @param {import('../../type/category').Category} props.category
+ * @param {import('../../type/tag').Tag} props.tag
  * @param {Number} props.postsCount
  * @returns {React.ReactElement}
  */
-export default function Category({ postsCount, posts, category }) {
+export default function Tag({ postsCount, posts, tag }) {
   return (
-    <CategoryContainer>
-      <CategoryTitle sectionName={category?.sections?.slug}>
-        {category?.name}
-      </CategoryTitle>
-      <CategoryArticles
+    <TagContainer>
+      <TagTitle>{tag?.name}</TagTitle>
+      <TagArticles
         postsCount={postsCount}
         posts={posts}
-        category={category}
+        tag={tag}
         renderPageSize={RENDER_PAGE_SIZE}
       />
-    </CategoryContainer>
+    </TagContainer>
   )
 }
 
@@ -74,7 +68,7 @@ export default function Category({ postsCount, posts, category }) {
  * @type {import('next').GetServerSideProps}
  */
 export async function getServerSideProps({ query, req }) {
-  const categorySlug = query.slug
+  const tagSlug = query.slug
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}
   if (traceHeader && !Array.isArray(traceHeader)) {
@@ -93,14 +87,14 @@ export async function getServerSideProps({ query, req }) {
         orderBy: { publishedDate: 'desc' },
         filter: {
           state: { equals: 'published' },
-          categories: { some: { slug: { equals: categorySlug } } },
+          tags: { some: { slug: { equals: tagSlug } } },
         },
       },
     }),
     client.query({
-      query: fetchCategorySections,
+      query: fetchTag,
       variables: {
-        categorySlug,
+        where: { slug: tagSlug },
       },
     }),
   ])
@@ -144,13 +138,13 @@ export async function getServerSideProps({ query, req }) {
   const postsCount = handledResponses[0]?.postsCount || 0
   /** @type {import('../../type/shared/article').Article[]} */
   const posts = handledResponses[0]?.posts || []
-  /** @type {import('../../type/category').Category} */
-  const category = handledResponses[1]?.category || {}
+  /** @type {import('../../type/tag').Tag} */
+  const tag = handledResponses[1]?.tag || {}
 
   const props = {
     postsCount,
     posts,
-    category,
+    tag,
   }
 
   return { props }

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -18,6 +18,22 @@ const TagContainer = styled.main`
     padding: 0;
   }
 `
+
+const TagTitleWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  ${({ theme }) => theme.breakpoint.md} {
+    &::after {
+      content: '';
+      margin: 0px 0px 0px 28px;
+      display: inline-block;
+      flex: 1 1 auto;
+      height: 2px;
+      background: linear-gradient(90deg, rgb(0, 0, 0) 30%, rgb(255, 255, 255));
+    }
+  }
+`
+
 const TagTitle = styled.h1`
   display: inline-block;
   margin: 16px 0 16px 16px;
@@ -53,7 +69,9 @@ const RENDER_PAGE_SIZE = 12
 export default function Tag({ postsCount, posts, tag }) {
   return (
     <TagContainer>
-      <TagTitle>{tag?.name}</TagTitle>
+      <TagTitleWrapper>
+        <TagTitle>{tag?.name}</TagTitle>
+      </TagTitleWrapper>
       <TagArticles
         postsCount={postsCount}
         posts={posts}

--- a/packages/mirror-media-next/type/author/index.js
+++ b/packages/mirror-media-next/type/author/index.js
@@ -1,0 +1,8 @@
+export default {}
+
+/**
+ * @typedef {import('../shared/gql/contact').Contact & {
+ *  id: String,
+ *  name: String
+ * }} Author
+ */

--- a/packages/mirror-media-next/type/category/index.js
+++ b/packages/mirror-media-next/type/category/index.js
@@ -1,7 +1,7 @@
 export default {}
 
 /**
- * @typedef {import('../gql/section').Section & {
+ * @typedef {import('../shared/gql/section').Section & {
  *  id: String,
  *  name: String,
  *  slug: String,
@@ -9,7 +9,7 @@ export default {}
  */
 
 /**
- * @typedef {import('../gql/category').Category & {
+ * @typedef {import('../shared/gql/category').Category & {
  *  id: String,
  *  name: String,
  *  slug: String,

--- a/packages/mirror-media-next/type/section/index.js
+++ b/packages/mirror-media-next/type/section/index.js
@@ -1,7 +1,7 @@
 export default {}
 
 /**
- * @typedef {import('../gql/section').Section & {
+ * @typedef {import('../shared/gql/section').Section & {
  *  id: String,
  *  name: String,
  *  slug: String,

--- a/packages/mirror-media-next/type/shared/article.js
+++ b/packages/mirror-media-next/type/shared/article.js
@@ -1,0 +1,59 @@
+export default {}
+
+/**
+ * @typedef {import('./draft-js').Draft} Draft
+ */
+
+/**
+ * @typedef {import('./gql/section').Section & {
+ *  slug: String,
+ *  name: String,
+ * }} ArticleSection
+ */
+
+/**
+ * @typedef {import('./gql/category').Category & {
+ *  slug: String,
+ *  name: String,
+ * }} ArticleCategory
+ */
+
+/**
+ * @typedef {import('./gql/photo').ImageFile & {
+ *  width: Number,
+ *  height: Number,
+ * }} HeroImageFile
+ */
+
+/**
+ * @typedef {import('./gql/photo').Resized & {
+ *  original: String,
+ *  w480: String,
+ *  w800: String,
+ *  w1200: String,
+ *  w1600: String,
+ *  w2400: String,
+ * }} HeroImageResized
+ */
+
+/**
+ * @typedef {import('./gql/photo').Photo & {
+ *  id: String,
+ *  name: String,
+ *  imageFile: HeroImageFile,
+ *  resized: HeroImageResized
+ * }} ArticleHeroImage
+ */
+
+/**
+ * @typedef {import('./gql/post').Post & {
+ *  id: String,
+ *  slug: String,
+ *  title: String,
+ *  publishDate: String,
+ *  draft: Draft,
+ *  categroies: ArticleCategory[],
+ *  sections: ArticleSection[],
+ *  heroImage: ArticleHeroImage,
+ * }} Article
+ */

--- a/packages/mirror-media-next/type/shared/category/index.js
+++ b/packages/mirror-media-next/type/shared/category/index.js
@@ -1,0 +1,18 @@
+export default {}
+
+/**
+ * @typedef {import('../gql/section').Section & {
+ *  id: String,
+ *  name: String,
+ *  slug: String,
+ * }} CategorySection
+ */
+
+/**
+ * @typedef {import('../gql/category').Category & {
+ *  id: String,
+ *  name: String,
+ *  slug: String,
+ *  sections: CategorySection,
+ * }} Category
+ */

--- a/packages/mirror-media-next/type/shared/draft-js.js
+++ b/packages/mirror-media-next/type/shared/draft-js.js
@@ -1,0 +1,18 @@
+export default {}
+
+/**
+ * @typedef {Object} Draft
+ * @property {DraftBlock[]} blocks
+ * @property {Object} entityMap
+ */
+
+/**
+ * @typedef {Object} DraftBlock
+ * @property {Object} data
+ * @property {Number} depth
+ * @property {Array} entityRanges
+ * @property {Array} inlineStyleRanges
+ * @property {String} key
+ * @property {String} text
+ * @property {String} type
+ */

--- a/packages/mirror-media-next/type/shared/gql/category.js
+++ b/packages/mirror-media-next/type/shared/gql/category.js
@@ -1,0 +1,9 @@
+export default {}
+
+/**
+ * @typedef {Object} Category
+ * @property {String} [id]
+ * @property {String} [name]
+ * @property {String} [slug]
+ * @property {import('./section').Section} [sections] it's singular but wrongly named as plural
+ */

--- a/packages/mirror-media-next/type/shared/gql/contact.js
+++ b/packages/mirror-media-next/type/shared/gql/contact.js
@@ -1,0 +1,7 @@
+export default {}
+
+/**
+ * @typedef {Object} Contact
+ * @property {String} [id]
+ * @property {String} [name]
+ */

--- a/packages/mirror-media-next/type/shared/gql/photo.js
+++ b/packages/mirror-media-next/type/shared/gql/photo.js
@@ -1,0 +1,25 @@
+export default {}
+
+/**
+ * @typedef {Object} Photo
+ * @property {String} [id]
+ * @property {String} [name]
+ * @property {ImageFile} [imageFile]
+ * @property {Resized} [resized]
+ */
+
+/**
+ * @typedef {Object} ImageFile
+ * @property {Number} [width]
+ * @property {Number} [height]
+ */
+
+/**
+ * @typedef {Object} Resized
+ * @property {String} [original]
+ * @property {String} [w480]
+ * @property {String} [w800]
+ * @property {String} [w1200]
+ * @property {String} [w1600]
+ * @property {String} [w2400]
+ */

--- a/packages/mirror-media-next/type/shared/gql/post.js
+++ b/packages/mirror-media-next/type/shared/gql/post.js
@@ -1,0 +1,13 @@
+export default {}
+
+/**
+ * @typedef {Object} Post
+ * @property {String} [id]
+ * @property {String} [slug]
+ * @property {String} [title]
+ * @property {String} [publishDate]
+ * @property {import('../draft-js').Draft} [brief]
+ * @property {import('./category').Category[]} [categories]
+ * @property {import('./section').Section[]} [sections]
+ * @property {import('./photo').Photo} [heroImage]
+ */

--- a/packages/mirror-media-next/type/shared/gql/section.js
+++ b/packages/mirror-media-next/type/shared/gql/section.js
@@ -1,0 +1,8 @@
+export default {}
+
+/**
+ * @typedef {Object} Section
+ * @property {String} [id]
+ * @property {String} [name]
+ * @property {String} [slug]
+ */

--- a/packages/mirror-media-next/type/shared/gql/tag.js
+++ b/packages/mirror-media-next/type/shared/gql/tag.js
@@ -1,0 +1,8 @@
+export default {}
+
+/**
+ * @typedef {Object} Tag
+ * @property {String} [id]
+ * @property {String} [name]
+ * @property {String} [slug]
+ */

--- a/packages/mirror-media-next/type/shared/section/index.js
+++ b/packages/mirror-media-next/type/shared/section/index.js
@@ -1,0 +1,9 @@
+export default {}
+
+/**
+ * @typedef {import('../gql/section').Section & {
+ *  id: String,
+ *  name: String,
+ *  slug: String,
+ * }} Section
+ */

--- a/packages/mirror-media-next/type/tag/index.js
+++ b/packages/mirror-media-next/type/tag/index.js
@@ -1,0 +1,9 @@
+export default {}
+
+/**
+ * @typedef {import('../shared/gql/tag').Tag & {
+ *  id: String,
+ *  name: String,
+ *  slug: String,
+ * }} Tag
+ */


### PR DESCRIPTION
# Feature

- Add category, section, tag and author page
- Add JSDoc for gql request and pages
- Add experimental InfiniteScrollList to encapsuate render logic for lists **(to be replaced in the future)**

## JSDoc for gql

file structure基於[這個討論](https://paper.dropbox.com/doc/mirror-media-next--BxyPEcd82HXbUWhSDC37WnmUAg-4ycqmvBJILA9l7XU0Zt0G#:uid=673569398346384308243769&h2=20230119:-JSDoc-convention)，將types分成page route層級和shared層級，以便快速查詢共用的type definition。

### 改動1.
移除type.js的命名，從`post.typedef.js` 改成 `post.js`，透過放在 type資料夾之中來辨識該檔為type definition

### 改動2.
原本關於gql的type definition會是取各個query中同一個list的最大公約數的property來定義，由個別的component或是page再特別增加需要的property type，不過開發後發現，因為gql設計上的彈性，一個list的property在不同的query下的最大公約數都會是optional的type，在使用上較為不便(還要自行判斷該property是否為必須)

因此後續在研究完JSDoc, TypeScript的相關做法之後決定採用針對使用到的list都會寫一個基本的型別的type放置在 `type/shared/gql` 路徑下，這個檔案中的所有的properties都會是optional的寫法，在component level或是page level會把需要的properties透過 `&` 的方式去overwrite掉原本optional的設定(同時給予適合商業logic的type 名稱， ex: Post -> Article)

日後新增其他的query的時候僅需要在`type/shared/gql`該list的type definition檔案中新增需要的optional property，並另外去定義實際使用的type即可。

實際使用如下，最後會拿來用的type為 `type/shared/article.js`中的`Article`
```
// in type/shared/gql/post.js
/**
 * @typedef {Object} Post
 * @property {String} [id]
 * @property {String} [slug]
 * @property {String} [title]
 * @property {String} [publishDate]
 * @property {import('../draft-js').Draft} [brief]
 * @property {import('./category').Category[]} [categories]
 * @property {import('./section').Section[]} [sections]
 * @property {import('./photo').Photo} [heroImage]
 */

// in type/shared/article.js (used in category, section, tag and author pages)
/**
 * @typedef {import('./gql/post').Post & {
 *  id: String,
 *  slug: String,
 *  title: String,
 *  publishDate: String,
 *  draft: Draft,
 *  categroies: ArticleCategory[],
 *  sections: ArticleSection[],
 *  heroImage: ArticleHeroImage,
 * }} Article
 */

```

### Prepare for TypeScript

目前的作法相對比較繁瑣，不過日後如果從JSDoc migrate到TypeScript之後即可使用TypeScript的[Pick](https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys)功能來取代目前用 `&` 來overwrite掉property的方式，使用上會簡潔很多。

```
// in type/shared/gql/post.js
interface Post {
  id: string
  slug: string
  title: string
  publishDate: string
}

// in type/shared/article.js (used in category, section, tag and author pages)
type Article = Pick<Post, "id" | "slug" | title">
```

### Follow up

新增最終的作法到readme之中