### PR TITLE
feat(mm-next): add component `aside-article-list` in story page

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/listing-post.js
+++ b/packages/mirror-media-next/apollo/fragments/listing-post.js
@@ -1,0 +1,54 @@
+import { gql } from '@apollo/client'
+
+/**
+ * @typedef {Object} Image
+ * @property {Object} resized
+ * @property {string} resized.w480
+ * @property {string} resized.w800
+ * @property {string} resized.w1200
+ * @property {string} resized.w1600
+ * @property {string} resized.w2400
+ * @property {string} resized.original
+ */
+
+/**
+ * @typedef {Object} Section
+ * @property {string} id
+ * @property {string} slug
+ * @property {string} name
+ */
+
+/**
+ * @typedef {Object} ListingPost
+ * @property {string} id
+ * @property {string} slug
+ * @property {string} title
+ * @property {string} style
+ * @property {Section[]} sections
+ * @property {Image  | null} heroImage
+ */
+
+const listingPost = gql`
+  fragment listingPost on Post {
+    id
+    slug
+    title
+    style
+    sections {
+      id
+      slug
+      name
+    }
+    heroImage {
+      resized {
+        w480
+        w800
+        w1200
+        w1600
+        w2400
+        original
+      }
+    }
+  }
+`
+export { listingPost }

--- a/packages/mirror-media-next/apollo/query/posts.js
+++ b/packages/mirror-media-next/apollo/query/posts.js
@@ -1,4 +1,31 @@
 import { gql } from '@apollo/client'
+import { listingPost } from '../fragments/listing-post'
+
+//TODO: result of fetchListingPost is similar to fetchPosts, should refactor to on gql query if possible
+
+/**
+ * @typedef {import('../fragments/listing-post').ListingPost} ResultOfFetchListingPosts
+ */
+
+const fetchListingPosts = gql`
+  ${listingPost}
+  query fetchListingPosts(
+    $take: Int
+    $sectionSlug: [String!]
+    $storySlug: String!
+  ) {
+    posts(
+      take: $take
+      orderBy: { publishedDate: desc }
+      where: {
+        sections: { some: { slug: { in: $sectionSlug } } }
+        slug: { not: { equals: $storySlug } }
+      }
+    ) {
+      ...listingPost
+    }
+  }
+`
 
 const fetchPosts = gql`
   query (
@@ -41,4 +68,4 @@ const fetchPosts = gql`
   }
 `
 
-export { fetchPosts }
+export { fetchPosts, fetchListingPosts }

--- a/packages/mirror-media-next/components/story/normal/aside-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/aside-article-list.js
@@ -9,6 +9,7 @@ import {
   getSectionTitleGql,
   getArticleHref,
 } from '../../../utils'
+import Image from '@readr-media/react-image'
 
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
@@ -181,7 +182,6 @@ export default function AsideArticleList({
 
     return () => observer.disconnect()
   }, [isLoaded, handleLoadMore])
-
   const newsJsx = item.map((item) => {
     const sectionName = getSectionNameGql(item.sections, undefined)
     const sectionTitle = getSectionTitleGql(item.sections, undefined)
@@ -190,11 +190,12 @@ export default function AsideArticleList({
       <li key={item.id}>
         <Article shouldReverseOrder={shouldReverseOrder}>
           <Link href={articleHref} target="_blank">
-            <img
-              src={
-                item?.heroImage?.resized?.w480 || '/images/default-og-img.png'
-              }
+            <Image
+              images={item?.heroImage?.resized}
               alt={item.title}
+              loadingImage={'/images/loading.gif'}
+              defaultImage={'/images/default-og-img.png'}
+              rwd={{ desktop: '120px' }}
             />
           </Link>
 

--- a/packages/mirror-media-next/components/story/normal/aside-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/aside-article-list.js
@@ -1,6 +1,5 @@
 //TODOs:
-// 1. add jsDoc for article
-// 2. add loading UI
+// 1. add loading UI
 import Link from 'next/link'
 import styled from 'styled-components'
 import { useEffect, useState, useRef, useCallback } from 'react'
@@ -14,6 +13,8 @@ import Image from '@readr-media/react-image'
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
  */
+
+/** @typedef {import('../../../apollo/query/posts').ResultOfFetchListingPosts} ArticleData */
 
 const Wrapper = styled.section`
   margin-top: 20px;
