### PR TITLE
feat(mm-next/topic): add topic page

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -39,6 +39,9 @@ export const listingPost = gql`
       ...heroImage
     }
     isFeatured
+    tags {
+      ...tag
+    }
   }
 `
 
@@ -132,6 +135,7 @@ export const asideListingPost = gql`
  * @property {Related[] } relateds related articles selected by cms users
  * @property {Related[] | null} manualOrderOfRelateds related articles with adjusted order
  * @property {boolean} isFeatured
+ * @property {import('./tag').Tag[]} tags
  */
 
 export const post = gql`

--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -38,6 +38,7 @@ export const listingPost = gql`
     heroImage {
       ...heroImage
     }
+    isFeatured
   }
 `
 
@@ -130,6 +131,7 @@ export const asideListingPost = gql`
  * @property {Draft} content - post content
  * @property {Related[] } relateds related articles selected by cms users
  * @property {Related[] | null} manualOrderOfRelateds related articles with adjusted order
+ * @property {boolean} isFeatured
  */
 
 export const post = gql`

--- a/packages/mirror-media-next/apollo/fragments/topic.js
+++ b/packages/mirror-media-next/apollo/fragments/topic.js
@@ -1,5 +1,6 @@
 import { gql } from '@apollo/client'
 import { heroImage } from './photo'
+import { post } from './post'
 
 /**
  * @typedef {Object} Topic
@@ -9,10 +10,28 @@ import { heroImage } from './photo'
  * @property {import('./photo').Photo} heroImage
  * @property {number} sortOrder
  * @property {string} createdAt
+ * @property {string} leading
+ * @property {string} type
+ * @property {string} style
+ * @property {number} postsCount
+ * @property {import('./post').Post[]} posts
  */
+
+export const simpleTopic = gql`
+  ${heroImage}
+  fragment simpleTopic on Topic {
+    id
+    name
+    brief
+    heroImage {
+      ...heroImage
+    }
+  }
+`
 
 export const topic = gql`
   ${heroImage}
+  ${post}
   fragment topic on Topic {
     id
     name
@@ -20,7 +39,17 @@ export const topic = gql`
     heroImage {
       ...heroImage
     }
-    sortOrder
-    createdAt
+    leading
+    type
+    style
+    postsCount(where: $postsFilter)
+    posts(
+      where: $postsFilter
+      orderBy: $postsOrderBy
+      take: $postsTake
+      skip: $postsSkip
+    ) {
+      ...post
+    }
   }
 `

--- a/packages/mirror-media-next/apollo/fragments/topic.js
+++ b/packages/mirror-media-next/apollo/fragments/topic.js
@@ -1,6 +1,7 @@
 import { gql } from '@apollo/client'
 import { heroImage } from './photo'
 import { post } from './post'
+import { tag } from './tag'
 
 /**
  * @typedef {Object} Topic
@@ -15,6 +16,7 @@ import { post } from './post'
  * @property {string} style
  * @property {number} postsCount
  * @property {import('./post').Post[]} posts
+ * @property {import('./tag').Tag[]} tags
  */
 
 export const simpleTopic = gql`
@@ -32,6 +34,7 @@ export const simpleTopic = gql`
 export const topic = gql`
   ${heroImage}
   ${post}
