### PR TITLE
feat(mm-next): if `draft-js` has no content, do not render related component

### DIFF
--- a/packages/mirror-media-next/components/story/normal/article-content.js
+++ b/packages/mirror-media-next/components/story/normal/article-content.js
@@ -1,0 +1,19 @@
+import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
+const { DraftRenderer, hasContentInRawContentBlock } = MirrorMedia
+
+/**
+ * @typedef {import('../../../type/draft-js').Draft} Content
+ */
+
+/**
+ *
+ * @param {Object} props
+ * @param {Content} props.content
+ * @returns {JSX.Element}
+ */
+export default function ArticleContent({
+  content = { blocks: [], entityMap: {} },
+}) {
+  const shouldRenderContent = hasContentInRawContentBlock(content)
+  return shouldRenderContent && <DraftRenderer rawContentBlock={content} />
+}

--- a/packages/mirror-media-next/components/story/normal/brief.js
+++ b/packages/mirror-media-next/components/story/normal/brief.js
@@ -1,8 +1,12 @@
 import styled from 'styled-components'
 import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
-const { DraftRenderer } = MirrorMedia
+const { DraftRenderer, hasContentInRawContentBlock } = MirrorMedia
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
+ */
+
+/**
+ * @typedef {import('../../../type/draft-js').Draft} Brief
  */
 
 const BriefContainer = styled.div`
@@ -31,24 +35,12 @@ const BriefContainer = styled.div`
   *::after {
     color: white;
   }
