### PR TITLE
feat(mm-next/story): render different components based on story style

### DIFF
--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -346,7 +346,7 @@ const DivideLine = styled.div`
  * @param {{postData: PostData}} param
  * @returns {JSX.Element}
  */
-export default function StoryNormalType({ postData }) {
+export default function StoryNormalStyle({ postData }) {
   const {
     title = '',
     slug = '',

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -80,6 +80,9 @@ const PC_HD_Advertisement = styled(MockAdvertisement)`
   display: none;
   margin: 24px auto;
   text-align: center;
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: block;
+  }
 `
 const PC_R1_Advertisement = styled(MockAdvertisement)`
   display: none;
@@ -124,13 +127,16 @@ const Title = styled.h1`
   }
 `
 const Main = styled.main`
+  margin: 20px auto 0;
+  width: 100%;
+  height: auto;
+  max-width: 1200px;
   padding: 0 20px;
-  margin-top: 20px;
   ${({ theme }) => theme.breakpoint.md} {
     padding: 0 64px;
   }
   ${({ theme }) => theme.breakpoint.xl} {
-    margin-top: 24px;
+    margin: 24px auto 0;
     display: flex;
     flex-direction: row;
     align-items: start;

--- a/packages/mirror-media-next/components/story/photography/index.js
+++ b/packages/mirror-media-next/components/story/photography/index.js
@@ -1,0 +1,3 @@
+export default function StoryPhotographyStyle() {
+  return <div>這是photography版型</div>
+}

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -1,0 +1,3 @@
+export default function StoryPremiumStyle() {
+  return <div>這是Premium版型</div>
+}

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -1,0 +1,3 @@
+export default function StoryWideStyle({ test }) {
+  return <div>這是wide版型: {test}</div>
+}

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -1,21 +1,33 @@
 //TODO: add component to add html head dynamically, not jus write head in every pag
-
+import { useState, useEffect } from 'react'
 import client from '../../apollo/apollo-client'
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
 import Head from 'next/head'
+import dynamic from 'next/dynamic'
+
 import { fetchPostBySlug } from '../../apollo/query/posts'
-import StoryNormalType from '../../components/story/normal'
+import StoryNormalStyle from '../../components/story/normal'
+
+const StoryWideStyle = dynamic(() => import('../../components/story/wide'))
+const StoryPhotographyStyle = dynamic(() =>
+  import('../../components/story/photography')
+)
+const StoryPremiumStyle = dynamic(() =>
+  import('../../components/story/premium')
+)
 
 /**
  * @typedef {import('../../components/story/normal').PostData} PostData
  */
 
-const StoryContainer = styled.div`
-  margin: 0 auto;
+//Todo: adjust height, make it not to scroll when loading
+const MockLoading = styled.div`
   width: 100%;
-  height: auto;
-  max-width: 1200px;
+  height: 100vh;
+  background-color: pink;
+  text-align: center;
+  font-size: 32px;
 `
 
 /**
@@ -25,6 +37,31 @@ const StoryContainer = styled.div`
  * @returns {JSX.Element}
  */
 export default function Story({ postData }) {
+  const [storyStyle, setStoryStyle] = useState(null)
+
+  const getRenderUi = () => {
+    switch (storyStyle) {
+      case 'style-normal':
+        return <StoryNormalStyle postData={postData} />
+      case 'style-wide':
+        return <StoryWideStyle test={'我是test的字串'} />
+      case 'style-photography':
+        return <StoryPhotographyStyle />
+      case 'style-premium':
+        return <StoryPremiumStyle />
+      default:
+        return <StoryNormalStyle postData={postData} />
+    }
+  }
+  const jsx = getRenderUi()
+
+  //mock for process of changing article type
+  useEffect(() => {
+    const time1 = setTimeout(() => {
+      setStoryStyle('style-normal')
+    }, 1000)
+    return () => clearTimeout(time1)
+  }, [])
   const { title = '' } = postData
 
   const headJsx = (
@@ -36,10 +73,8 @@ export default function Story({ postData }) {
   return (
     <>
       {headJsx}
-
-      <StoryContainer>
-        <StoryNormalType postData={postData}></StoryNormalType>
-      </StoryContainer>
+      {!storyStyle && <MockLoading>Loading...</MockLoading>}
+      <div style={{ display: `${storyStyle ? 'block' : 'none'}` }}>{jsx}</div>
     </>
   )
 }


### PR DESCRIPTION
## Notable change
1. 調整story頁邏輯，於client side才會顯示對應版型的元件。
2. 使用nextjs `dynamic`，動態載入對應版型的元件，減少頁面初載入所需時間。
3. 目前僅使用useEffect模擬切換版型的過程，未來將新增一函式，以判斷所需要顯示的版型為何。