### PR TITLE
feat(mm-next): add `writers`, `sections`, `relateds` with manual order

### DIFF
--- a/packages/mirror-media-next/apollo/query/post.js
+++ b/packages/mirror-media-next/apollo/query/post.js
@@ -84,6 +84,7 @@ import { gql } from '@apollo/client'
  * @property {string} [updatedAt] - post updated date
  * @property {PostState} [state] - post state, different states will have different post access of viewing
  * @property {Section[]} [sections] - which sections does this post belong to
+ * @property {Section[] | null} [manualOrderOfSections] - sections with adjusted order
  * @property {Contact[]} [writers] -  the field called '作者' in cms
  * @property {Contact[] | null} [manualOrderOfWriters] - writers with adjusted order
  * @property {Contact[]} [photographers] - the field called '攝影' in cms
@@ -118,6 +119,7 @@ const fetchPostBySlug = gql`
         name
         slug
       }
+      manualOrderOfSections
       writers {
         id
         name

--- a/packages/mirror-media-next/apollo/query/post.js
+++ b/packages/mirror-media-next/apollo/query/post.js
@@ -99,7 +99,8 @@ import { gql } from '@apollo/client'
  * @property {string} [heroCaption] - caption to explain hero video or image
  * @property {Draft} [brief] - post brief
  * @property {Draft} [content] - post content
- * @property {Related[] | []} [relateds]
+ * @property {Related[] | []} [relateds] related articles selected by cms users
+ * @property {Related[] | [] | null} [manualOrderOfRelateds] related articles with adjusted order
  */
 
 const fetchPostBySlug = gql`
@@ -186,6 +187,7 @@ const fetchPostBySlug = gql`
           }
         }
       }
+      manualOrderOfRelateds
     }
   }
 `

--- a/packages/mirror-media-next/apollo/query/post.js
+++ b/packages/mirror-media-next/apollo/query/post.js
@@ -3,6 +3,7 @@ import { gql } from '@apollo/client'
 //TODOs:
 // 1. specify DraftBlock typedef
 // 2. refactor jsDoc, make it follow jsDoc convention of importing and using
