### PR TITLE
feat(apollo/fragment): adjust `@typdef`, make it property required

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/category.js
+++ b/packages/mirror-media-next/apollo/fragments/category.js
@@ -3,11 +3,11 @@ import { section } from './section'
 
 /**
  * @typedef {Object} Category
- * @property {string} [id]
- * @property {string} [name]
- * @property {string} [slug]
- * @property {boolean} [isMemberOnly]
- * @property {import('./section').Section[]} [sections] it's singular but wrongly named as plural
+ * @property {string} id
+ * @property {string} name
+ * @property {string} slug
+ * @property {boolean} isMemberOnly
+ * @property {import('./section').Section[]} sections it's singular but wrongly named as plural
  */
 
 export const category = gql`

--- a/packages/mirror-media-next/apollo/fragments/contact.js
+++ b/packages/mirror-media-next/apollo/fragments/contact.js
@@ -2,8 +2,8 @@ import { gql } from '@apollo/client'
 
 /**
  * @typedef {Object} Contact
- * @property {string} [id]
- * @property {string} [name]
+ * @property {string} id
+ * @property {string} name
  */
 
 export const contact = gql`

--- a/packages/mirror-media-next/apollo/fragments/photo.js
+++ b/packages/mirror-media-next/apollo/fragments/photo.js
@@ -2,26 +2,26 @@ import { gql } from '@apollo/client'
 
 /**
  * @typedef {Object} ImageFile
- * @property {number} [width]
- * @property {number} [height]
+ * @property {number} width
+ * @property {number} height
  */
 
 /**
  * @typedef {Object} Resized
- * @property {string} [original]
- * @property {string} [w480]
- * @property {string} [w800]
- * @property {string} [w1200]
- * @property {string} [w1600]
- * @property {string} [w2400]
+ * @property {string} original
+ * @property {string} w480
+ * @property {string} w800
+ * @property {string} w1200
+ * @property {string} w1600
+ * @property {string} w2400
  */
 
 /**
  * @typedef {Object} Photo
- * @property {string} [id]
- * @property {string} [name]
- * @property {ImageFile} [imageFile]
- * @property {Resized} [resized]
+ * @property {string} id
+ * @property {string} name
+ * @property {ImageFile} imageFile
+ * @property {Resized} resized
  */
 
 export const heroImage = gql`

--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -8,14 +8,14 @@ import { heroVideo } from './video'
 
 /**
  * @typedef {Object} ListingPost
- * @property {string} [id]
- * @property {string} [slug]
- * @property {string} [title]
- * @property {string} [publishedDate]
- * @property {import('../../type/draft-js').Draft} [brief]
- * @property {import('./category').Category} [categories]
- * @property {import('./section').Section} [sections]
- * @property {import('./photo').Photo} [heroImage]
+ * @property {string} id
+ * @property {string} slug
+ * @property {string} title
+ * @property {string} publishedDate
+ * @property {import('../../type/draft-js').Draft} brief
+ * @property {import('./category').Category[]} categories
+ * @property {import('./section').Section[] } sections
+ * @property {import('./photo').Photo | null} heroImage
  */
 
 export const listingPost = gql`
@@ -43,11 +43,11 @@ export const listingPost = gql`
 
 /**
  * @typedef {Object} AsideListingPost
- * @property {string} [id]
- * @property {string} [slug]
- * @property {string} [title]
- * @property {import('./section').Section} [sections]
- * @property {import('./photo').Photo} [heroImage]
+ * @property {string} id
+ * @property {string} slug
+ * @property {string} title
+ * @property {import('./section').Section[]} sections
+ * @property {import('./photo').Photo | null} heroImage
  */
 
 export const asideListingPost = gql`