-  .DraftEditor-editorContainer {
-    background-color: ${
-      /**
-       * @param {Object} props
-       * @param {String} props.sectionSlug
-       * @param {Theme} [props.theme]
-       */
-      ({ theme, sectionSlug }) =>
-        sectionSlug && theme.color.sectionsColor[sectionSlug]
-          ? theme.color.sectionsColor[sectionSlug]
-          : theme.color.brandColor.darkBlue
-    };
-  }
 `
+
 /**
  *
  * @param {Object} props
- * @param {Object} props.brief
+ * @param {Brief} props.brief
  * @param {String} [props.sectionSlug]
  * @returns {JSX.Element}
  */
@@ -56,9 +48,12 @@ export default function ArticleBrief({
   brief = { blocks: [], entityMap: {} },
   sectionSlug = '',
 }) {
+  const shouldRenderBrief = hasContentInRawContentBlock(brief)
   return (
-    <BriefContainer sectionSlug={sectionSlug}>
-      <DraftRenderer rawContentBlock={brief}></DraftRenderer>
-    </BriefContainer>
+    shouldRenderBrief && (
+      <BriefContainer sectionSlug={sectionSlug}>
+        <DraftRenderer rawContentBlock={brief}></DraftRenderer>
+      </BriefContainer>
+    )
   )
 }

--- a/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
+++ b/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
@@ -31,7 +31,7 @@ import styled from 'styled-components'
 const Wrapper = styled.figure`
   margin: 20px 0 0;
   ${({ theme }) => theme.breakpoint.md} {
-    margin: 0;
+    margin: 0 0 34px;
   }
 `
 

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -15,14 +15,13 @@ import SubscribeInviteBanner from '../../../components/story/normal/subscribe-in
 import DonateBanner from '../../../components/story/shared/donate-banner'
 import MagazineInviteBanner from '../../../components/story/shared/magazine-invite-banner'
 import RelatedArticleList from '../../../components/story/normal/related-article-list'
+import ArticleContent from './article-content'
 import HeroImageAndVideo from './hero-image-and-video'
 import {
   transformTimeDataIntoTaipeiTime,
   sortArrayWithOtherArrayId,
 } from '../../../utils'
 import { fetchListingPosts } from '../../../apollo/query/posts'
-import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
-const { DraftRenderer } = MirrorMedia
 import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
@@ -50,7 +49,10 @@ import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
  */
 
 /**
- * @typedef {import('../../../apollo/query/post').Draft} Draft
+ * @typedef {import('./brief').Brief} Brief
+ */
+/**
+ * @typedef {import('./article-content').Content} Content
  */
 
 /**
@@ -82,8 +84,8 @@ import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
  * heroVideo : HeroVideo | null,
  * heroImage : HeroImage | null,
  * heroCaption: string,
- * brief: Draft,
- * content: Draft,
+ * brief: Brief | null,
+ * content: Content | null,
  * relateds: Relateds | []
  * } } PostData
  */
@@ -375,10 +377,10 @@ export default function StoryNormalType({ postData }) {
     vocals = [],
     extend_byline = '',
     tags = [],
-    brief = [],
+    brief = { blocks: [], entityMap: {} },
     relateds = [],
     manualOrderOfRelateds = [],
-    content = {},
+    content = { blocks: [], entityMap: {} },
   } = postData
 
   const sectionsWithOrdered =
@@ -478,16 +480,12 @@ export default function StoryNormalType({ postData }) {
               tags={tags}
             ></ArticleInfo>
           </InfoAndHero>
+
           <ArticleBrief
             sectionSlug={section?.slug}
             brief={brief}
           ></ArticleBrief>
-          <div>
-            <DraftRenderer
-              rawContentBlock={content}
-              image="/images/default-og-img.png"
-            ></DraftRenderer>
-          </div>
+          <ArticleContent content={content} />
           <DonateBanner />
           <SocialNetworkServiceSmall />
           <SubscribeInviteBanner />

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",
-    "@mirrormedia/lilith-draft-renderer": "1.1.0-alpha.14",
+    "@mirrormedia/lilith-draft-renderer": "1.1.0-alpha.19",
     "@next/font": "^13.1.2",
     "@readr-media/react-image": "^1.5.1",
     "@svgr/webpack": "^6.3.1",

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -222,9 +222,7 @@ const transformTimeDataIntoSlashFormat = (time) => {
 const sortArrayWithOtherArrayId = (arrayNeedToSort, arraySortReference) => {
   const sortedArray = arrayNeedToSort.slice().sort((a, b) => {
     const aIndex = arraySortReference.findIndex((x) => x.id === a.id)
-    console.log(aIndex)
     const bIndex = arraySortReference.findIndex((x) => x.id === b.id)
-    console.log(bIndex)
     return aIndex - bIndex
   })
   return sortedArray

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,13 +1299,14 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@mirrormedia/lilith-draft-renderer@1.1.0-alpha.14":
-  version "1.1.0-alpha.14"
-  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.1.0-alpha.14.tgz#206af6061d7ecde2a07bc63a71706c0f0debb478"
-  integrity sha512-JASf8zgVX4jAXrvY6Uto6JPuF0M8rJTPBW/FYMkE0Z2EadQQ4zkN+4bJLOScEMcId9LHe6aaHPBhwbhWDfVDkg==
+"@mirrormedia/lilith-draft-renderer@1.1.0-alpha.19":
+  version "1.1.0-alpha.19"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.1.0-alpha.19.tgz#80c00539f3fd4d1138afde477749847682f31b95"
+  integrity sha512-8+RfQCqyH8AnGNyaeLNLMp6+q1lOaqUH0vXqUteUj70Xg7LA93f+xcBiHvzKzK54ZHi+WV4GoK1Q+Mqss5Et1Q==
   dependencies:
     "@readr-media/react-image" "^1.5.1"
     draft-js "^0.11.7"
+    node-html-parser "^6.1.5"
 
 "@next/env@13.0.7":
   version "13.0.7"
@@ -2473,6 +2474,17 @@ css-select@^4.1.3:
     domutils "^2.8.0"
     nth-check "^2.0.1"
 
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
 css-to-react-native@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
@@ -2490,7 +2502,7 @@ css-tree@^1.1.2, css-tree@^1.1.3:
     mdn-data "2.0.14"
     source-map "^0.6.1"
 
-css-what@^6.0.1:
+css-what@^6.0.1, css-what@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
   integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
@@ -2601,6 +2613,15 @@ dom-serializer@^1.0.1:
     domhandler "^4.2.0"
     entities "^2.0.0"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
 dom7@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/dom7/-/dom7-4.0.4.tgz#8b68c5d8e5e2ed0fddb1cb93e433bc9060c8f3fb"
@@ -2608,7 +2629,7 @@ dom7@^4.0.4:
   dependencies:
     ssr-window "^4.0.0"
 
-domelementtype@^2.0.1, domelementtype@^2.2.0:
+domelementtype@^2.0.1, domelementtype@^2.2.0, domelementtype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
@@ -2620,6 +2641,13 @@ domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
+domhandler@^5.0.1, domhandler@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
 domutils@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
@@ -2628,6 +2656,15 @@ domutils@^2.8.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
+
+domutils@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
+  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.1"
 
 draft-js@^0.11.7:
   version "0.11.7"
@@ -2701,6 +2738,11 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 entities@^4.3.0:
   version "4.4.0"
@@ -3610,6 +3652,11 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
@@ -4523,6 +4570,14 @@ node-forge@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+
+node-html-parser@^6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.5.tgz#c819dceb13a10a7642ff92f94f870b4f77968097"
+  integrity sha512-fAaM511feX++/Chnhe475a0NHD8M7AxDInsqQpz6x63GRF7xYNdS8Vo5dKsIVPgsOvG7eioRRTZQnWBrhDHBSg==
+  dependencies:
+    css-select "^5.1.0"
+    he "1.2.0"
 
 node-releases@^2.0.6:
   version "2.0.6"


### PR DESCRIPTION
## Notable Change
1. 新增 utils 函式`isDraftHasContent`，用於判斷draft-js回傳的block是否有內容
2. 新增元件`article-content`，用於render文章頁內容
3. 如果draft-js並無資料，則不render相關的元件