### PR TITLE
feat(mm-next): add html `title` in story and index page

### DIFF
--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -1,11 +1,13 @@
 //TODO: will fetch topic data twice (once in header, once in index),
 //should fetch only once by using Redux.
 //TODO: add typedef of editor choice data
+//TODO: add component to add html head dynamically, not jus write head in every pag
 import React, { useMemo } from 'react'
 import styled from 'styled-components'
 import axios from 'axios'
 import errors from '@twreporter/errors'
 import client from '../apollo/apollo-client'
+import Head from 'next/head'
 import { gql } from '@apollo/client'
 import {
   ENV,
@@ -67,18 +69,23 @@ export default function Home({
     [topicsData]
   )
   return (
-    <IndexContainer>
-      <FlashNews flashNews={flashNews} />
-      <IndexTop>
-        <NavTopics topics={topics} />
-        <SubscribeMagazine />
-      </IndexTop>
-      <EditorChoice editorChoice={editorChoice}></EditorChoice>
-      <LatestNews
-        latestNewsData={latestNewsData}
-        latestNewsTimestamp={latestNewsTimestamp}
-      />
-    </IndexContainer>
+    <>
+      <Head>
+        <title>鏡週刊 Mirror Media</title>
+      </Head>
+      <IndexContainer>
+        <FlashNews flashNews={flashNews} />
+        <IndexTop>
+          <NavTopics topics={topics} />
+          <SubscribeMagazine />
+        </IndexTop>
+        <EditorChoice editorChoice={editorChoice}></EditorChoice>
+        <LatestNews
+          latestNewsData={latestNewsData}
+          latestNewsTimestamp={latestNewsTimestamp}
+        />
+      </IndexContainer>
+    </>
   )
 }
 

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -1,10 +1,13 @@
 //TODO: adjust margin and padding of all margin and padding after implement advertisement.
+//TODO: add component to add html head dynamically, not jus write head in every pag
 
 import { useCallback } from 'react'
 import client from '../../apollo/apollo-client'
 import errors from '@twreporter/errors'
 import styled, { css } from 'styled-components'
 import Link from 'next/link'
+import Head from 'next/head'
+
 import MockAdvertisement from '../../components/mock-advertisement'
 import Image from 'next/image'
 import ArticleInfo from '../../components/story/normal/article-info'
@@ -441,144 +444,154 @@ export default function Story({ postData }) {
     { vocals: vocals },
     { extend_byline: extend_byline },
   ]
+  const headJsx = (
+    <Head>
+      <title>{title}</title>
+    </Head>
+  )
   const publishedTaipeiTime = transformTimeDataIntoTaipeiTime(publishedDate)
   const updatedTaipeiTime = transformTimeDataIntoTaipeiTime(updatedAt)
 
   return (
-    <StoryContainer>
-      <PC_HD_Advertisement
-        width="970px"
-        height="250px"
-        text="PC_HD 970*250"
-      ></PC_HD_Advertisement>
-      <Main>
-        <Article>
-          <SectionAndDate>
-            <Section sectionSlug={section?.slug}>{section?.name || ''}</Section>
-            <Date>{publishedTaipeiTime}</Date>
-          </SectionAndDate>
-          <Title>{title}</Title>
-          <InfoAndHero>
-            <HeroImage>
-              <Image
-                src={
-                  'https://storage.googleapis.com/static-mirrormedia-dev/images/20160929123258-7818228bd4c9933a170433e57a90616c-tablet.png'
-                }
-                width={640}
-                height={427}
-                alt="首圖"
-              ></Image>
-              <p className="caption">這是首圖圖說</p>
-            </HeroImage>
+    <>
+      {headJsx}
+      <StoryContainer>
+        <PC_HD_Advertisement
+          width="970px"
+          height="250px"
+          text="PC_HD 970*250"
+        ></PC_HD_Advertisement>
+        <Main>
+          <Article>
+            <SectionAndDate>
+              <Section sectionSlug={section?.slug}>
+                {section?.name || ''}
+              </Section>
+              <Date>{publishedTaipeiTime}</Date>
+            </SectionAndDate>
+            <Title>{title}</Title>
+            <InfoAndHero>
+              <HeroImage>
+                <Image
+                  src={
+                    'https://storage.googleapis.com/static-mirrormedia-dev/images/20160929123258-7818228bd4c9933a170433e57a90616c-tablet.png'
+                  }
+                  width={640}
+                  height={427}
+                  alt="首圖"
+                ></Image>
+                <p className="caption">這是首圖圖說</p>
+              </HeroImage>
 
-            <ArticleInfo
-              updatedDate={updatedTaipeiTime}
-              publishedDate={publishedTaipeiTime}
-              credits={credits}
-              tags={tags}
-            ></ArticleInfo>
-          </InfoAndHero>
-          <ArticleBrief
-            sectionSlug={section?.slug}
-            brief={brief}
-          ></ArticleBrief>
-          <DonateBanner />
-          <SocialNetworkServiceSmall />
-          <SubscribeInviteBanner />
-          <RelatedArticleList relateds={relateds} />
-          <M_AT3_Advertisement
-            text="M_AT3 336*280"
-            width="336px"
-            height="280px"
-            className="ad"
-          />
-          <SocialNetworkServiceLarge
-            shouldShowLargePagePlugin={true}
-            flexDirection="column"
-          />
-          <M_AT3_Advertisement
-            text="M_E1 336*280"
-            width="336px"
-            height="280px"
-            className="ad"
-          />
-          <AdvertisementDableMobile>
-            dable廣告(手機版)施工中......
-          </AdvertisementDableMobile>
-          <StoryEndDesktop>
-            <StoryMoreInfo>
-              更多內容，歡迎&nbsp;
-              <Link href="/papermag" target="_blank">
-                鏡週刊紙本雜誌
-              </Link>
-              、
-              <Link href="/subscribe" target="_blank">
-                鏡週刊數位訂閱
-              </Link>
-              、
-              <Link href="/story/webauthorize/" target="_blank">
-                了解內容授權資訊
-              </Link>
-              。
-            </StoryMoreInfo>
-            <MagazineInviteBanner />
-            <AdvertisementDableDesktop>
-              dable廣告 (桌機版) 施工中......
-            </AdvertisementDableDesktop>
-          </StoryEndDesktop>
-        </Article>
-        <Aside>
-          <PC_R1_Advertisement
-            text="PC_R1 300*600"
-            width="300px"
-            height="600px"
-            className="ad"
-          ></PC_R1_Advertisement>
-          <AsideArticleList
-            heading="最新文章"
-            fetchArticle={handleFetchLatestNews}
-            shouldReverseOrder={false}
-            renderAmount={6}
-          ></AsideArticleList>
+              <ArticleInfo
+                updatedDate={updatedTaipeiTime}
+                publishedDate={publishedTaipeiTime}
+                credits={credits}
+                tags={tags}
+              ></ArticleInfo>
+            </InfoAndHero>
+            <ArticleBrief
+              sectionSlug={section?.slug}
+              brief={brief}
+            ></ArticleBrief>
+            <DonateBanner />
+            <SocialNetworkServiceSmall />
+            <SubscribeInviteBanner />
+            <RelatedArticleList relateds={relateds} />
+            <M_AT3_Advertisement
+              text="M_AT3 336*280"
+              width="336px"
+              height="280px"
+              className="ad"
+            />
+            <SocialNetworkServiceLarge
+              shouldShowLargePagePlugin={true}
+              flexDirection="column"
+            />
+            <M_AT3_Advertisement
+              text="M_E1 336*280"
+              width="336px"
+              height="280px"
+              className="ad"
+            />
+            <AdvertisementDableMobile>
+              dable廣告(手機版)施工中......
+            </AdvertisementDableMobile>
+            <StoryEndDesktop>
+              <StoryMoreInfo>
+                更多內容，歡迎&nbsp;
+                <Link href="/papermag" target="_blank">
+                  鏡週刊紙本雜誌
+                </Link>
+                、
+                <Link href="/subscribe" target="_blank">
+                  鏡週刊數位訂閱
+                </Link>
+                、
+                <Link href="/story/webauthorize/" target="_blank">
+                  了解內容授權資訊
+                </Link>
+                。
+              </StoryMoreInfo>
+              <MagazineInviteBanner />
+              <AdvertisementDableDesktop>
+                dable廣告 (桌機版) 施工中......
+              </AdvertisementDableDesktop>
+            </StoryEndDesktop>
+          </Article>
+          <Aside>
+            <PC_R1_Advertisement
+              text="PC_R1 300*600"
+              width="300px"
+              height="600px"
+              className="ad"
+            ></PC_R1_Advertisement>
+            <AsideArticleList
+              heading="最新文章"
+              fetchArticle={handleFetchLatestNews}
+              shouldReverseOrder={false}
+              renderAmount={6}
+            ></AsideArticleList>
 
-          <PC_R2_Advertisement
-            text="PC_R2 300*600"
-            width="300px"
-            height="600px"
-            className="ad"
-          ></PC_R2_Advertisement>
-          <DivideLine />
-          <AsideArticleList
-            heading="熱門文章"
-            fetchArticle={handleFetchLatestNews}
-            shouldReverseOrder={false}
-            renderAmount={6}
-          ></AsideArticleList>
-          <AsideFbPagePlugin></AsideFbPagePlugin>
-        </Aside>
-      </Main>
-      <StoryEndMobileTablet>
-        <StoryMoreInfo>
-          更多內容，歡迎&nbsp;
-          <Link href="/papermag" target="_blank">
-            鏡週刊紙本雜誌
-          </Link>
-          、
-          <Link href="/subscribe" target="_blank">
-            鏡週刊數位訂閱
-          </Link>
-          、
-          <Link href="/story/webauthorize/" target="_blank">
-            了解內容授權資訊
-          </Link>
-          。
-        </StoryMoreInfo>
-        <MagazineInviteBanner />
-        <AdvertisementDableDesktop>
-          dable廣告 (桌機版) 施工中......
-        </AdvertisementDableDesktop>
-      </StoryEndMobileTablet>
-    </StoryContainer>
+            <PC_R2_Advertisement
+              text="PC_R2 300*600"
+              width="300px"
+              height="600px"
+              className="ad"
+            ></PC_R2_Advertisement>
+            <DivideLine />
+            <AsideArticleList
+              heading="熱門文章"
+              fetchArticle={handleFetchLatestNews}
+              shouldReverseOrder={false}
+              renderAmount={6}
+            ></AsideArticleList>
+            <AsideFbPagePlugin></AsideFbPagePlugin>
+          </Aside>
+        </Main>
+        <StoryEndMobileTablet>
+          <StoryMoreInfo>
+            更多內容，歡迎&nbsp;
+            <Link href="/papermag" target="_blank">
+              鏡週刊紙本雜誌
+            </Link>
+            、
+            <Link href="/subscribe" target="_blank">
+              鏡週刊數位訂閱
+            </Link>
+            、
+            <Link href="/story/webauthorize/" target="_blank">
+              了解內容授權資訊
+            </Link>
+            。
+          </StoryMoreInfo>
+          <MagazineInviteBanner />
+          <AdvertisementDableDesktop>
+            dable廣告 (桌機版) 施工中......
+          </AdvertisementDableDesktop>
+        </StoryEndMobileTablet>
+      </StoryContainer>
+    </>
   )
 }
 


### PR DESCRIPTION
- 新增`<title>`於html `<head>`中
- 目前是直接於story頁與首頁寫入<head>，用於測試ga是否正常運作。
- 未來將新增一元件CustomHead（將近似於readr所用的[元件](https://github.com/readr-media/Sachiel/blob/dev/packages/readr/components/layout/custom-head.tsx)），並依據不同頁面傳入的資料，載入不同<head>資訊。