@@ -92,10 +92,10 @@ export const asideListingPost = gql`
 
 /**
  * @typedef {Object} Related
- * @property {string} [id] - unique id
- * @property {string} [slug] - post slug
- * @property {string} [title] - post title
- * @property {HeroImage} [heroImage] - hero image of the post
+ * @property {string} id - unique id
+ * @property {string} slug - post slug
+ * @property {string} title - post title
+ * @property {HeroImage} heroImage - hero image of the post
  */
 
 /**
@@ -104,32 +104,32 @@ export const asideListingPost = gql`
 
 /**
  * @typedef {Object} Post
- * @property {string} [id] - unique id of post
- * @property {string} [slug] - post slug
- * @property {string} [title] - post title
- * @property {'dark' | 'light'} [titleColor] - font color of title should be light or dark
- * @property {string} [subtitle] - post subtitle
- * @property {string} [publishedDate] - post published date
- * @property {string} [updatedAt] - post updated date
- * @property {PostState} [state] - post state, different states will have different post access of viewing
- * @property {Section[]} [sections] - which sections does this post belong to
- * @property {Section[] | null} [manualOrderOfSections] - sections with adjusted order
- * @property {Contact[]} [writers] -  the field called '作者' in cms
- * @property {Contact[] | null} [manualOrderOfWriters] - writers with adjusted order
- * @property {Contact[]} [photographers] - the field called '攝影' in cms
- * @property {Contact[]} [camera_man] - the field called '影音' in cms
- * @property {Contact[]} [designers] - the field called '設計' in cms
- * @property {Contact[]} [engineers] - the field called '工程' in cms
- * @property {Contact[]} [vocals] - the field called '主播' in cms
- * @property {string} [extend_byline] - the field called '作者(其他)' in cms
- * @property {Tag[]} [tags] - tags of the post
- * @property {HeroVideo | null} [heroVideo] - hero video of the post
- * @property {HeroImage | null} [heroImage] - hero image of the post
- * @property {string} [heroCaption] - caption to explain hero video or image
- * @property {Draft} [brief] - post brief
- * @property {Draft} [content] - post content
- * @property {Related[] | []} [relateds] related articles selected by cms users
- * @property {Related[] | [] | null} [manualOrderOfRelateds] related articles with adjusted order
+ * @property {string} id - unique id of post
+ * @property {string} slug - post slug
+ * @property {string} title - post title
+ * @property {'dark' | 'light'} titleColor - font color of title should be light or dark
+ * @property {string} subtitle - post subtitle
+ * @property {string} publishedDate - post published date
+ * @property {string} updatedAt - post updated date
+ * @property {PostState} state - post state, different states will have different post access of viewing
+ * @property {Section[] | null } sections - which sections does this post belong to
+ * @property {Section[] | null} manualOrderOfSections - sections with adjusted order
+ * @property {Contact[] | null} writers -  the field called '作者' in cms
+ * @property {Contact[] | null} manualOrderOfWriters - writers with adjusted order
+ * @property {Contact[] } photographers - the field called '攝影' in cms
+ * @property {Contact[] } camera_man - the field called '影音' in cms
+ * @property {Contact[] } designers - the field called '設計' in cms
+ * @property {Contact[] } engineers - the field called '工程' in cms
+ * @property {Contact[] } vocals - the field called '主播' in cms
+ * @property {string} extend_byline - the field called '作者(其他)' in cms
+ * @property {Tag[] } tags - tags of the post
+ * @property {HeroVideo | null} heroVideo - hero video of the post
+ * @property {HeroImage | null} heroImage - hero image of the post
+ * @property {string} heroCaption - caption to explain hero video or image
+ * @property {Draft} brief - post brief
+ * @property {Draft} content - post content
+ * @property {Related[] } relateds related articles selected by cms users
+ * @property {Related[] | null} manualOrderOfRelateds related articles with adjusted order
  */
 
 export const post = gql`

--- a/packages/mirror-media-next/apollo/fragments/section.js
+++ b/packages/mirror-media-next/apollo/fragments/section.js
@@ -2,9 +2,9 @@ import { gql } from '@apollo/client'
 
 /**
  * @typedef {Object} Section
- * @property {string} [id]
- * @property {string} [name]
- * @property {string} [slug]
+ * @property {string} id
+ * @property {string} name
+ * @property {string} slug
  */
 
 export const section = gql`