@@ -133,7 +134,7 @@ const Loading = styled.div`
  * - If is true, image of article should display at right, title and label should display at left.
  * - If is false, image of article should display at left, title and label should display at right.
  * optional, default value is `false`.
- * @param {()=>Promise<Object[] | []>} props.fetchArticle
+ * @param {()=>Promise<ArticleData[] | []>} props.fetchArticle
  * - A Promise base function for fetching article.
  * - If fulfilled, it will return a array of object, which item is a article.
  * - If rejected, it will return an empty array

--- a/packages/mirror-media-next/components/story/normal/aside-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/aside-article-list.js
@@ -1,0 +1,133 @@
+import styled from 'styled-components'
+
+/**
+ * @typedef {import('../../../type/theme').Theme} Theme
+ */
+
+const Wrapper = styled.section`
+  margin-top: 20px;
+`
+const Heading = styled.div`
+  background-color: ${
+    /**
+     * @param {Object} props
+     * @param {Theme} props.theme
+     */
+    ({ theme }) => theme.color.brandColor.darkBlue
+  };
+  border: 1px solid #dedede;
+  color: #fff;
+  padding: 8px 0 8px 20px;
+`
+
+const NewsWrapper = styled.ul`
+  border: 1px solid #dedede;
+  padding: 20.5px 20px;
+  width: 100%;
+  height: fit-content;
+  display: flex;
+  flex-direction: column;
+  gap: 21px;
+`
+const News = styled.li`
+  width: 100%;
+  margin: 0 auto;
+  height: 80px;
+  display: flex;
+  flex-direction: ${
+    /**
+     * @param {Object} props
+     * @param {boolean} props.shouldReverseOrder
+     */
+    ({ shouldReverseOrder }) => (shouldReverseOrder ? 'row-reverse' : 'row')
+  };
+  gap: 12px;
+  img {
+    width: 120px;
+  }
+`
+
+const Label = styled.div`
+  width: fit-content;
+  height: 25px;
+  padding: 0 8px;
+  text-align: center;
+  color: white;
+  font-size: 14px;
+  line-height: 25px;
+  font-weight: 400;
+  background-color: ${
+    /**
+     * @param {Object} props
+     * @param {Theme} props.theme
+     */
+    ({ theme }) => theme.color.brandColor.lightBlue
+  };
+`
+const Title = styled.p`
+  margin-top: 8px;
+  text-align: left;
+  width: 100%;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 600;
+  color: ${
+    /**
+     * @param {Object} props
+     * @param {Theme} props.theme
+     */
+    ({ theme }) => theme.color.brandColor.darkBlue
+  };
+
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+`
+/**
+ *
+ * @param {Object} props
+ * @param {string} props.heading - heading of this components, showing user what kind of news is
+ * @param {boolean} props.shouldReverseOrder
+ * - control the css layout of news.
+ * - If is true, image of news should display at right, content and label should display at left.
+ * - If is false, image of news should display at left, content and label should display at right.
+ * optional, default value is `false`.
+ * @returns {JSX.Element}
+ */
+export default function AsideArticleList({
+  heading = '',
+  shouldReverseOrder = false,
+}) {
+  const newsJsx = (
+    <>
+      <News shouldReverseOrder={shouldReverseOrder}>
+        <img src="/images/default-og-img.png" />
+
+        <div>
+          <Label>標籤標籤</Label>
+          <Title>
+            標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題
+          </Title>
+        </div>
+      </News>
+      <News shouldReverseOrder={shouldReverseOrder}>
+        <img src="/images/default-og-img.png" />
+
+        <div>
+          <Label>標籤標籤</Label>
+          <Title>
+            標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題
+          </Title>
+        </div>
+      </News>
+    </>
+  )
+
+  return (
+    <Wrapper>
+      <Heading>{heading}</Heading>
+      <NewsWrapper>{newsJsx}</NewsWrapper>
+    </Wrapper>
+  )
+}

--- a/packages/mirror-media-next/components/story/normal/aside-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/aside-article-list.js
@@ -1,4 +1,14 @@
+//TODOs:
+// 1. add jsDoc for article
+// 2. add loading UI
+import Link from 'next/link'
 import styled from 'styled-components'
+import { useEffect, useState, useRef, useCallback } from 'react'
+import {
+  getSectionNameGql,
+  getSectionTitleGql,
+  getArticleHref,
+} from '../../../utils'
 
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
@@ -20,19 +30,32 @@ const Heading = styled.div`
   padding: 8px 0 8px 20px;
 `
 
-const NewsWrapper = styled.ul`
+const articleHeight = 80 //px
+const articleWrapperGap = 21 //px
+const ArticleWrapper = styled.ul`
   border: 1px solid #dedede;
   padding: 20.5px 20px;
   width: 100%;
+  min-height: ${
+    /**
+     *
+     * @param {Object} param
+     * @param {number} param.renderAmount
+     */
+    ({ renderAmount }) =>
+      `calc(20.5px + 20.5px + ${
+        renderAmount * articleHeight
+      }px + ${articleWrapperGap}px * 5) `
+  };
   height: fit-content;
   display: flex;
   flex-direction: column;
-  gap: 21px;
+  gap: ${`${articleWrapperGap}px`};
 `
