### PR TITLE
feat(mm-next): set `max-age` of `Cache-Control` at index page

### DIFF
--- a/packages/mirror-media-next/config/index.js
+++ b/packages/mirror-media-next/config/index.js
@@ -56,6 +56,7 @@ switch (ENV) {
 }
 
 export {
+  ENV,
   GCP_PROJECT_ID,
   API_TIMEOUT,
   API_HOST,

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -8,12 +8,14 @@ import errors from '@twreporter/errors'
 import client from '../apollo/apollo-client'
 import { gql } from '@apollo/client'
 import {
+  ENV,
   API_TIMEOUT,
   URL_STATIC_COMBO_TOPICS,
   URL_K3_FLASH_NEWS,
   URL_STATIC_POST_EXTERNAL,
   GCP_PROJECT_ID,
 } from '../config'
+
 import { transformRawDataToArticleInfo } from '../utils'
 import FlashNews from '../components/flash-news'
 import NavTopics from '../components/nav-topics'
@@ -110,8 +112,12 @@ export default function Home({
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps(context) {
-  const headers = context?.req?.headers
+export async function getServerSideProps({ res, req }) {
+  if (ENV === 'dev' || ENV === 'staging' || ENV === 'prod') {
+    res.setHeader('Cache-Control', 'public, max-age=180')
+  }
+
+  const headers = req?.headers
   const traceHeader = headers?.['x-cloud-trace-context']
   let globalLogFields = {}
   if (traceHeader && !Array.isArray(traceHeader)) {
@@ -231,7 +237,6 @@ export async function getServerSideProps(context) {
             }
           ) {
             id
-            s
             order
             choices {
               id
@@ -253,6 +258,7 @@ export async function getServerSideProps(context) {
         }
       `,
     })
+    console.log(editorChoiceApollo)
   } catch (err) {
     const { graphQLErrors, clientErrors, networkError } = err
     const annotatingError = errors.helpers.wrap(


### PR DESCRIPTION
## Notable Change 
若首頁最新文章json檔，於server-side取得的時間，與使用者瀏覽器相差超過180秒，則需要於client side重新fetch一次，以保持最新文章的時效性。目前實作邏輯是由[元件`latest-news.js`實作](https://github.com/mirror-media/Adam/blob/dev/packages/mirror-media-next/components/latest-news.js#L138-L152)，但經討論後，則由page層設定Cache-Control時間亦可達到同樣目的，且實作相對簡潔，故改由page層設定Cache-Control。
此PR僅處理page層，而元件`latest-news.js`的相關實作程式碼，將於 #107 merge進codebase後被移除。