--- a/packages/mirror-media-next/apollo/fragments/tag.js
+++ b/packages/mirror-media-next/apollo/fragments/tag.js
@@ -2,9 +2,9 @@ import { gql } from '@apollo/client'
 
 /**
  * @typedef {Object} Tag
- * @property {string} [id]
- * @property {string} [name]
- * @property {string} [slug]
+ * @property {string} id
+ * @property {string} name
+ * @property {string} slug
  */
 
 export const tag = gql`

--- a/packages/mirror-media-next/apollo/fragments/topic.js
+++ b/packages/mirror-media-next/apollo/fragments/topic.js
@@ -3,12 +3,12 @@ import { heroImage } from './photo'
 
 /**
  * @typedef {Object} Topic
- * @property {string} [id]
- * @property {string} [name]
- * @property {import('../../type/draft-js').Draft} [brief]
- * @property {import('./photo').Photo} [heroImage]
- * @property {nunber} [sortOrder]
- * @property {string} [createdAt]
+ * @property {string} id
+ * @property {string} name
+ * @property {import('../../type/draft-js').Draft} brief
+ * @property {import('./photo').Photo} heroImage
+ * @property {number} sortOrder
+ * @property {string} createdAt
  */
 
 export const topic = gql`

--- a/packages/mirror-media-next/apollo/fragments/video.js
+++ b/packages/mirror-media-next/apollo/fragments/video.js
@@ -6,9 +6,9 @@ import { gql } from '@apollo/client'
 
 /**
  * @typedef {Object} HeroVideo - certain video information
- * @property {string} [id] - unique id
- * @property {string} [urlOriginal] - video url
- * @property {Pick<HeroImage,'id'> & Pick<HeroImage['resized'], 'original'>} [heroImage] - video url
+ * @property {string} id - unique id
+ * @property {string} urlOriginal - video url
+ * @property {Pick<HeroImage, 'id' | 'resized'> & Pick<HeroImage['resized'], 'original'>} heroImage - video url
  */
 
 export const heroVideo = gql`

--- a/packages/mirror-media-next/components/author/author-articles.js
+++ b/packages/mirror-media-next/components/author/author-articles.js
@@ -19,10 +19,7 @@ const Loading = styled.div`
 `
 /**
  * @typedef {import('../shared/article-list').Article} Article
- * @typedef {import('../../apollo/fragments/contact').Contact & {
- *  id: string,
- *  name: string
- * }} Author
+ * @typedef {import('../../apollo/fragments/contact').Contact} Author
  */
 
 /**

--- a/packages/mirror-media-next/components/category/category-articles.js
+++ b/packages/mirror-media-next/components/category/category-articles.js
@@ -21,13 +21,7 @@ const Loading = styled.div`
 /**
  * @typedef {import('../shared/article-list').Article} Article
  * @typedef {import('../shared/article-list').Section} Section
- * @typedef {import('../../apollo/fragments/category').Category & {
- *  id: string,
- *  name: string,
- *  slug: string,
- *  isMemberOnly: boolean,
- *  sections: Section[],
- * }} Category
+ * @typedef {import('../../apollo/fragments/category').Category} Category
  */
 
 /**

--- a/packages/mirror-media-next/components/header.js
+++ b/packages/mirror-media-next/components/header.js
@@ -116,6 +116,9 @@ const SearchInputWrapper = styled.div`
 `
 
 /**
+ * TODO: use typedef in `../apollo/fragments/section`
+ * Should be done after fetch header data from new json file
+ *
  * Remove item from array `categories` if which is member only category.
  * @param {import('../type').Section} section
  * @returns {import('../type').Section}
@@ -131,6 +134,8 @@ function filterOutIsMemberOnlyCategoriesInNormalSection(section) {
 }
 
 /**
+ * TODO: use typedef in `../apollo/fragments/section` and  `../apollo/fragments/topic`
+ * Should be done after fetch header data from new json file
  * @param {Object} props
  * @param {import('../type').Section[]} props.sectionsData
  * @param {import('../type').Topic[]} props.topicsData

--- a/packages/mirror-media-next/components/layout.js
+++ b/packages/mirror-media-next/components/layout.js
@@ -2,6 +2,8 @@ import Header from './header'
 import React from 'react'
 
 /**
+ * TODO: use typedef in `../apollo/fragments/section`
+ * Should be done after fetch header data from new json file
  *
  * @param {Object} props
  * @param {import('../type').Section[]} props.sectionsData

--- a/packages/mirror-media-next/components/mobile-sidebar.js
+++ b/packages/mirror-media-next/components/mobile-sidebar.js
@@ -250,7 +250,8 @@ const SocialMediaList = styled.div`
   }
 `
 /**
- *
+ * TODO: use typedef in `../apollo/fragments/section`
+ * Should be done after fetch header data from new json file
  * @param {Object} props
  * @param {import('../type').Topic[]} props.topics
  * @param {import('../type').Section[]} props.sections

--- a/packages/mirror-media-next/components/nav-sections.js
+++ b/packages/mirror-media-next/components/nav-sections.js
@@ -130,6 +130,8 @@ function getCategoryHref(sectionName, categoryName) {
   return `/category/${categoryName}`
 }
 /**
+ * TODO: use typedef in `../apollo/fragments/section`
+ * Should be done after fetch header data from new json file
  * @param {{sections: import('../type').Section[] | []  }} props
  * @returns {React.ReactElement}
  */