+  ${tag}
   fragment topic on Topic {
     id
     name
@@ -50,6 +53,9 @@ export const topic = gql`
       skip: $postsSkip
     ) {
       ...post
+    }
+    tags {
+      ...tag
     }
   }
 `

--- a/packages/mirror-media-next/apollo/query/topics.js
+++ b/packages/mirror-media-next/apollo/query/topics.js
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client'
-import { topic } from '../fragments/topic'
+import { simpleTopic, topic } from '../fragments/topic'
 
 const fetchTopics = gql`
-  ${topic}
+  ${simpleTopic}
   query (
     $take: Int
     $skip: Int
@@ -11,9 +11,24 @@ const fetchTopics = gql`
   ) {
     topicsCount(where: $filter)
     topics(take: $take, skip: $skip, orderBy: $orderBy, where: $filter) {
+      ...simpleTopic
+    }
+  }
+`
+
+const fetchTopic = gql`
+  ${topic}
+  query (
+    $topicFilter: TopicWhereUniqueInput!
+    $postsFilter: PostWhereInput!
+    $postsOrderBy: [PostOrderByInput!]!
+    $postsTake: Int
+    $postsSkip: Int!
+  ) {
+    topic(where: $topicFilter) {
       ...topic
     }
   }
 `
 
-export { fetchTopics }
+export { fetchTopics, fetchTopic }

--- a/packages/mirror-media-next/components/topic/group/group-articles-item.js
+++ b/packages/mirror-media-next/components/topic/group/group-articles-item.js
@@ -1,0 +1,154 @@
+import styled from 'styled-components'
+import Image from '@readr-media/react-image'
+
+/**
+ * @typedef {import('../../../type/theme').Theme} Theme
+ */
+
+const ItemWrapper = styled.a`
+  display: flex;
+  position: relative;
+  width: 300px;
+  margin: 0 auto;
+  font-size: 18px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #4a4a4a;
+  column-gap: 12px;
+  ${({ theme }) => theme.breakpoint.md} {
+    flex-direction: column;
+    width: 320px;
+    padding-bottom: 36px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    padding-bottom: 40px;
+    margin-bottom: -1px;
+    &:nth-child(3n-1) {
+      width: 384px;
+      padding: 0 32px;
+    }
+  }
+`
+
+const ImageContainer = styled.div`
+  position: relative;
+  width: 147px;
+  height: 99px;
+  flex: none;
+  border-radius: 16px;
+  overflow: hidden;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    width: 100%;
+    height: 214px;
+  }
+`
+
+const ItemDetail = styled.div`
+  ${({ theme }) => theme.breakpoint.md} {
+    margin-top: 20px;
+  }
+`
+
+const ItemTitle = styled.h3`
+  color: #b17f5a;
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-weight: 500;
+  font-size: 13px;
+  line-height: 18px;
+  ${({ theme }) => theme.breakpoint.md} {
+    font-size: 18px;
+    line-height: 26px;
+    -webkit-line-clamp: 2;
+    height: 52px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    font-size: 18px;
+  }
+`
+
+const ItemBrief = styled.p`
+  display: none;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    display: block;
+    height: 72px;
+    margin-top: 20px;
+    font-size: 16px;
+    line-height: 1.5;
+    color: #4a4a4a;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin-top: 20px;
+  }
+`
+
+/**
+ * @typedef {import('../../../apollo/fragments/section').Section & {
+ *  id: string,
+ *  name: string,
+ *  slug: string,
+ * }} Section
+ *
+ * @typedef {import('../../../apollo/fragments/category').Category & {
+ *  id: string,
+ *  name: string,
+ *  slug: string,
+ * }} Category
+ *
+ * @typedef {import('../../../apollo/fragments/photo').Photo & {
+ *  id: String,
+ *  name: String,
+ *  imageFile: import('../../../apollo/fragments/photo').ImageFile,
+ *  resized: import('../../../apollo/fragments/photo').Resized
+ * }} HeroImage
+ *
+ * @typedef {import('../../../apollo/fragments/tag').Tag} Tag
+ * @typedef {import('../../../apollo/fragments/post').Post & {
+ *  id: string,
+ *  slug: string,
+ *  title: string,
+ *  publishedDate: string,
+ *  brief: import('../../../type/draft-js').Draft,
+ *  categroies: Category[],
+ *  sections: Section[],
+ *  heroImage: HeroImage,
+ *  tags: Tag[]
+ * }} Article
+ */
+
+/**
+ * @param {Object} props
+ * @param {Article} props.item
+ * @returns {React.ReactElement}
+ */
+export default function GroupArticlesItem({ item }) {
+  return (
+    <ItemWrapper
+      href={`/story/${item.slug}`}
+      target="_blank"
+      className="groupArticleItem"
+    >
+      <ImageContainer>
+        <Image
+          images={item.heroImage?.resized}
+          alt={item.title}
+          loadingImage="/images/loading.gif"
+          defaultImage="/images/default-og-img.png"
+          rwd={{ tablet: '320px', desktop: '220px' }}
+        />
+      </ImageContainer>
+      <ItemDetail className="groupListBlockContent">
+        <ItemTitle>{item.title}</ItemTitle>
+        <ItemBrief>{item.brief?.blocks[0]?.text}</ItemBrief>
+      </ItemDetail>
+    </ItemWrapper>
+  )
+}

--- a/packages/mirror-media-next/components/topic/group/topic-group-articles.js
+++ b/packages/mirror-media-next/components/topic/group/topic-group-articles.js
@@ -1,0 +1,81 @@
+import styled from 'styled-components'
+import GroupArticlesItem from './group-articles-item'
+
+const Container = styled.div`
+  &:first-of-type h2 {
+    padding: 16px 0 19px;
+  }
+  ${({ theme }) => theme.breakpoint.md} {
+    &:first-of-type h2 {
+      padding: 24px 0 35px;
+    }
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    &:first-of-type h2 {
+      padding: 16px 0 39px;
+    }
+  }
+`
+
+const GroupTitle = styled.h2`
+  padding: 20px 0 19px;
+  text-align: center;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 1.5;
+  color: #b17f5a;
+  ${({ theme }) => theme.breakpoint.md} {
+    font-size: 32px;
+    padding: 60px 0 35px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    padding: 40px 0 39px;
+  }
+`
+
+const GroupArticles = styled.div`
+  display: grid;
+  grid-template-columns: 320px;
+  justify-content: center;
+  row-gap: 20px;
+  margin: 0 auto;
+  ${({ theme }) => theme.breakpoint.md} {
+    grid-template-columns: repeat(2, 320px);
+    gap: 36px 32px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    width: 1024px;
+    grid-template-columns: 320px 384px 320px;
+    column-gap: unset;
+    border-bottom: 1px solid #4a4a4a;
+  }
+`
+
+/**
+ * @typedef {import('./group-articles-item').Article} Article
+ * @typedef {import('../../../apollo/fragments/tag').Tag & {
+ *  id: string;
+ *  name: string;
+ *  slug: string;
+ * }} Tag
+ */
+
+/**
+ *
+ * @param {Object} props
+ * @param {Article[]} props.posts
+ * @param {Tag} props.tag
+ * @returns {React.ReactElement}
+ */
+export default function TopicGroupArticles({ tag, posts }) {
+  return (
+    <Container className={`groupListBlockContainer tag-${tag.slug}`}>
+      <GroupTitle>{tag.name}</GroupTitle>
+      <GroupArticles className="groupArticles">
+        {posts.map((item) => (
+          <GroupArticlesItem key={item.id} item={item} />
+        ))}
+      </GroupArticles>
+    </Container>
+  )
+}

--- a/packages/mirror-media-next/components/topic/group/topic-group.js
+++ b/packages/mirror-media-next/components/topic/group/topic-group.js
@@ -1,0 +1,98 @@
+import styled, { css } from 'styled-components'
+import TopicGroupArticles from './topic-group-articles'
+
+const Container = styled.main`
+  margin: 0 auto;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    padding: 0;
+  }
+
+  // custom css from cms, mainly used class name .topic, .topic-title, .leading
+  ${({ customCss }) =>
+    customCss &&
+    css`
+      ${customCss}
+    `}
+`
+
+const Topic = styled.div`
+  background-repeat: no-repeat;
+  height: auto;
+  padding-top: 66.66%;
+  background-position: 50%;
+  background-size: cover;
+
+  ${({ theme }) => theme.breakpoint.md} {
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    height: 600px;
+    background-size: contain;
+  }
+`
+
+const TopicGroups = styled.div`
+  padding-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+`
+
+/**
+ * @typedef {import('../../../apollo/fragments/photo').Photo & {
+ *  id: string;
+ *  name: string;
+ *  imageFile: {
+ *    width: number;
+ *    height: number;
+ *  }
+ *  resized: {
+ *    original: string;
+ *    w480: string;
+ *    w800: string;
+ *    w1200: string;
+ *    w1600: string;
+ *    w2400: string;
+ *  }
+ * }} Photo
+ * @typedef {import('./topic-group-articles').Tag} Tag
+ * @typedef {import('./topic-group-articles').Article} Article
+ * @typedef {import('../../../apollo/fragments/topic').Topic & {
+ *  id: string;
+ *  name: string;
+ *  brief: import('../../../type/draft-js').Draft;
+ *  heroImage: Photo;
+ *  leading: string;
+ *  type: string;
+ *  style: string;
+ *  posts: Article[];
+ *  tags: Tag[]
+ * }} Topic
+ */
+
+/**
+ * @param {Object} props
+ * @param {Topic} props.topic
+ * @returns {React.ReactElement}
+ */
+export default function TopicGroup({ topic }) {
+  const { style, posts, tags } = topic
+
+  return (
+    <>
+      <Container customCss={style} className="topicContainer">
+        <Topic className="topic" />
+        <TopicGroups className="groupList">
+          {tags.map((tag) => (
+            <TopicGroupArticles
+              key={tag.id}
+              tag={tag}
+              posts={posts.filter((post) =>
+                post.tags.some((postTag) => postTag.id === tag.id)
+              )}
+            />
+          ))}
+        </TopicGroups>
+      </Container>
+    </>
+  )
+}

--- a/packages/mirror-media-next/components/topic/group/topic-group.js
+++ b/packages/mirror-media-next/components/topic/group/topic-group.js
@@ -23,11 +23,9 @@ const Topic = styled.div`
   background-position: 50%;
   background-size: cover;
 
