### PR TITLE
feat(mm-next): add google tag manager, enable GA and GTM in certain environment

### DIFF
--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -17,7 +17,7 @@ let URL_K3_FLASH_NEWS = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/getpo
 let URL_STATIC_COMBO_SECTIONS = ''
 let URL_STATIC_POST_EXTERNAL = ''
 let DONATION_PAGE_URL = ''
-let GA_TRACKING_ID = ''
+let GA_MEASUREMENT_ID = ''
 let GTM_ID = ''
 switch (ENV) {
   case 'prod':
@@ -32,7 +32,7 @@ switch (ENV) {
     URL_STATIC_POST_EXTERNAL =
       'https://statics.mirrormedia.mg/json/post_external'
     DONATION_PAGE_URL = 'https://mirrormedia.oen.tw/'
-    GA_TRACKING_ID = 'G-341XFN0675'
+    GA_MEASUREMENT_ID = 'G-341XFN0675'
     GTM_ID = 'GTM-NCH86SP'
     break
   case 'staging':
@@ -47,7 +47,7 @@ switch (ENV) {
     URL_STATIC_POST_EXTERNAL =
       'https://statics.mirrormedia.mg/json/post_external'
     DONATION_PAGE_URL = 'https://mirrormedia.oen.tw/'
-    GA_TRACKING_ID = 'G-32D7P3MJ8B'
+    GA_MEASUREMENT_ID = 'G-32D7P3MJ8B'
     GTM_ID = 'GTM-KVDZ27K'
 
     break
@@ -63,7 +63,7 @@ switch (ENV) {
     URL_STATIC_POST_EXTERNAL =
       'https://statics.mirrormedia.mg/dev/post_external'
     DONATION_PAGE_URL = 'https://mirrormedia.testing.oen.tw/'
-    GA_TRACKING_ID = 'G-36HYH6NF6P'
+    GA_MEASUREMENT_ID = 'G-36HYH6NF6P'
     GTM_ID = 'GTM-PBNLSMX'
     break
   default:
@@ -76,7 +76,7 @@ switch (ENV) {
     URL_K3_FLASH_NEWS = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/api/v2/getposts?where={"categories":{"$in":["5979ac0de531830d00e330a7","5979ac33e531830d00e330a9","57e1e16dee85930e00cad4ec","57e1e200ee85930e00cad4f3"]},"isAudioSiteOnly":false}&clean=content&max_results=10&page=1&sort=-publishedDate`
     URL_STATIC_POST_EXTERNAL = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/json/post_external`
     DONATION_PAGE_URL = 'https://mirrormedia.testing.oen.tw/'
-    GA_TRACKING_ID = 'G-36HYH6NF6P'
+    GA_MEASUREMENT_ID = 'G-36HYH6NF6P'
     GTM_ID = 'GTM-PBNLSMX'
 }
 
@@ -90,6 +90,6 @@ export {
   URL_K3_FLASH_NEWS,
   URL_STATIC_POST_EXTERNAL,
   DONATION_PAGE_URL,
-  GA_TRACKING_ID,
+  GA_MEASUREMENT_ID,
   GTM_ID,
 }

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -18,7 +18,7 @@ let URL_STATIC_COMBO_SECTIONS = ''
 let URL_STATIC_POST_EXTERNAL = ''
 let DONATION_PAGE_URL = ''
 let GA_TRACKING_ID = ''
-
+let GTM_ID = ''
 switch (ENV) {
   case 'prod':
     API_TIMEOUT = 1500
@@ -33,6 +33,7 @@ switch (ENV) {
       'https://statics.mirrormedia.mg/json/post_external'
     DONATION_PAGE_URL = 'https://mirrormedia.oen.tw/'
     GA_TRACKING_ID = 'G-341XFN0675'
+    GTM_ID = 'GTM-NCH86SP'
     break
   case 'staging':
     API_TIMEOUT = 1500
@@ -47,6 +48,7 @@ switch (ENV) {
       'https://statics.mirrormedia.mg/json/post_external'
     DONATION_PAGE_URL = 'https://mirrormedia.oen.tw/'
     GA_TRACKING_ID = 'G-32D7P3MJ8B'
+    GTM_ID = 'GTM-KVDZ27K'
 
     break
   case 'dev':
@@ -62,7 +64,7 @@ switch (ENV) {
       'https://statics.mirrormedia.mg/dev/post_external'
     DONATION_PAGE_URL = 'https://mirrormedia.testing.oen.tw/'
     GA_TRACKING_ID = 'G-36HYH6NF6P'
-
+    GTM_ID = 'GTM-PBNLSMX'
     break
   default:
     API_TIMEOUT = 5000
@@ -75,6 +77,7 @@ switch (ENV) {
     URL_STATIC_POST_EXTERNAL = `${API_PROTOCOL}://${RESTFUL_API_HOST}:${API_PORT}/json/post_external`
     DONATION_PAGE_URL = 'https://mirrormedia.testing.oen.tw/'
     GA_TRACKING_ID = 'G-36HYH6NF6P'
+    GTM_ID = 'GTM-PBNLSMX'
 }
 
 export {
@@ -88,4 +91,5 @@ export {
   URL_STATIC_POST_EXTERNAL,
   DONATION_PAGE_URL,
   GA_TRACKING_ID,
+  GTM_ID,
 }

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -25,6 +25,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-ga4": "^2.1.0",
+    "react-gtm-module": "^2.0.11",
     "styled-components": "5.3.5",
     "swiper": "^8.4.4"
   },

--- a/packages/mirror-media-next/pages/_app.js
+++ b/packages/mirror-media-next/pages/_app.js
@@ -9,6 +9,8 @@ import { ApolloProvider } from '@apollo/client'
 import client from '../apollo/apollo-client'
 import PremiumLayout from '../components/premium-layout'
 import * as gtag from '../utils/gtag'
+import TagManager from 'react-gtm-module'
+import { GTM_ID } from '../config/index.mjs'
 import {
   URL_STATIC_COMBO_SECTIONS,
   URL_STATIC_COMBO_TOPICS,
@@ -48,6 +50,7 @@ function MyApp({ Component, pageProps, sectionsData = [], topicsData = [] }) {
   const router = useRouter()
   useEffect(() => {
     gtag.init()
+    TagManager.initialize({ gtmId: GTM_ID })
   }, [])
   const getLayout = Component.getLayout || defaultGetLayout
   return (

--- a/packages/mirror-media-next/pages/_app.js
+++ b/packages/mirror-media-next/pages/_app.js
@@ -10,7 +10,7 @@ import client from '../apollo/apollo-client'
 import PremiumLayout from '../components/premium-layout'
 import * as gtag from '../utils/gtag'
 import TagManager from 'react-gtm-module'
-import { GTM_ID } from '../config/index.mjs'
+import { ENV, GTM_ID } from '../config/index.mjs'
 import {
   URL_STATIC_COMBO_SECTIONS,
   URL_STATIC_COMBO_TOPICS,
@@ -48,9 +48,12 @@ function defaultGetLayout(page, sectionsData, topicsData) {
 
 function MyApp({ Component, pageProps, sectionsData = [], topicsData = [] }) {
   const router = useRouter()
+  //Temporarily enable google analytics and google tag manager only in dev and local environment.
   useEffect(() => {
-    gtag.init()
-    TagManager.initialize({ gtmId: GTM_ID })
+    if (ENV === 'dev' || ENV === 'local') {
+      gtag.init()
+      TagManager.initialize({ gtmId: GTM_ID })
+    }
   }, [])
   const getLayout = Component.getLayout || defaultGetLayout
   return (

--- a/packages/mirror-media-next/utils/gtag.js
+++ b/packages/mirror-media-next/utils/gtag.js
@@ -1,11 +1,11 @@
 // https://github.com/codler/react-ga4#readme
 import ga4 from 'react-ga4'
-import { GA_TRACKING_ID } from '../config/index.mjs'
+import { GA_MEASUREMENT_ID } from '../config/index.mjs'
 
 const init = () => {
   ga4.initialize([
     {
-      trackingId: GA_TRACKING_ID,
+      trackingId: GA_MEASUREMENT_ID,
     },
   ])
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5008,6 +5008,11 @@ react-ga@^3.3.1:
   resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.1.tgz#d8e1f4e05ec55ed6ff944dcb14b99011dfaf9504"
   integrity sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==
 
+react-gtm-module@^2.0.11:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.11.tgz#14484dac8257acd93614e347c32da9c5ac524206"
+  integrity sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
- 埋入google tag manager
- 重新命名變數`GA_TRACKING_ID`，改為GA4官方使用名稱`GA_MEASURMENT_ID`
- 僅在local與dev環境下啟動GA與GTM 