-const News = styled.li`
+const Article = styled.figure`
   width: 100%;
   margin: 0 auto;
-  height: 80px;
+  height: ${`${articleHeight}px`};
   display: flex;
   flex-direction: ${
     /**
@@ -42,8 +65,12 @@ const News = styled.li`
     ({ shouldReverseOrder }) => (shouldReverseOrder ? 'row-reverse' : 'row')
   };
   gap: 12px;
-  img {
-    width: 120px;
+  a {
+    min-width: 120px;
+    img {
+      width: 100%;
+      height: 100%;
+    }
   }
 `
 
@@ -59,9 +86,13 @@ const Label = styled.div`
   background-color: ${
     /**
      * @param {Object} props
-     * @param {Theme} props.theme
+     * @param {string} props.sectionTitle
+     * @param {Theme} [props.theme]
      */
-    ({ theme }) => theme.color.brandColor.lightBlue
+    ({ sectionTitle, theme }) =>
+      sectionTitle && theme.color.sectionsColor[sectionTitle]
+        ? theme.color.sectionsColor[sectionTitle]
+        : theme.color.brandColor.lightBlue
   };
 `
 const Title = styled.p`
@@ -84,50 +115,106 @@ const Title = styled.p`
   -webkit-line-clamp: 2;
   overflow: hidden;
 `
+
+const Loading = styled.div`
+  height: 500px;
+  margin: auto;
+  width: 100%;
+  background-color: pink;
+`
+
 /**
  *
  * @param {Object} props
  * @param {string} props.heading - heading of this components, showing user what kind of news is
  * @param {boolean} props.shouldReverseOrder
- * - control the css layout of news.
- * - If is true, image of news should display at right, content and label should display at left.
- * - If is false, image of news should display at left, content and label should display at right.
+ * - control the css layout of article.
+ * - If is true, image of article should display at right, title and label should display at left.
+ * - If is false, image of article should display at left, title and label should display at right.
  * optional, default value is `false`.
+ * @param {()=>Promise<Object[] | []>} props.fetchArticle
+ * - A Promise base function for fetching article.
+ * - If fulfilled, it will return a array of object, which item is a article.
+ * - If rejected, it will return an empty array
+ * @param {number} [props.renderAmount]
+ * - a number of article we want to render, it will determine the height of `ArticleWrapper` to prevent Cumulative Layout Shift (CLS) problem after article is loaded.
  * @returns {JSX.Element}
  */
 export default function AsideArticleList({
   heading = '',
   shouldReverseOrder = false,
+  fetchArticle,
+  renderAmount = 6,
 }) {
-  const newsJsx = (
-    <>
-      <News shouldReverseOrder={shouldReverseOrder}>
-        <img src="/images/default-og-img.png" />
+  const wrapperRef = useRef(null)
+  const [item, setItem] = useState([])
+  const [isLoaded, setIsLoaded] = useState(false)
+  const handleLoadMore = useCallback(() => {
+    fetchArticle().then((articles) => {
+      if (articles.length && Array.isArray(articles)) {
+        setItem(articles)
+        setIsLoaded(true)
+      } else {
+        setIsLoaded(true)
+      }
+    })
+  }, [fetchArticle])
 
-        <div>
-          <Label>標籤標籤</Label>
-          <Title>
-            標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題
-          </Title>
-        </div>
-      </News>
-      <News shouldReverseOrder={shouldReverseOrder}>
-        <img src="/images/default-og-img.png" />
+  useEffect(() => {
+    let callback = (entries, observer) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          if (isLoaded) {
+            observer.unobserve(entry.target)
+          } else {
+            handleLoadMore()
+          }
+        }
+      })
+    }
+    const observer = new IntersectionObserver(callback, {
+      root: null,
+      rootMargin: '0px',
+      threshold: 0,
+    })
+    observer.observe(wrapperRef.current)
 