-  ${({ theme }) => theme.breakpoint.md} {
-  }
   ${({ theme }) => theme.breakpoint.xl} {
     height: 600px;
-    background-size: contain;
+    padding-top: 0;
   }
 `
 

--- a/packages/mirror-media-next/components/topic/list/list-articles-item.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles-item.js
@@ -1,0 +1,157 @@
+import styled from 'styled-components'
+import Image from '@readr-media/react-image'
+
+const ItemWrapper = styled.a`
+  display: block;
+  position: relative;
+  width: 100%;
+  margin: 0 auto;
+  font-size: 18px;
+`
+
+const ImageContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: 214px;
+  border-radius: 16px;
+  overflow: hidden;
+  ${({ theme }) => theme.breakpoint.md} {
+    height: 147px;
+  }
+  > img {
+    background: white;
+  }
+`
+
+const ItemSection = styled.div`
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  padding: 8px;
+  color: white;
+  font-size: 16px;
+  font-weight: 300;
+  border-radius: 16px;
+  background-color: ${
+    /**
+     * @param {Object} props
+     * @param {String } props.sectionName
+     * @param {Theme} [props.theme]
+     */
+    ({ sectionName, theme }) =>
+      sectionName && theme.color.sectionsColor[sectionName]
+        ? theme.color.sectionsColor[sectionName]
+        : theme.color.brandColor.lightBlue
+  };
+  ${({ theme }) => theme.breakpoint.md} {
+    font-size: 18px;
+    font-weight: 600;
+    padding: 4px 20px;
+  }
+`
+
+const ItemDetail = styled.div`
+  margin: 20px 20px 36px 20px;
+  ${({ theme }) => theme.breakpoint.md} {
+    margin: 8px 8px 40px 8px;
+  }
+`
+
+const ItemTitle = styled.div`
+  color: #054f77;
+  line-height: 25px;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    height: 75px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    font-size: 18px;
+  }
+`
+
+const ItemBrief = styled.div`
+  font-size: 16px;
+  color: #979797;
+  margin-top: 20px;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    margin-top: 16px;
+  }
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin-top: 20px;
+    -webkit-line-clamp: 4;
+  }
+`
+
+/**
+ * @typedef {import('../../../apollo/fragments/section').Section & {
+ *  id: string,
+ *  name: string,
+ *  slug: string,
+ * }} Section
+ *
+ * @typedef {import('../../../apollo/fragments/category').Category & {
+ *  id: string,
+ *  name: string,
+ *  slug: string,
+ * }} Category
+ *
+ * @typedef {import('../../../apollo/fragments/photo').Photo & {
+ *  id: String,
+ *  name: String,
+ *  imageFile: import('../../../apollo/fragments/photo').ImageFile,
+ *  resized: import('../../../apollo/fragments/photo').Resized
+ * }} HeroImage
+ *
+ * @typedef {import('../../../apollo/fragments/post').Post & {
+ *  id: string,
+ *  slug: string,
+ *  title: string,
+ *  publishedDate: string,
+ *  brief: import('../../../type/draft-js').Draft,
+ *  categroies: Category[],
+ *  sections: Section[],
+ *  heroImage: HeroImage,
+ * }} Article
+ */
+
+/**
+ * @param {Object} props
+ * @param {Article} props.item
+ * @returns {React.ReactElement}
+ */
+export default function ListArticlesItem({ item }) {
+  const itemSection = item.sections.find((section) => section.slug !== 'member')
+
+  return (
+    <ItemWrapper href={`/story/${item.slug}`} target="_blank">
+      <ImageContainer>
+        <Image
+          images={item.heroImage?.resized}
+          alt={item.title}
+          loadingImage="/images/loading.gif"
+          defaultImage="/images/default-og-img.png"
+          rwd={{ tablet: '320px', desktop: '220px' }}
+        />
+        {itemSection && (
+          <ItemSection sectionName={itemSection?.slug}>
+            {itemSection?.name}
+          </ItemSection>
+        )}
+      </ImageContainer>
+      <ItemDetail>
+        <ItemTitle>{item.title}</ItemTitle>
+        <ItemBrief>{item.brief?.blocks[0]?.text}</ItemBrief>
+      </ItemDetail>
+    </ItemWrapper>
+  )
+}