--- a/packages/mirror-media-next/components/section/topic/topic-list-item.js
+++ b/packages/mirror-media-next/components/section/topic/topic-list-item.js
@@ -63,14 +63,7 @@ const ItemBrief = styled.div`
 /**
  * @typedef {import('../../../apollo/fragments/photo').Photo} HeroImage
  *
- * @typedef {import('../../../apollo/fragments/topic').Topic & {
- *  id: string,
- *  name: string,
- *  brief: import('../../../type/draft-js').Draft,
- *  heroImage: HeroImage,
- *  sortOrder: number,
- *  createdAt: string,
- * }} Topic
+ * @typedef {import('../../../apollo/fragments/topic').Topic} Topic
  *
  */
 

--- a/packages/mirror-media-next/components/section/topic/topic-list-item.js
+++ b/packages/mirror-media-next/components/section/topic/topic-list-item.js
@@ -61,12 +61,7 @@ const ItemBrief = styled.div`
 `
 
 /**
- * @typedef {import('../../../apollo/fragments/photo').Photo & {
- *  id: String,
- *  name: String,
- *  imageFile: import('../../../apollo/fragments/photo').ImageFile,
- *  resized: import('../../../apollo/fragments/photo').Resized
- * }} HeroImage
+ * @typedef {import('../../../apollo/fragments/photo').Photo} HeroImage
  *
  * @typedef {import('../../../apollo/fragments/topic').Topic & {
  *  id: string,

--- a/packages/mirror-media-next/components/shared/article-list-item.js
+++ b/packages/mirror-media-next/components/shared/article-list-item.js
@@ -98,12 +98,7 @@ const ItemBrief = styled.div`
  *
  * @typedef {Pick<import('../../apollo/fragments/category').Category, 'id' |'name' | 'slug'>} Category
  *