-        <div>
-          <Label>標籤標籤</Label>
-          <Title>
-            標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題標題
-          </Title>
-        </div>
-      </News>
-    </>
-  )
+    return () => observer.disconnect()
+  }, [isLoaded, handleLoadMore])
+
+  const newsJsx = item.map((item) => {
+    const sectionName = getSectionNameGql(item.sections, undefined)
+    const sectionTitle = getSectionTitleGql(item.sections, undefined)
+    const articleHref = getArticleHref(item.slug, item.style, undefined)
+    return (
+      <li key={item.id}>
+        <Article shouldReverseOrder={shouldReverseOrder}>
+          <Link href={articleHref} target="_blank">
+            <img
+              src={
+                item?.heroImage?.resized?.w480 || '/images/default-og-img.png'
+              }
+              alt={item.title}
+            />
+          </Link>
+
+          <figcaption>
+            <Label sectionTitle={sectionTitle}>{sectionName}</Label>
+            <Link href={articleHref} target="_blank">
+              <Title>{item.title}</Title>
+            </Link>
+          </figcaption>
+        </Article>
+      </li>
+    )
+  })
 
   return (
     <Wrapper>
       <Heading>{heading}</Heading>
-      <NewsWrapper>{newsJsx}</NewsWrapper>
+      <ArticleWrapper renderAmount={renderAmount} ref={wrapperRef}>
+        {isLoaded ? newsJsx : <Loading>Loading...</Loading>}
+      </ArticleWrapper>
     </Wrapper>
   )
 }

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -5,9 +5,9 @@ import MockAdvertisement from '../../components/mock-advertisement'
 import Image from 'next/image'
 import ArticleInfo from '../../components/story/normal/article-info'
 import ArticleBrief from '../../components/story/normal/brief'
+import AsideArticleList from '../../components/story/normal/aside-article-list'
 import { transformTimeDataIntoTaipeiTime } from '../../utils'
 import GetPostBySlug from '../../apollo/query/get-post-by-slug.gql'
-
 /**
  * @typedef {import('../../type/theme').Theme} Theme
  */
@@ -33,10 +33,17 @@ const StoryContainer = styled.div`
   max-width: 1200px;
 `
 
-const StoryMockAdvertisement = styled(MockAdvertisement)`
+const PC_HD_Advertisement = styled(MockAdvertisement)`
   margin: 24px auto;
   text-align: center;
-  display: none;
+`
+const PC_R1_Advertisement = styled(MockAdvertisement)`
+  margin: 0 auto;
+  text-align: center;
+`
+const PC_R2_Advertisement = styled(MockAdvertisement)`
+  margin: 20px auto;
+  text-align: center;
 `
 const Title = styled.h1`
   margin: 0 auto;