--- a/packages/mirror-media-next/components/topic/list/list-articles.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles.js
@@ -1,0 +1,38 @@
+import styled from 'styled-components'
+import ListArticlesItem from './list-articles-item'
+
+const ItemContainer = styled.div`
+  display: grid;
+  grid-template-columns: 320px;
+  justify-content: center;
+  row-gap: 20px;
+  margin-top: 40px;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    grid-template-columns: repeat(3, 220px);
+    gap: 32px 10px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    grid-template-columns: repeat(4, 220px);
+    gap: 48px;
+  }
+`
+
+/**
+ * @typedef {import('./list-articles-item').Article} Article
+ */
+
+/**
+ * @param {Object} props
+ * @param {Article[]} props.renderList
+ * @returns {React.ReactElement}
+ */
+export default function ListArticles({ renderList }) {
+  return (
+    <ItemContainer>
+      {renderList.map((item) => (
+        <ListArticlesItem key={item.id} item={item} />
+      ))}
+    </ItemContainer>
+  )
+}

--- a/packages/mirror-media-next/components/topic/list/topic-list-articles.js
+++ b/packages/mirror-media-next/components/topic/list/topic-list-articles.js
@@ -1,0 +1,77 @@
+import styled from 'styled-components'
+import client from '../../../apollo/apollo-client'
+
+import InfiniteScrollList from '../../infinite-scroll-list'
+import Image from 'next/legacy/image'
+import LoadingPage from '../../../public/images/loading_page.gif'
+import { fetchTopic } from '../../../apollo/query/topics'
+import ListArticles from './list-articles'
+
+const Loading = styled.div`
+  margin: 20px auto 0;
+  padding: 0 0 20px;
+  text-align: center;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 64px auto 0;
+    padding: 0 0 64px;
+  }
+`
+
+/**
+ * @typedef {import('./list-articles').Article} Article
+ */
+
+/**
+ *
+ * @param {Object} props
+ * @param {number} props.postsCount
+ * @param {Article[]} props.posts
+ * @param {string} props.topicId
+ * @param {number} props.renderPageSize
+ * @returns {React.ReactElement}
+ */
+export default function TopicListArticles({
+  postsCount,
+  posts,
+  topicId,
+  renderPageSize,
+}) {
+  async function fetchTopicPostsFromPage(page) {
+    try {
+      const response = await client.query({
+        query: fetchTopic,
+        variables: {
+          topicFilter: { id: topicId },
+          postsFilter: { state: { equals: 'published' } },
+          postsOrderBy: [{ isFeatured: 'desc' }, { publishedDate: 'desc' }],
+          postsTake: renderPageSize,
+          postsSkip: (page - 1) * renderPageSize,
+        },
+      })
+      console.log(response.data)
+      return response.data.topic.posts
+    } catch (error) {
+      console.error(error)
+    }
+    return
+  }
+
+  const loader = (
+    <Loading key={0}>
+      <Image src={LoadingPage} alt="loading page"></Image>
+    </Loading>
+  )
+
+  return (
+    <InfiniteScrollList
+      initialList={posts}
+      renderAmount={renderPageSize}
+      fetchCount={Math.ceil(postsCount / renderPageSize)}
+      fetchListInPage={fetchTopicPostsFromPage}
+      loader={loader}
+    >
+      {(renderList) => <ListArticles renderList={renderList} />}
+    </InfiniteScrollList>
+  )
+}

