### PR TITLE
feat(mm-next): add function for handle apollo error, and get trace log

### DIFF
--- a/packages/mirror-media-next/apollo/apollo-client.js
+++ b/packages/mirror-media-next/apollo/apollo-client.js
@@ -1,5 +1,5 @@
 import { ApolloClient, InMemoryCache } from '@apollo/client'
-
+import errors from '@twreporter/errors'
 import { API_HOST } from '../config/index.mjs'
 
 const client = new ApolloClient({
@@ -11,5 +11,58 @@ const client = new ApolloClient({
     },
   },
 })
+/**
+ * TODO: solve type problem in `queryOption?.query?.definitions[0]?.name?.value`, not just using `@ts-ignore`
+ * Function for handle apollo query request.
+ * Return result if request is succeed; throws an error if failed.
+ * Error is wrapped by `@twreporter/errors`
+ * @async
+ * @param {import('@apollo/client').QueryOptions} queryOption - Option for queries. See [doc](https://www.apollographql.com/docs/react/data/queries/) to get detail.
+ * @param {{ 'logging.googleapis.com/trace': string } | {}} [globalLogFields]
+ * - When an error is thrown, identify which request occurred error.
+ * - You can get the value by using function `getGlobalLogFields` in `utils/log.js`.
+ * @returns {Promise<import('@apollo/client').ApolloQueryResult<any>>}
+ * @throws {Error}
+ */
+export const clientQuery = async (queryOption, globalLogFields = {}) => {
+  try {
+    const result = await client.query(queryOption)
+    return result
+  } catch (err) {
+    /**
+     * @type {import('@apollo/client').ApolloError}
+     */
+    const { graphQLErrors, clientErrors, networkError } = err
 
+    const queryName =
+      // @ts-ignore
+      queryOption?.query?.definitions[0]?.name?.value || 'unknown query'
+
+    const annotatingError = errors.helpers.wrap(
+      err,
+      'ApolloError',
+      `Error occurs when using Apollo Client query ${queryName} `
+    )
+    throw new Error(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(
+          annotatingError,
+          {
+            withStack: true,
+            withPayload: true,
+          },
+          0,
+          0
+        ),
+        debugPayload: {
+          graphQLErrors,
+          clientErrors,
+          networkError,
+        },
+        ...globalLogFields,
+      })
+    )
+  }
+}
 export default client

--- a/packages/mirror-media-next/utils/log.js
+++ b/packages/mirror-media-next/utils/log.js
@@ -1,0 +1,25 @@
+import { GCP_PROJECT_ID } from '../config/index.mjs'
+
+/**
+ *  Follow [Writing structured logs](https://cloud.google.com/run/docs/logging#writing_structured_logs)
+ *  doc to do logging.
+ *
+ *  @param {import('http').IncomingMessage} req
+ *  @param {string} [projectId]
+ *  @return {Object}
+ */
+function getGlobalLogFields(req, projectId = GCP_PROJECT_ID) {
+  const headers = req?.headers
+  const traceHeader = headers?.['x-cloud-trace-context']
+  const globalLogFields = {}
+  if (traceHeader && !Array.isArray(traceHeader)) {
+    const [trace] = traceHeader.split('/')
+    globalLogFields[
+      'logging.googleapis.com/trace'
+    ] = `projects/${projectId}/traces/${trace}`
+  }
+
+  return globalLogFields
+}
+
+export { getGlobalLogFields }


### PR DESCRIPTION
## Notable Change
1. 依據之前PR #91 的討論，新增一個自訂函式`clientQuery`，使用該函式可以傳入Apollo query相關的option，並會在成功時回傳結果；失敗的話則會拋出錯誤，該錯誤會透過套件`@twreporter/errors`進行包裝，以符合gcp logging所需要的格式。
2. 新增一函式，用於取得trace log。

## Todo & need discussion
有幾個問題請教跟討論：
1. 目前`clientQuery`只會傳入兩個參數`queryOption`、`globalLogFields`。但我在想是否需要傳入其他參數，讓拋出錯誤時帶的資訊更清楚？比如說可以傳入`errorServerity`，讓[`serverity`](https://github.com/mirror-media/Adam/pull/162/commits/e1d3bf9c387b72577741f0bf102a0461d1ad1644#diff-8a4e57544f0d63865e9e66f56d473ebe0a6d8770547d136b48f61a9e8a109ce5R48)不會只是`ERROR`，而是可以有其他選項。但這部分我不太確定大家的需求為何，想要看到什麼樣的錯誤資訊，所以想跟其他人討論一下。

3. 有一個typescript error我目前解不出來，不知道有沒有遇過類似的問題，以及要如何解掉：

    由於參數`queryOption`，我將其type指定為`apollo/client的QueryOptions`（這是參考原本client.query的type），但是這樣會造成[`queryOption?.query?.definitions[0]?.name?.value`](https://github.com/mirror-media/Adam/pull/162/commits/e1d3bf9c387b72577741f0bf102a0461d1ad1644#diff-8a4e57544f0d63865e9e66f56d473ebe0a6d8770547d136b48f61a9e8a109ce5R39)會產生以下錯誤：
    ```
      Property 'name' does not exist on type 'DefinitionNode'.
      Property 'name' does not exist on type 'SchemaDefinitionNode'.
    ```
    
    而`definitions`的type為
    ```
    export interface DocumentNode {
      readonly kind: Kind.DOCUMENT;
      readonly loc?: Location;
      readonly definitions: ReadonlyArray<DefinitionNode>;
    }
    
    export declare type DefinitionNode =
      | ExecutableDefinitionNode
      | TypeSystemDefinitionNode
      | TypeSystemExtensionNode;
    ```
    我曾經嘗試過將definition的type指定為別的type，比如說
    ```
        /**
         * @type {Readonly<import('graphql').ExecutableDefinitionNode[]>}
         */
        const def = queryOption?.query?.definitions
    ```
    但這是無效的做法。目前解不太出來，所以暫時以ts-ignore忽略這個錯誤。