+// 3. remove this file, move & refactor related code into fragments/post and query/posts
 
 /**
  * @typedef {'published' | 'draft' | 'scheduled' | 'archived' | 'invisible'} PostState
@@ -84,6 +85,7 @@ import { gql } from '@apollo/client'
  * @property {PostState} [state] - post state, different states will have different post access of viewing
  * @property {Section[]} [sections] - which sections does this post belong to
  * @property {Contact[]} [writers] -  the field called '作者' in cms
+ * @property {Contact[] | null} [manualOrderOfWriters] - writers with adjusted order
  * @property {Contact[]} [photographers] - the field called '攝影' in cms
  * @property {Contact[]} [camera_man] - the field called '影音' in cms
  * @property {Contact[]} [designers] - the field called '設計' in cms
@@ -116,11 +118,11 @@ const fetchPostBySlug = gql`
         name
         slug
       }
-
       writers {
         id
         name
       }
+      manualOrderOfWriters
       photographers {
         id
         name

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -69,9 +69,7 @@ const { DraftRenderer } = MirrorMedia
  */
 
 /**
- * @typedef {(import('../../apollo/query/post').Related & {
- *  id: string, slug: string, title: string, heroImage: HeroImage})[]
- * } Relateds
+ * @typedef {import('../../components/story/normal/related-article-list').Relateds} Relateds
  */
 
 /**
@@ -87,7 +85,7 @@ const { DraftRenderer } = MirrorMedia
  * state: "published" | "draft" | "scheduled" | "archived" | "invisible",
  * sections: Sections | [],
  * manualOrderOfSections: Sections | [] | null,
- * writers: Contacts | [],
+ * writers: import('../../components/story/normal/article-info').Contacts | [],
  * manualOrderOfWriters: Contacts | [] | null,
  * photographers: Contacts | [],
  * camera_man: Contacts | [],
@@ -418,6 +416,7 @@ export default function Story({ postData }) {
     tags = [],
     brief = [],
     relateds = [],
+    manualOrderOfRelateds = [],
     content = {},
   } = postData
 
@@ -425,6 +424,16 @@ export default function Story({ postData }) {
     manualOrderOfSections && manualOrderOfSections.length
       ? sortArrayWithOtherArrayId(sections, manualOrderOfSections)
       : sections
+  const relatedsWithOrdered =
+    manualOrderOfRelateds && manualOrderOfRelateds.length
+      ? sortArrayWithOtherArrayId(relateds, manualOrderOfRelateds)
+      : relateds
+
+  const writersWithOrdered =
+    manualOrderOfWriters && manualOrderOfWriters.length
+      ? sortArrayWithOtherArrayId(writers, manualOrderOfWriters)
+      : writers
+
   const [section] = sectionsWithOrdered
 
   /**
@@ -448,10 +457,7 @@ export default function Story({ postData }) {
       return []
     }
   }, [section, slug])
-  const writersWithOrdered =
-    manualOrderOfWriters && manualOrderOfWriters.length
-      ? manualOrderOfWriters
-      : writers
+
   const credits = [
     { writers: writersWithOrdered },
     { photographers: photographers },
@@ -520,7 +526,7 @@ export default function Story({ postData }) {
             <DonateBanner />
             <SocialNetworkServiceSmall />
             <SubscribeInviteBanner />
-            <RelatedArticleList relateds={relateds} />
+            <RelatedArticleList relateds={relatedsWithOrdered} />
             <M_AT3_Advertisement
               text="M_AT3 336*280"
               width="336px"

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -19,7 +19,10 @@ import SubscribeInviteBanner from '../../components/story/normal/subscribe-invit
 import DonateBanner from '../../components/story/shared/donate-banner'
 import MagazineInviteBanner from '../../components/story/shared/magazine-invite-banner'
 import RelatedArticleList from '../../components/story/normal/related-article-list'
-import { transformTimeDataIntoTaipeiTime } from '../../utils'
+import {
+  transformTimeDataIntoTaipeiTime,
+  sortArrayWithOtherArrayId,
+} from '../../utils'
 import { fetchListingPosts } from '../../apollo/query/posts'
 import { fetchPostBySlug } from '../../apollo/query/post'
 import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
@@ -83,6 +86,7 @@ const { DraftRenderer } = MirrorMedia
  * updatedAt: string,
  * state: "published" | "draft" | "scheduled" | "archived" | "invisible",
  * sections: Sections | [],
+ * manualOrderOfSections: Sections | [] | null,
  * writers: Contacts | [],
  * manualOrderOfWriters: Contacts | [] | null,
  * photographers: Contacts | [],
@@ -400,6 +404,7 @@ export default function Story({ postData }) {
     title = '',
     slug = '',
     sections = [],
+    manualOrderOfSections = [],
     publishedDate = '',
     updatedAt = '',
     writers = [],
@@ -415,7 +420,12 @@ export default function Story({ postData }) {
     relateds = [],
     content = {},
   } = postData
-  const [section] = sections
+
+  const sectionsWithOrdered =
+    manualOrderOfSections && manualOrderOfSections.length
+      ? sortArrayWithOtherArrayId(sections, manualOrderOfSections)
+      : sections
+  const [section] = sectionsWithOrdered
 
   /**
    * @returns {Promise<AsideArticleData[] | []>}

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -84,6 +84,7 @@ const { DraftRenderer } = MirrorMedia
  * state: "published" | "draft" | "scheduled" | "archived" | "invisible",
  * sections: Sections | [],
  * writers: Contacts | [],
+ * manualOrderOfWriters: Contacts | [] | null,
  * photographers: Contacts | [],
  * camera_man: Contacts | [],
  * designers: Contacts | [],
@@ -402,6 +403,7 @@ export default function Story({ postData }) {
     publishedDate = '',
     updatedAt = '',
     writers = [],
+    manualOrderOfWriters = [],
     photographers = [],
     camera_man = [],
     designers = [],
@@ -436,9 +438,12 @@ export default function Story({ postData }) {
       return []
     }
   }, [section, slug])
-
+  const writersWithOrdered =
+    manualOrderOfWriters && manualOrderOfWriters.length
+      ? manualOrderOfWriters
+      : writers
   const credits = [
-    { writers: writers },
+    { writers: writersWithOrdered },
     { photographers: photographers },
     { camera_man: camera_man },
     { designers: designers },

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -213,6 +213,23 @@ const transformTimeDataIntoSlashFormat = (time) => {
   return transformTimeData(time, 'slash')
 }
 
+//TODO: add more specific type in param `arrayNeedToSort` and `arraySortReference`
+/**
+ * Sorts an array of objects based on the order of ids in another array of objects.
+ * @param {Object[]} arrayNeedToSort
+ * @param {Object[]} arraySortReference
+ */
+const sortArrayWithOtherArrayId = (arrayNeedToSort, arraySortReference) => {
+  const sortedArray = arrayNeedToSort.slice().sort((a, b) => {
+    const aIndex = arraySortReference.findIndex((x) => x.id === a.id)
+    console.log(aIndex)
+    const bIndex = arraySortReference.findIndex((x) => x.id === b.id)
+    console.log(bIndex)
+    return aIndex - bIndex
+  })
+  return sortedArray
+}
+
 export {
   transformRawDataToArticleInfo,
   transformTimeDataIntoTaipeiTime,
@@ -220,4 +237,5 @@ export {
   getSectionNameGql,
   getSectionTitleGql,
   getArticleHref,
+  sortArrayWithOtherArrayId,
 }


### PR DESCRIPTION
## Notable Change
1. 調整apollo query，取得多個field
2. 新增一utils函式，用於陣列的排序（排序依據另一陣列的元素的id）
3. 頁面顯示經排序過的`writer`、`sections`、`relateds`