--- a/packages/mirror-media-next/components/topic/list/topic-list.js
+++ b/packages/mirror-media-next/components/topic/list/topic-list.js
@@ -1,0 +1,252 @@
+import styled from 'styled-components'
+import { Swiper, SwiperSlide } from 'swiper/react'
+import { Autoplay, Navigation } from 'swiper'
+import TopicListArticles from './topic-list-articles'
+
+// Import Swiper styles
+import 'swiper/css'
+import 'swiper/css/pagination'
+import 'swiper/css/navigation'
+import css from 'styled-jsx/css'
+import { useCallback, useState } from 'react'
+
+const Container = styled.main`
+  margin: 0 auto;
+  background: #eee;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    padding: 0;
+  }
+
+  // custom css from cms, mainly used class name .topic, .topic-title, .leading
+  ${({ customCss }) =>
+    customCss &&
+    css`
+      ${customCss}
+    `}
+`
+
+const Topic = styled.div`
+  background-repeat: no-repeat;
+  height: auto;
+  padding-top: 66.66%;
+  background-position: 50%;
+  background-size: cover;
+
+  ${({ theme }) => theme.breakpoint.md} {
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    height: 600px;
+    background-size: contain;
+  }
+`
+const TopicTitle = styled.div`
+  background-repeat: no-repeat;
+`
+const TopicLeading = styled.div`
+  width: 87.5%;
+  max-width: 450px;
+  margin: 0 auto;
+  .swiper-button-prev,
+  .swiper-button-next {
+    display: none;
+  }
+  .swiper-slide {
+    img {
+      display: block;
+      height: 100%;
+      width: 100%;
+    }
+  }
+  ${({ theme }) => theme.breakpoint.md} {
+    width: 50%;
+    max-width: 830px;
+  }
+`
+const CustomSwiperPrev = styled.div`
+  position: absolute;
+  top: 50%;
+  width: 12px;
+  height: 28px;
+  margin-top: calc(0px - (28px / 2));
+  z-index: 10;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #204f74;
+  left: 8px;
+  ${({ theme }) => theme.breakpoint.md} {
+    left: -24px;
+  }
+
+  &:after {
+    content: 'prev';
+    font-family: swiper-icons;
+    font-size: 28px;
+    text-transform: none !important;
+    letter-spacing: 0;
+    font-variant: initial;
+    line-height: 1;
+  }
+`
+
+const CustomSwiperNext = styled.div`
+  position: absolute;
+  top: 50%;
+  width: 12px;
+  height: 28px;
+  margin-top: calc(0px - (28px / 2));
+  z-index: 10;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #204f74;
+  right: 8px;
+  ${({ theme }) => theme.breakpoint.md} {
+    right: -24px;
+  }
+
+  &:after {
+    content: 'next';
+    font-family: swiper-icons;
+    font-size: 28px;
+    text-transform: none !important;
+    letter-spacing: 0;
+    font-variant: initial;
+    line-height: 1;
+  }
+`
+
+/**
+ * @typedef {import('../../../apollo/fragments/photo').Photo & {
+ *  id: string;
+ *  name: string;
+ *  imageFile: {
+ *    width: number;
+ *    height: number;
+ *  }
+ *  resized: {
+ *    original: string;
+ *    w480: string;
+ *    w800: string;
+ *    w1200: string;
+ *    w1600: string;
+ *    w2400: string;
+ *  }
+ * }} Photo
+ * @typedef {import('./topic-list-articles').Article} Article
+ * @typedef {import('../../../apollo/fragments/topic').Topic & {
+ *  id: string;
+ *  name: string;
+ *  brief: import('../../../type/draft-js').Draft;
+ *  heroImage: Photo;
+ *  leading: string;
+ *  type: string;
+ *  style: string;
+ *  posts: Article[];
+ * }} Topic
+ * an mm 2.0 data from example http://104.199.190.189:8080/images?where=%7B%22topics%22%3A%7B%22%24in%22%3A%5B%225a30e6ae4be59110005c5e6b%22%5D%7D%7D&max_results=25
+ * @typedef {{
+ *  _id: string,
+ *  description: string
+ *  createTime: string
+ *  image: {
+ *    filename: string
+ *    resizedTargets: {
+ *      tiny: {
+ *        height: number
+ *        width: number
+ *        url: string
+ *      }
+ *      mobile: {
+ *        height: number
+ *        width: number
+ *        url: string
+ *      }
+ *      tablet: {
+ *        height: number
+ *        width: number
+ *        url: string
+ *      }
+ *      desktop: {
+ *        height: number
+ *        width: number
+ *        url: string
+ *      }
+ *    }
+ *    keywords: string
+ *  }
+ * }} SlideshowItem
+ */
+
+/**
+ * @param {Object} props
+ * @param {Topic} props.topic
+ * @param {number} props.renderPageSize
+ * @param {SlideshowItem[]} props.slideshowData
+ * @returns {React.ReactElement}
+ */
+export default function TopicList({ topic, renderPageSize, slideshowData }) {
+  const [swiperRef, setSwiperRef] = useState(null)
+  const { postsCount, posts, id, style } = topic
+
+  const handlePrevious = useCallback(() => {
+    swiperRef?.slidePrev()
+  }, [swiperRef])
+
+  const handleNext = useCallback(() => {
+    swiperRef?.slideNext()
+  }, [swiperRef])
+
+  return (
+    <>
+      <Container customCss={style}>
+        <Topic className="topic">
+          <TopicTitle className="topic-title" />
+          <TopicLeading className="leading">
+            {!!slideshowData.length && (
+              <>
+                <CustomSwiperPrev onClick={handlePrevious} />
+                <CustomSwiperNext onClick={handleNext} />
+                <Swiper
+                  onSwiper={setSwiperRef}
+                  spaceBetween={100}
+                  centeredSlides={true}
+                  autoplay={{
+                    delay: 4000,
+                    disableOnInteraction: false,
+                  }}
+                  pagination={{
+                    clickable: true,
+                  }}
+                  loop={true}
+                  speed={750}
+                  navigation={true}
+                  modules={[Autoplay, Navigation]}
+                >
+                  {slideshowData.map((item) => (
+                    <SwiperSlide key={item._id}>
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={item.image?.resizedTargets?.tablet?.url}
+                        alt={item.description}
+                      />
+                    </SwiperSlide>
+                  ))}
+                </Swiper>
+              </>
+            )}
+          </TopicLeading>
+        </Topic>
+        <TopicListArticles
+          topicId={id}
+          posts={posts}
+          postsCount={postsCount}
+          renderPageSize={renderPageSize}
+        />
+      </Container>
+    </>
+  )
+}