@@ -161,7 +168,6 @@ const Aside = styled.aside`
   ${({ theme }) => theme.breakpoint.xl} {
     display: block;
     width: 365px;
-    border: 1px solid black;
   }
 `
 /**
@@ -202,11 +208,11 @@ export default function Story({ postData }) {
 
   return (
     <StoryContainer>
-      <StoryMockAdvertisement
+      <PC_HD_Advertisement
         width="970px"
         height="250px"
         text="PC_HD 970*250"
-      ></StoryMockAdvertisement>
+      ></PC_HD_Advertisement>
       <Main>
         <Article>
           <SectionAndDate>
@@ -239,7 +245,26 @@ export default function Story({ postData }) {
             brief={brief}
           ></ArticleBrief>
         </Article>
-        <Aside>這是側欄</Aside>
+        <Aside>
+          <PC_R1_Advertisement
+            text="PC_R1 300*600"
+            width="300px"
+            height="600px"
+          ></PC_R1_Advertisement>
+          <AsideArticleList
+            heading="最新文章"
+            shouldReverseOrder={false}
+          ></AsideArticleList>
+          <PC_R2_Advertisement
+            text="PC_R2 300*600"
+            width="300px"
+            height="600px"
+          ></PC_R2_Advertisement>
+          <AsideArticleList
+            heading="熱門文章"
+            shouldReverseOrder={true}
+          ></AsideArticleList>
+        </Aside>
       </Main>
     </StoryContainer>
   )

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import client from '../../apollo/apollo-client'
 import errors from '@twreporter/errors'
 import styled, { css } from 'styled-components'
@@ -8,6 +9,8 @@ import ArticleBrief from '../../components/story/normal/brief'
 import AsideArticleList from '../../components/story/normal/aside-article-list'
 import { transformTimeDataIntoTaipeiTime } from '../../utils'
 import GetPostBySlug from '../../apollo/query/get-post-by-slug.gql'
+import { fetchListingPosts } from '../../apollo/query/posts'
+
 /**
  * @typedef {import('../../type/theme').Theme} Theme
  */
@@ -179,6 +182,7 @@ const Aside = styled.aside`
 export default function Story({ postData }) {
   const {
     title = '',
+    slug = '',
     sections = [],
     publishedDate = '',
     updatedAt = '',
@@ -192,8 +196,24 @@ export default function Story({ postData }) {
     tags = [],
     brief = [],
   } = postData
-
   const [section] = sections
+
+  const handleFetchLatestNews = useCallback(async () => {
+    try {
+      const res = await client.query({
+        query: fetchListingPosts,
+        variables: {
+          take: 6,
+          sectionSlug: section.slug,
+          storySlug: slug,
+        },
+      })
+      return res.data?.posts
+    } catch (err) {
+      return []
+    }
+  }, [section, slug])
+
   const credits = [
     { writers: writers },
     { photographers: photographers },
@@ -253,17 +273,15 @@ export default function Story({ postData }) {
           ></PC_R1_Advertisement>
           <AsideArticleList
             heading="最新文章"
+            fetchArticle={handleFetchLatestNews}
             shouldReverseOrder={false}
+            renderAmount={6}
           ></AsideArticleList>
           <PC_R2_Advertisement
             text="PC_R2 300*600"
             width="300px"
             height="600px"
           ></PC_R2_Advertisement>
-          <AsideArticleList
-            heading="熱門文章"
-            shouldReverseOrder={true}
-          ></AsideArticleList>
         </Aside>
       </Main>
     </StoryContainer>

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -15,6 +15,10 @@ import { fetchListingPosts } from '../../apollo/query/posts'
  * @typedef {import('../../type/theme').Theme} Theme
  */
 
+/**
+ * @typedef {import('../../components/story/normal/aside-article-list').ArticleData} AsideArticleData
+ */
+
 const sectionColor = css`
   ${
     /**
@@ -177,7 +181,7 @@ const Aside = styled.aside`
  *
  * @param {Object} props
  * @param {import('../../type/post.typedef').Post} props.postData
- * @returns
+ * @returns {JSX.Element}
  */
 export default function Story({ postData }) {
   const {
@@ -198,8 +202,14 @@ export default function Story({ postData }) {
   } = postData
   const [section] = sections
 
+  /**
+   * @returns {Promise<AsideArticleData[] | []>}
+   */
   const handleFetchLatestNews = useCallback(async () => {
     try {
+      /**
+       * @type {import('@apollo/client').ApolloQueryResult<{posts: AsideArticleData[]}>}
+       */
       const res = await client.query({
         query: fetchListingPosts,
         variables: {


### PR DESCRIPTION
## Notable Change
1. 新增元件 `aside-article-list`，用於呈現一般文章頁的側欄最新文章與熱門文章。
2. 新增gql query與fragment，用於取得最新文章的資料。未來將重構`posts.js`，使fragment可被複用
3. 調整最新文章抓取資料邏輯：原為server-side就抓取資料，但因不同種類的文章未必會需要顯示最新文章，故現在調整至client-side才抓取資料，並搭配intersection observer實作懶載入。
4. 使用套件`@readr-media/react-image` 載入圖片
5. 新增相關的jsDoc