- * @typedef {import('../../apollo/fragments/photo').Photo & {
- *  id: String,
- *  name: String,
- *  imageFile: import('../../apollo/fragments/photo').ImageFile,
- *  resized: import('../../apollo/fragments/photo').Resized
- * }} HeroImage
+ * @typedef {import('../../apollo/fragments/photo').Photo} HeroImage
  *
  * @typedef {import('../../apollo/fragments/post').ListingPost & {
  *  id: string,

--- a/packages/mirror-media-next/components/shared/article-list-item.js
+++ b/packages/mirror-media-next/components/shared/article-list-item.js
@@ -96,16 +96,7 @@ const ItemBrief = styled.div`
  *
  * @typedef {import('../../apollo/fragments/photo').Photo} HeroImage
  *
- * @typedef {import('../../apollo/fragments/post').ListingPost & {
- *  id: string,
- *  slug: string,
- *  title: string,
- *  publishedDate: string,
- *  brief: import('../../type/draft-js').Draft,
- *  categroies: Category[],
- *  sections: Section[],
- *  heroImage: HeroImage,
- * }} Article
+ * @typedef {import('../../apollo/fragments/post').ListingPost } Article
  */
 
 /**

--- a/packages/mirror-media-next/components/shared/article-list-item.js
+++ b/packages/mirror-media-next/components/shared/article-list-item.js
@@ -96,11 +96,7 @@ const ItemBrief = styled.div`
  *  slug: string,
  * }} Section
  *