--- a/packages/mirror-media-next/components/topic/list/topic-list.js
+++ b/packages/mirror-media-next/components/topic/list/topic-list.js
@@ -37,7 +37,7 @@ const Topic = styled.div`
   }
   ${({ theme }) => theme.breakpoint.xl} {
     height: 600px;
-    background-size: contain;
+    padding-top 0;
   }
 `
 const TopicTitle = styled.div`

--- a/packages/mirror-media-next/pages/section/topic.js
+++ b/packages/mirror-media-next/pages/section/topic.js
@@ -99,7 +99,7 @@ export async function getServerSideProps({ req }) {
       const annotatingError = errors.helpers.wrap(
         response.reason,
         'UnhandledError',
-        'Error occurs while getting section page data'
+        'Error occurs while getting section/topic page data'
       )
 
       console.log(

--- a/packages/mirror-media-next/pages/topic/[id].js
+++ b/packages/mirror-media-next/pages/topic/[id].js
@@ -1,0 +1,120 @@
+import errors from '@twreporter/errors'
+
+import client from '../../apollo/apollo-client'
+import axios from 'axios'
+
+import { fetchTopic } from '../../apollo/query/topics'
+import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import TopicList from '../../components/topic/list/topic-list'
+
+const RENDER_PAGE_SIZE = 12
+
+/**
+ * @typedef {import('../../components/topic/list/topic-list').SlideshowItem} SlideshowItem
+ * @typedef {import('../../components/topic/list/topic-list').Topic} Topic
+ */
+
+/**
+ * @param {Object} props
+ * @param {Topic} props.topic
+ * @param {SlideshowItem[]} props.slideshowData
+ * @returns
+ */
+export default function Topic({ topic, slideshowData }) {
+  switch (topic.type) {
+    case 'list':
+      return (
+        <TopicList
+          topic={topic}
+          renderPageSize={RENDER_PAGE_SIZE}
+          slideshowData={slideshowData}
+        />
+      )
+
+    default:
+      break
+  }
+}
+
+/**
+ * @type {import('next').GetServerSideProps}
+ */
+export async function getServerSideProps({ query, req }) {
+  const topicId = query.id
+  const traceHeader = req.headers?.['x-cloud-trace-context']
+  let globalLogFields = {}
+  if (traceHeader && !Array.isArray(traceHeader)) {
+    const [trace] = traceHeader.split('/')
+    globalLogFields[
+      'logging.googleapis.com/trace'
+    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
+  }
+
+  const responses = await Promise.allSettled([
+    client.query({
+      query: fetchTopic,
+      variables: {
+        topicFilter: { id: topicId },
+        postsFilter: { state: { equals: 'published' } },
+        postsOrderBy: [{ isFeatured: 'desc' }, { publishedDate: 'desc' }],
+        postsTake: RENDER_PAGE_SIZE * 2,
+        postsSkip: 0,
+      },
+    }),
+  ])
+
+  const handledResponses = responses.map((response) => {
+    if (response.status === 'fulfilled') {
+      return response.value.data
+    } else if (response.status === 'rejected') {
+      const { graphQLErrors, clientErrors, networkError } = response.reason
+      const annotatingError = errors.helpers.wrap(
+        response.reason,
+        'UnhandledError',
+        'Error occurs while getting topic page data'
+      )
+
+      console.log(
+        JSON.stringify({
+          severity: 'ERROR',
+          message: errors.helpers.printAll(
+            annotatingError,
+            {
+              withStack: true,
+              withPayload: true,
+            },
+            0,
+            0
+          ),
+          debugPayload: {
+            graphQLErrors,
+            clientErrors,
+            networkError,
+          },
+          ...globalLogFields,
+        })
+      )
+      return
+    }
+  })
+  /** @type {Topic} */
+  const topic = handledResponses[0]?.topic || {}
+  /** @type {SlideshowItem[]} */
+  let slideshowData = []
+  if (topic && topic.leading === 'slideshow') {
+    // mm 2.0 fetch way, need to be changed to query mm k6 directly
+    const { data } = await axios({
+      method: 'get',
+      url: 'http://104.199.190.189:8080/images?where=%7B%22topics%22%3A%7B%22%24in%22%3A%5B%225a30e6ae4be59110005c5e6b%22%5D%7D%7D&max_results=25',
+      timeout: 1500,
+    })
+    slideshowData = data?._items
+  }
+
+  const props = {
+    topic,
+    slideshowData,
+  }
+
+  return { props }
+}


### PR DESCRIPTION
# Feature
新增 topic 頁面，包含 list 和 group 類別。

## List type
### HeroImage (上半部)
List type 包含了兩種 leading (標頭)，分別是 slideshow 和 none (沒設置)，
兩者都是透過 custom CSS 設置 div.topic 的 background-image 來達到 heroImage 的設定，
並基於不同 topic 的圖片微調 CSS，
slideshow 的圖片 k3 的來源是先在圖片的 list 上設定 topic，接著透過 topic id 的方式來找到該 topic 所有的圖片，
如果圖片上的 keywords 欄位有設置 `@-` 開頭的字串，就代表該 slideshow 在呈現圖片時需要以連結的方式呈現。
[slideshow 圖片範例](https://mirrormedia.tw/keystone/images/5fd9c4091b3e3a0f0032823d)

### Articles (下半部)
文章的方式較為單純，透過無線滾動把所有該 topic 的文章 load 出來即可。

## Group type
### HeroImage (上半部)
Group type leading 一率是 none，
跟 list type 一樣，透過 custom CSS 來設置 heroImage 且不同的圖片有不同的 CSS

### Group Articles (下半部)
Topic list 中 related 的 posts 將會依照 Topic tags 來分組呈現，
因沒辦法簡單的實現各個 tag 先取得前幾篇 posts 所以目前的做法是在 server side 先一次取得所有的 posts，
讓頁面載入時每個 tag 都有對應的 posts 可以呈現，之後應視情況優化這段邏輯。

## TBD
- 因為 k6 的 Photo 並沒有搬到 topic 和 keywords 欄位，所以 slideshow 目前還只能放假資料，需要等欄位補齊後才能拿到真正的資料
- Topic 缺少了 og-image, og-description 和 og-title 
  - 導致沒辦法在 topic 頁附上正常的 og 資訊
  - /section/topic 頁面需要使用 og-image
- 因每個 topic 中的 custom CSS 都是基於舊的 topic 頁面來寫的，因此需要全面的檢查各個 topic 是否出現嚴重跑版的狀況，而目前因為 k3 -> k6 的 data migration 並不完全，沒辦法在 k6 上面全面檢查，需等資料搬完後再作進一步的檢查甚至修改 custom CSS
- Group posts fetch 優化，避免 server side 的資料超過[建議大小](https://nextjs.org/docs/messages/large-page-data)