### PR TITLE
feat: add redirect rule for donation page

### DIFF
--- a/packages/mirror-media-next/components/story/normal/article-info.js
+++ b/packages/mirror-media-next/components/story/normal/article-info.js
@@ -273,7 +273,7 @@ export default function ArticleInfo({
           </Link>
           <ButtonCopyLink />
         </SocialMedia>
-        <DonateLink href="https://www.mirrormedia.mg/" target="_blank">
+        <DonateLink href="/donate" target="_blank">
           <Image
             src={'/images/donate.png'}
             width={13.33}

--- a/packages/mirror-media-next/next.config.js
+++ b/packages/mirror-media-next/next.config.js
@@ -1,3 +1,19 @@
+const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
+let DONATION_PAGE_URL = ''
+
+switch (ENV) {
+  case 'prod':
+  case 'staging':
+    DONATION_PAGE_URL = 'https://mirrormedia.oen.tw/'
+    break
+  case 'dev':
+    DONATION_PAGE_URL = 'https://mirrormedia.testing.oen.tw/'
+
+    break
+  default:
+    DONATION_PAGE_URL = 'https://mirrormedia.testing.oen.tw/'
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -34,6 +50,16 @@ const nextConfig = {
     )
 
     return config
+  },
+  async redirects() {
+    return [
+      // currently, donation page will redirect user to external page
+      {
+        source: '/donate',
+        destination: DONATION_PAGE_URL,
+        permanent: true,
+      },
+    ]
   },
 
   output: 'standalone',


### PR DESCRIPTION
## Notable Changes
* Add redirect rule for donation page
* Update link information of donation button

## References
* https://github.com/mirror-media/mirror-media-nuxt/pull/933
* https://github.com/mirror-media/kubernetes-configs/pull/153

## Discussions
目前是在 `next.config.js` 上，藉由環境差異來設定 `DONATION_PAGE_URL` 的數值，
比較好的作法應該是把這部份放到 `config/index.js` 中，藉此來統一，
如果要這個做的話，會需要以下調整：
1. `next.config.js` 要改名為 `next.config.mjs`，且 `module.exports` 要調整為 `export default`
2. `config/index.js` 要改名為 `config/index.mjs`
3. 原先引用 `config` 的須調整為引用 `config/index.mjs`
藉由這些調整，才能夠在 Node.js 環境下，使用 ES6 的 import/export，
就看是否要做這一部份，然後在這個 PR，或再發一個 PR 處理