- * @typedef {import('../../apollo/fragments/category').Category & {
- *  id: string,
- *  name: string,
- *  slug: string,
- * }} Category
+ * @typedef {Pick<import('../../apollo/fragments/category').Category, 'id' |'name' | 'slug'>} Category
  *
  * @typedef {import('../../apollo/fragments/photo').Photo & {
  *  id: String,

--- a/packages/mirror-media-next/components/shared/article-list-item.js
+++ b/packages/mirror-media-next/components/shared/article-list-item.js
@@ -90,11 +90,7 @@ const ItemBrief = styled.div`
 `
 
 /**
- * @typedef {import('../../apollo/fragments/section').Section & {
- *  id: string,
- *  name: string,
- *  slug: string,
- * }} Section
+ * @typedef {import('../../apollo/fragments/section').Section } Section
  *
  * @typedef {Pick<import('../../apollo/fragments/category').Category, 'id' |'name' | 'slug'>} Category
  *

--- a/packages/mirror-media-next/components/shared/premium-article-list-item.js
+++ b/packages/mirror-media-next/components/shared/premium-article-list-item.js
@@ -102,11 +102,7 @@ const ItemDate = styled.div`
 `
 
 /**
- * @typedef {import('../../apollo/fragments/section').Section & {
- *  id: string,
- *  name: string,
- *  slug: string,
- * }} Section
+ * @typedef {import('../../apollo/fragments/section').Section } Section
  *
  * @typedef {import('../../apollo/fragments/category').Category} Category
  *

--- a/packages/mirror-media-next/components/shared/premium-article-list-item.js
+++ b/packages/mirror-media-next/components/shared/premium-article-list-item.js
@@ -108,16 +108,7 @@ const ItemDate = styled.div`
  *
  * @typedef {import('../../apollo/fragments/photo').Photo } HeroImage
  *
- * @typedef {import('../../apollo/fragments/post').ListingPost & {
- *  id: string,
- *  slug: string,
- *  title: string,
- *  publishedDate: string,
- *  brief: import('../../type/draft-js').Draft,
- *  categroies: Category[],
- *  sections: Section[],
- *  heroImage: HeroImage,
- * }} Article
+ * @typedef {import('../../apollo/fragments/post').ListingPost} Article
  */
 
 /**

--- a/packages/mirror-media-next/components/shared/premium-article-list-item.js
+++ b/packages/mirror-media-next/components/shared/premium-article-list-item.js
@@ -110,12 +110,7 @@ const ItemDate = styled.div`
  *
  * @typedef {import('../../apollo/fragments/category').Category} Category
  *
- * @typedef {import('../../apollo/fragments/photo').Photo & {
- *  id: String,
- *  name: String,
- *  imageFile: import('../../apollo/fragments/photo').ImageFile,
- *  resized: import('../../apollo/fragments/photo').Resized
- * }} HeroImage
+ * @typedef {import('../../apollo/fragments/photo').Photo } HeroImage
  *
  * @typedef {import('../../apollo/fragments/post').ListingPost & {
  *  id: string,

--- a/packages/mirror-media-next/components/shared/premium-article-list-item.js
+++ b/packages/mirror-media-next/components/shared/premium-article-list-item.js
@@ -108,11 +108,7 @@ const ItemDate = styled.div`
  *  slug: string,
  * }} Section
  *
- * @typedef {import('../../apollo/fragments/category').Category & {
- *  id: string,
- *  name: string,
- *  slug: string,
- * }} Category
+ * @typedef {import('../../apollo/fragments/category').Category} Category
  *
  * @typedef {import('../../apollo/fragments/photo').Photo & {
  *  id: String,

--- a/packages/mirror-media-next/components/shared/section-articles.js
+++ b/packages/mirror-media-next/components/shared/section-articles.js
@@ -21,11 +21,7 @@ const Loading = styled.div`
 
 /**
  * @typedef {import('../shared/article-list').Article} Article
- * @typedef {import('../../apollo/fragments/section').Section & {
- *  id: string,
- *  name: string,
- *  slug: string,
- * }} Section
+ * @typedef {import('../../apollo/fragments/section').Section } Section
  */
 
 /**

--- a/packages/mirror-media-next/components/story/normal/article-info.js
+++ b/packages/mirror-media-next/components/story/normal/article-info.js
@@ -150,7 +150,7 @@ const CREDIT_TITLE_NAME_MAP = {
  */
 
 /**
- * @typedef {(import('../../../apollo/fragments/post').Post['tags'] & {id: string, slug: string, name: string})[]} Tags
+ * @typedef {import('../../../apollo/fragments/tag').Tag[]} Tags
  */
 
 /**

--- a/packages/mirror-media-next/components/story/normal/article-info.js
+++ b/packages/mirror-media-next/components/story/normal/article-info.js
@@ -146,7 +146,7 @@ const CREDIT_TITLE_NAME_MAP = {
 }
 
 /**
- * @typedef {import('../../../apollo/fragments/post').Contact & { id: string, name: string }[]} Contacts
+ * @typedef {import('../../../apollo/fragments/contact').Contact[]} Contacts
  */
 
 /**

--- a/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
+++ b/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
@@ -17,15 +17,7 @@ import styled from 'styled-components'
  */
 
 /**
- * @typedef {import('../../../apollo/fragments/post').HeroVideo & {
- * id: string,
- * name:string,
- * urlOriginal: string,
- * heroImage: {
- *    resized:
- *      Pick<HeroImage,'id'> & Pick<HeroImage['resized'], 'original'>
- *   }
- * } } HeroVideo
+ * @typedef {import('../../../apollo/fragments/video').HeroVideo } HeroVideo
  */
 
 const Wrapper = styled.figure`

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -36,8 +36,7 @@ import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
  */
 
 /**
- * @typedef {(import('../../../apollo/fragments/post').Section &
- * { id: string, slug: string, name: string })[]} Sections
+ * @typedef {import('../../../apollo/fragments/section').Section[] } Sections
  */
 
 /**

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -59,34 +59,7 @@ import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
  */
 
 /**
- * @typedef {import('../../../apollo/fragments/post').Post &
- * {
- * id: string,
- * slug: string,
- * title: string,
- * titleColor: "dark" | "light",
- * subtitle: string,
- * publishedDate: string,
- * updatedAt: string,
- * state: "published" | "draft" | "scheduled" | "archived" | "invisible",
- * sections: Sections | [],
- * manualOrderOfSections: Sections | [] | null,
- * writers: Contacts | [],
- * manualOrderOfWriters: Contacts | [] | null,
- * photographers: Contacts | [],
- * camera_man: Contacts | [],
- * designers: Contacts | [],
- * engineers: Contacts | [],
- * vocals: Contacts | [],
- * extend_byline: string,
- * tags: import('../../../components/story/normal/article-info').Tags | [],
- * heroVideo : HeroVideo | null,
- * heroImage : HeroImage | null,
- * heroCaption: string,
- * brief: Brief | null,
- * content: Content | null,
- * relateds: Relateds | []
- * } } PostData
+ * @typedef {import('../../../apollo/fragments/post').Post } PostData
  */
 
 const sectionColor = css`

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -72,7 +72,7 @@ import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
  * state: "published" | "draft" | "scheduled" | "archived" | "invisible",
  * sections: Sections | [],
  * manualOrderOfSections: Sections | [] | null,
- * writers: import('../../../components/story/normal/article-info').Contacts | [],
+ * writers: Contacts | [],
  * manualOrderOfWriters: Contacts | [] | null,
  * photographers: Contacts | [],
  * camera_man: Contacts | [],

--- a/packages/mirror-media-next/components/tag/tag-articles.js
+++ b/packages/mirror-media-next/components/tag/tag-articles.js
@@ -20,11 +20,7 @@ const Loading = styled.div`
 
 /**
  * @typedef {import('../shared/article-list').Article} Article
- * @typedef {import('../../apollo/fragments/tag').Tag & {
- *  id: string,
- *  name: string,
- *  slug: string,
- * }} Tag
+ * @typedef {import('../../apollo/fragments/tag').Tag} Tag
  */
 
 /**

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -30,6 +30,9 @@ const getArticleHref = (slug, style, partner) => {
 }
 
 /**
+ * TODO: use typedef in `../apollo/fragments/section`
+ * Should be done after fetch header data from new json file
+ *
  * Get section name based on different condition
  * @param {import('../type/raw-data.typedef').Section[]} sections
  * @param {Object | ''} partner
@@ -45,6 +48,9 @@ function getSectionName(sections = [], partner = '') {
 }
 
 /**
+ * TODO: use typedef in `../apollo/fragments/section`
+ * Should be done after fetch header data from new json file
+ *
  * Get section title based on different condition
  * @param {import('../type/raw-data.typedef').Section[]} sections
  * @param {Object | ''} partner
@@ -74,6 +80,9 @@ function getSectionTitle(sections = [], partner) {
 //TODO:
 // - remove function for handling data from k3 server
 // - adjust typedef of Section
+
+//TODO: use typedef in `../apollo/fragments/section`
+// Should be done after fetch header data from new json file
 /**
  * Get section name based on different condition
  * Because data structure of keystone 6 response is different from keystone 3, we create this function to handle data from keystone 6 server.
@@ -90,6 +99,8 @@ function getSectionNameGql(sections = [], partner = '') {
   return sections[0]?.name
 }
 
+// TODO: use typedef in `../apollo/fragments/section`
+// Should be done after fetch header data from new json file
 /**
  * Get section title based on different condition
  * Because data structure of keystone 6 response is different from keystone 3, we create this function to handle data from keystone 6 server.


### PR DESCRIPTION
## Notable Change
1. 依據先前的討論，將apollo/fragments裡面的`@typedef`，將其property都改為required。
2. 如果元件要引用apollo/fragments裡面的`@typedef`，則可以使用typescript的`Pick`，或直接使用。
3. 目前一個fragment中可能會有多個`@typedef`，但未來應該是只留存一個`@typedef`，如果元件要使用其中部分的屬性，則於元件中直接使用Pick，選取需要的屬性：

```
// apollo/fragments/some-field.js
/**
 * @typedef {Object} SomeField
 * @property {string} propertyA
 * @property {string} propertyB
 * @property {string} propertyC
 */

// component A, need all property in `SomeField`
/**
 * @typedef {import('../apollo/fragments/some-field.js).SomeField} SomeField
 */

// component B, only need property `A` and `B` in `SomeField`
/**
 * @typedef {Pick<import('../apollo/fragments/some-field.js).SomeField, 'A' | 'B'>} SomeField
 */

```

但這將未來另發PR處理，避免該PR內容過於雜亂。