### PR TITLE
feat(mm-next/story): add component for render wide layout in story page

### DIFF
--- a/packages/mirror-media-next/components/story/normal/article-content.js
+++ b/packages/mirror-media-next/components/story/normal/article-content.js
@@ -1,8 +1,5 @@
 import styled from 'styled-components'
-import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
-const { DraftRenderer, hasContentInRawContentBlock, removeEmptyContentBlock } =
-  MirrorMedia
-
+import DraftRenderBlock from '../shared/draft-renderer-block'
 /**
  * @typedef {import('../../../type/draft-js').Draft} Content
  */
@@ -23,17 +20,11 @@ const Wrapper = styled.section`
 export default function ArticleContent({
   content = { blocks: [], entityMap: {} },
 }) {
-  const shouldRenderContent = hasContentInRawContentBlock(content)
-  let contentJsx = null
-
-  if (shouldRenderContent) {
-    const contentWithRemovedEmptyBlock = removeEmptyContentBlock(content)
-    contentJsx = (
-      <Wrapper>
-        <DraftRenderer rawContentBlock={contentWithRemovedEmptyBlock} />
-      </Wrapper>
-    )
-  }
-
-  return <>{contentJsx}</>
+  return (
+    <DraftRenderBlock
+      rawContentBlock={content}
+      contentLayout="normal"
+      wrapper={(children) => <Wrapper>{children}</Wrapper>}
+    />
+  )
 }

--- a/packages/mirror-media-next/components/story/normal/brief.js
+++ b/packages/mirror-media-next/components/story/normal/brief.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
-import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
-const { DraftRenderer, hasContentInRawContentBlock } = MirrorMedia
+import DraftRenderBlock from '../shared/draft-renderer-block'
+
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
  */
@@ -48,12 +48,13 @@ export default function ArticleBrief({
   brief = { blocks: [], entityMap: {} },
   sectionSlug = '',
 }) {
-  const shouldRenderBrief = hasContentInRawContentBlock(brief)
   return (
-    shouldRenderBrief && (
-      <BriefContainer sectionSlug={sectionSlug}>
-        <DraftRenderer rawContentBlock={brief}></DraftRenderer>
-      </BriefContainer>
-    )
+    <DraftRenderBlock
+      rawContentBlock={brief}
+      contentLayout="normal"
+      wrapper={(children) => (
+        <BriefContainer sectionSlug={sectionSlug}>{children}</BriefContainer>
+      )}
+    />
   )
 }

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -413,7 +413,7 @@ export default function StoryNormalStyle({ postData }) {
         url: URL_STATIC_POPULAR_NEWS,
         timeout: API_TIMEOUT,
       })
-      return data.filter((data) => data)
+      return data.filter((data) => data).slice(0.6)
     } catch (err) {
       return []
     }

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -17,6 +17,7 @@ import MagazineInviteBanner from '../../../components/story/shared/magazine-invi
 import RelatedArticleList from '../../../components/story/normal/related-article-list'
 import ArticleContent from './article-content'
 import HeroImageAndVideo from './hero-image-and-video'
+import Divider from '../shared/divider'
 import {
   transformTimeDataIntoDotFormat,
   sortArrayWithOtherArrayId,
@@ -328,19 +329,7 @@ const AdvertisementDableMobile = styled(AdvertisementDable)`
     width: 640px;
   }
 `
-const DivideLine = styled.div`
-  background-color: #000000;
-  width: 208px;
-  height: 2px;
-  margin: 32px auto 36px;
-  ${({ theme }) => theme.breakpoint.md} {
-    width: 100%;
-    margin: 36px auto;
-  }
-  ${({ theme }) => theme.breakpoint.xl} {
-    display: none;
-  }
-`
+
 /**
  *
  * @param {{postData: PostData}} param
@@ -545,7 +534,7 @@ export default function StoryNormalStyle({ postData }) {
             height="600px"
             className="ad"
           ></PC_R2_Advertisement>
-          <DivideLine />
+          <Divider />
           <AsideArticleList
             heading="熱門文章"
             fetchArticle={handleFetchPopularNews}

--- a/packages/mirror-media-next/components/story/shared/divider.js
+++ b/packages/mirror-media-next/components/story/shared/divider.js
@@ -1,0 +1,21 @@
+import styled from 'styled-components'
+const DivideLine = styled.hr`
+  background-color: #000000;
+  width: 208px;
+  height: 2px;
+  margin: 32px auto 36px;
+  ${({ theme }) => theme.breakpoint.md} {
+    width: 100%;
+    margin: 36px auto;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
+  }
+`
+/**
+ * For divide two article-list
+ * @returns {JSX.Element}
+ */
+export default function Divider() {
+  return <DivideLine />
+}

--- a/packages/mirror-media-next/components/story/shared/donate-banner.js
+++ b/packages/mirror-media-next/components/story/shared/donate-banner.js
@@ -37,10 +37,15 @@ const DonateLinkInBanner = styled(DonateLink)`
     width: 140px;
   }
 `
-
-export default function DonateBanner() {
+/**
+ *
+ * @param {Object} props
+ * @param {string} [props.className]
+ * @returns {JSX.Element}
+ */
+export default function DonateBanner({ className }) {
   return (
-    <Container>
+    <Container className={className}>
       <p className="title">小心意大意義，小額贊助鏡週刊！</p>
 
       <DonateLinkInBanner />

--- a/packages/mirror-media-next/components/story/shared/draft-renderer-block.js
+++ b/packages/mirror-media-next/components/story/shared/draft-renderer-block.js
@@ -1,0 +1,46 @@
+import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
+const { DraftRenderer, hasContentInRawContentBlock, removeEmptyContentBlock } =
+  MirrorMedia
+
+/**
+ * @callback WrapperFunction
+ * @param {JSX.Element} children - The React element to wrap.
+ * @returns {JSX.Element} The wrapped React element.
+ */
+
+/**
+ * Component for render blocks of draft.js
+ * We use package `@mirrormedia/draft-renderer` to render the block of draft.js
+ * @param {Object} props
+ * @param {import('../../../type/draft-js').Draft} props.rawContentBlock - The blocks of draft.js we want to render.
+ * @param { 'normal' | 'wide' | 'photography' | 'premium' } [props.contentLayout]
+ * - Which layout we want to render.
+ * - Different layout will affect the style of blocks.
+ * - Optional, default value is `normal`
+ * @param {WrapperFunction} [props.wrapper]
+ * - The function to wrap all blocks, you can use it to put all blocks in a jsx element.
+ * - Optional, default value is `(children) => <>{children}</>`.
+ * @returns  {JSX.Element}
+ */
+export default function DraftRenderBlock({
+  rawContentBlock = { blocks: [], entityMap: {} },
+  contentLayout = 'normal',
+  wrapper = (children) => <>{children}</>,
+}) {
+  const draftWrapper = wrapper || ((children) => <>{children}</>)
+  const shouldRenderDraft = hasContentInRawContentBlock(rawContentBlock)
+  let draftJsx = null
+
+  if (shouldRenderDraft) {
+    const contentWithRemovedEmptyBlock =
+      removeEmptyContentBlock(rawContentBlock)
+    draftJsx = draftWrapper(
+      <DraftRenderer
+        rawContentBlock={contentWithRemovedEmptyBlock}
+        contentLayout={contentLayout}
+      />
+    )
+  }
+
+  return <>{draftJsx}</>
+}

--- a/packages/mirror-media-next/components/story/wide/aside-article-list.js
+++ b/packages/mirror-media-next/components/story/wide/aside-article-list.js
@@ -1,0 +1,269 @@
+//TODOs:
+// 1. add loading UI
+// 2. adjust desktop style
+import Link from 'next/link'
+import styled from 'styled-components'
+import { useEffect, useState, useRef, useCallback } from 'react'
+import { getArticleHref } from '../../../utils'
+import Image from '@readr-media/react-image'
+
+/**
+ * @typedef {import('../../../type/theme').Theme} Theme
+ */
+
+/** @typedef {import('../../../apollo/fragments/post').AsideListingPost} ArticleData */
+
+const Wrapper = styled.section`
+  margin: 24px auto 0;
+  width: 100%;
+  max-width: 618px;
+`
+const Heading = styled.h2`
+  text-align: center;
+  color: ${({ theme, color }) => theme.color.brandColor[color]};
+  font-size: 21px;
+  line-height: 1.5;
+  ${({ theme }) => theme.breakpoint.md} {
+    text-align: left;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    background-color: ${
+      /**
+       * @param {Object} props
+       * @param {Theme} props.theme
+       */
+      ({ theme }) => theme.color.brandColor.darkBlue
+    };
+    border: 1px solid #dedede;
+    font-size: 18px;
+    color: #fff;
+    padding: 8px 0 8px 20px;
+  }
+`
+
+const articleHeightMobile = 254 //px
+const articleHeightTablet = 177 //px
+const articleHeightDesktop = 80 //px
+const articleMarginBottomMobile = 20 //px
+const articleMarginBottomTablet = 36 //px
+const ArticleWrapper = styled.ul`
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+  min-height: ${
+    /**
+     *
+     * @param {Object} param
+     * @param {number} param.renderAmount
+     */
+    ({ renderAmount }) =>
+      `calc(${
+        renderAmount * articleHeightMobile
+      }px + ${articleMarginBottomMobile}px * ${renderAmount - 1}) `
+  };
+  ${({ theme }) => theme.breakpoint.md} {
+    min-height: ${({ renderAmount }) =>
+      `calc(${
+        renderAmount * articleHeightTablet
+      }px + ${articleMarginBottomTablet}px * ${renderAmount - 1}) `};
+    margin-bottom: ${`${articleMarginBottomTablet}px`};
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    border: 1px solid #dedede;
+    padding: 20.5px 20px;
+    width: 100%;
+    min-height: ${({ renderAmount }) =>
+      // 20.5px is padding-top and padding-bottom of articleWrapper
+      `calc(20.5px + 20.5px + ${
+        renderAmount * articleHeightDesktop
+      }px + ${articleMarginBottomTablet}px * ${renderAmount - 1}) `};
+    height: fit-content;
+  }
+`
+const Article = styled.figure`
+  display: flex;
+  flex-direction: column;
+  max-width: 276px;
+  margin: 0 auto ${`${articleMarginBottomMobile}px`} auto;
+
+  .article-image {
+    height: 184px;
+  }
+  ${({ theme }) => theme.breakpoint.md} {
+    flex-direction: row;
+    height: ${`${articleHeightTablet}px`};
+    max-width: 100%;
+    justify-content: space-between;
+    margin: 0 auto ${`${articleMarginBottomTablet}px`} 0;
+    .article-image {
+      height: 100%;
+      min-width: 266px;
+      max-width: 266px;
+      margin-right: 28px;
+    }
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    height: ${`${articleHeightDesktop}px`};
+    flex-direction: ${
+      /**
+       * @param {Object} props
+       * @param {boolean} props.shouldReverseOrder
+       */
+      ({ shouldReverseOrder }) => (shouldReverseOrder ? 'row-reverse' : 'row')
+    };
+    /* gap: 12px; */
+    .article-image {
+      min-width: 120px;
+      img {
+        width: 100%;
+        height: 100%;
+      }
+    }
+  }
+`
+const FigureCaption = styled.figcaption`
+  width: 100%;
+`
+
+const Title = styled.span`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  color: ${({ theme, color }) => theme.color.brandColor[color]};
+  font-size: 18px;
+  line-height: 1.5;
+  font-weight: 400;
+  margin-top: 16px;
+  height: 54px;
+  ${({ theme }) => theme.breakpoint.md} {
+    font-size: 20px;
+    line-height: 32px;
+    margin-top: 0;
+    height: auto;
+    -webkit-line-clamp: 5;
+    height: 100%;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin-top: 8px;
+    text-align: left;
+    width: 100%;
+    font-size: 16px;
+    line-height: 1.5;
+
+    font-weight: 600;
+    color: ${
+      /**
+       * @param {Object} props
+       * @param {Theme} props.theme
+       */
+      ({ theme }) => theme.color.brandColor.darkBlue
+    };
+
+    -webkit-line-clamp: 2;
+  }
+`
+
+const Loading = styled.div`
+  height: 500px;
+  margin: auto;
+  width: 100%;
+  background-color: pink;
+`
+
+/**
+ *
+ * @param {Object} props
+ * @param {string} props.heading - heading of this components, showing user what kind of news is
+ * @param {boolean} props.shouldReverseOrder
+ * - control the css layout of article.
+ * - If is true, image of article should display at right, title and label should display at left.
+ * - If is false, image of article should display at left, title and label should display at right.
+ * optional, default value is `false`.
+ * @param {()=>Promise<ArticleData[] | []>} props.fetchArticle
+ * - A Promise base function for fetching article.
+ * - If fulfilled, it will return a array of object, which item is a article.
+ * - If rejected, it will return an empty array
+ * @param {number} [props.renderAmount]
+ * - a number of article we want to render, it will determine the height of `ArticleWrapper` to prevent Cumulative Layout Shift (CLS) problem after article is loaded.
+ * @returns {JSX.Element}
+ */
+export default function AsideArticleList({
+  heading = '',
+  shouldReverseOrder = false,
+  fetchArticle,
+  renderAmount = 6,
+}) {
+  const wrapperRef = useRef(null)
+  const [item, setItem] = useState([])
+  const [isLoaded, setIsLoaded] = useState(false)
+  const handleLoadMore = useCallback(() => {
+    fetchArticle().then((articles) => {
+      if (articles.length && Array.isArray(articles)) {
+        setItem(articles)
+        setIsLoaded(true)
+      } else {
+        setIsLoaded(true)
+      }
+    })
+  }, [fetchArticle])
+
+  useEffect(() => {
+    let callback = (entries, observer) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          if (isLoaded) {
+            observer.unobserve(entry.target)
+          } else {
+            handleLoadMore()
+          }
+        }
+      })
+    }
+    const observer = new IntersectionObserver(callback, {
+      root: null,
+      rootMargin: '0px',
+      threshold: 0,
+    })
+    observer.observe(wrapperRef.current)
+
+    return () => observer.disconnect()
+  }, [isLoaded, handleLoadMore])
+  const newsJsx = item.map((item) => {
+    const articleHref = getArticleHref(item.slug, item.style, undefined)
+    return (
+      <li key={item.id}>
+        <Article shouldReverseOrder={shouldReverseOrder}>
+          <Link href={articleHref} target="_blank" className="article-image">
+            <Image
+              images={item?.heroImage?.resized}
+              alt={item.title}
+              loadingImage={'/images/loading.gif'}
+              defaultImage={'/images/default-og-img.png'}
+              rwd={{ mobile: '276px', tablet: '266px', desktop: '120px' }}
+            />
+          </Link>
+
+          <FigureCaption>
+            <Link href={articleHref} target="_blank">
+              <Title color={heading === '熱門文章' ? 'darkBlue' : 'gray'}>
+                {item.title}
+              </Title>
+            </Link>
+          </FigureCaption>
+        </Article>
+      </li>
+    )
+  })
+
+  return (
+    <Wrapper>
+      <Heading color={heading === '熱門文章' ? 'darkBlue' : 'gray'}>
+        {heading}
+      </Heading>
+      <ArticleWrapper renderAmount={renderAmount} ref={wrapperRef}>
+        {isLoaded ? newsJsx : <Loading>Loading...</Loading>}
+      </ArticleWrapper>
+    </Wrapper>
+  )
+}

--- a/packages/mirror-media-next/components/story/wide/hero-image-and-video.js
+++ b/packages/mirror-media-next/components/story/wide/hero-image-and-video.js
@@ -1,0 +1,151 @@
+import CustomImage from '@readr-media/react-image'
+import styled from 'styled-components'
+/**
+ * @typedef {import('../../../apollo/fragments/post').HeroImage &
+ * {
+ *  id: string,
+ *  resized: {
+ *    original: string,
+ *    w480: string,
+ *    w800: string,
+ *    w1200: string,
+ *    w1600: string,
+ *    w2400: string
+ *  }
+ * } } HeroImage
+ */
+
+/**
+ * @typedef {import('../../../apollo/fragments/video').HeroVideo } HeroVideo
+ */
+
+const ArticleTitle = styled.h1`
+  color: rgba(0, 0, 0, 0.87);
+  font-size: 24px;
+  font-family: var(--notoserifTC-font);
+  font-weight: 700;
+  text-align: center;
+  margin: 20px 10px 0;
+
+  width: auto;
+  max-width: 800px;
+  ${({ theme }) => theme.breakpoint.md} {
+    position: absolute;
+    left: 50%;
+    bottom: 18px;
+    transform: translate(-50%, 0%);
+    color: rgba(255, 255, 255, 0.87);
+    margin: 0 auto;
+    width: 90vw;
+    font-size: 36px;
+    line-height: 52px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    bottom: 60px;
+    font-size: 40px;
+    line-height: 1.5;
+  }
+`
+const Wrapper = styled.section`
+  ${({ theme }) => theme.breakpoint.md} {
+    position: relative;
+  }
+`
+const Figure = styled.figure`
+  margin: 0 0 0;
+  height: 100vh;
+  background-color: #d9d9d9;
+  position: relative;
+
+  video {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    object-position: center center;
+  }
+  .readr-media-react-image {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    object-position: center center;
+  }
+  ${({ theme }) => theme.breakpoint.md} {
+    margin: 0 0 0;
+
+    &::after {
+      content: ' ';
+      position: absolute;
+      display: block;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: linear-gradient(
+        0deg,
+        rgba(0, 0, 0, 0.15),
+        rgba(0, 0, 0, 0.15)
+      );
+    }
+  }
+`
+
+const HeroCaption = styled.figcaption`
+  display: none;
+`
+/**
+ *
+ * @param {Object} props
+ * @param {HeroImage | null} props.heroImage
+ * @param {HeroVideo | null} props.heroVideo
+ * @param {string} props.heroCaption
+ * @param {string} props.title
+ * @returns
+ */
+export default function HeroImageAndVideo({
+  heroImage = null,
+  heroVideo = null,
+  heroCaption = '',
+  title = '',
+}) {
+  const shouldShowHeroVideo = Boolean(heroVideo)
+  const shouldShowHeroImage = Boolean(!shouldShowHeroVideo && heroImage)
+  const heroJsx = () => {
+    if (shouldShowHeroVideo) {
+      return (
+        <video
+          preload="metadata"
+          controlsList="nodownload"
+          playsInline={true}
+          controls={true}
+          poster={heroVideo?.heroImage?.resized?.original}
+          src={heroVideo.urlOriginal}
+        />
+      )
+    } else if (shouldShowHeroImage) {
+      return (
+        <CustomImage
+          images={heroImage.resized}
+          loadingImage={'/images/loading@4x.gif'}
+          defaultImage={'/images/default-og-img.png'}
+          alt={heroCaption ? heroCaption : title}
+          objectFit={'cover'}
+          width={''}
+          height={''}
+          rwd={{ mobile: '100vw', default: '100vw' }}
+          priority={true}
+        />
+      )
+    }
+    return null
+  }
+
+  return (
+    <Wrapper>
+      <Figure>
+        {heroJsx()}
+        <HeroCaption>{title}</HeroCaption>
+      </Figure>
+      <ArticleTitle>{title}</ArticleTitle>
+    </Wrapper>
+  )
+}

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -11,7 +11,7 @@ import HeroImageAndVideo from './hero-image-and-video'
 import DonateBanner from '../shared/donate-banner'
 import RelatedArticleList from './related-article-list'
 import AsideArticleList from './aside-article-list'
-
+import Divider from '../shared/divider'
 import { fetchAsidePosts } from '../../../apollo/query/posts'
 
 /**
@@ -79,6 +79,7 @@ const Aside = styled.aside`
     margin-top: 64px;
   }
 `
+
 /**
  *
  * @param {Object} param
@@ -152,6 +153,13 @@ export default function StoryWideStyle({ postData }) {
         </ContentWrapper>
         <Aside>
           <RelatedArticleList relateds={relateds} />
+          <AsideArticleList
+            heading="最新文章"
+            fetchArticle={handleFetchLatestNews}
+            shouldReverseOrder={false}
+            renderAmount={6}
+          />
+          <Divider />
           <AsideArticleList
             heading="最新文章"
             fetchArticle={handleFetchLatestNews}

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -1,11 +1,13 @@
 import { useCallback } from 'react'
 import styled from 'styled-components'
+import axios from 'axios'
 import client from '../../../apollo/apollo-client'
 
 import {
   transformTimeDataIntoDotFormat,
   sortArrayWithOtherArrayId,
 } from '../../../utils'
+import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
 import DonateLink from '../shared/donate-link'
 import HeroImageAndVideo from './hero-image-and-video'
 import DonateBanner from '../shared/donate-banner'
@@ -131,6 +133,25 @@ export default function StoryWideStyle({ postData }) {
     }
   }, [section, slug])
 
+  /**
+   * @returns {Promise<any[] | []>}
+   */
+  const handleFetchPopularNews = async () => {
+    try {
+      /**
+       * @type {import('axios').AxiosResponse<any[] | []>}>}
+       */
+      const { data } = await axios({
+        method: 'get',
+        url: URL_STATIC_POPULAR_NEWS,
+        timeout: API_TIMEOUT,
+      })
+      return data.filter((data) => data).slice(0, 6)
+    } catch (err) {
+      return []
+    }
+  }
+
   return (
     <Main>
       <article>
@@ -161,8 +182,8 @@ export default function StoryWideStyle({ postData }) {
           />
           <Divider />
           <AsideArticleList
-            heading="最新文章"
-            fetchArticle={handleFetchLatestNews}
+            heading="熱門文章"
+            fetchArticle={handleFetchPopularNews}
             shouldReverseOrder={false}
             renderAmount={6}
           />

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -3,6 +3,7 @@ import { transformTimeDataIntoDotFormat } from '../../../utils'
 import DonateLink from '../shared/donate-link'
 import HeroImageAndVideo from './hero-image-and-video'
 import DonateBanner from '../shared/donate-banner'
+import RelatedArticleList from './related-article-list'
 /**
  * @typedef {import('../../../apollo/fragments/post').Post} PostData
  */
@@ -57,7 +58,17 @@ const StyledDonateBanner = styled(DonateBanner)`
     margin-right: auto;
   }
 `
-
+const Aside = styled.aside`
+  width: 100%;
+  max-width: 640px;
+  margin: 20px auto;
+  ${({ theme }) => theme.breakpoint.md} {
+    margin-top: 32px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin-top: 64px;
+  }
+`
 /**
  *
  * @param {Object} param
@@ -72,6 +83,7 @@ export default function StoryWideStyle({ postData }) {
     heroCaption = '',
     updatedAt = '',
     publishedDate = '',
+    relateds = [],
   } = postData
 
   const updatedAtFormatTime = transformTimeDataIntoDotFormat(updatedAt)
@@ -96,6 +108,9 @@ export default function StoryWideStyle({ postData }) {
 
           <StyledDonateBanner />
         </ContentWrapper>
+        <Aside>
+          <RelatedArticleList relateds={relateds} />
+        </Aside>
       </article>
     </Main>
   )

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -1,3 +1,77 @@
-export default function StoryWideStyle({ test }) {
-  return <div>這是wide版型: {test}</div>
+import styled from 'styled-components'
+import { transformTimeDataIntoDotFormat } from '../../../utils'
+import DonateLink from '../shared/donate-link'
+import HeroImageAndVideo from './hero-image-and-video'
+
+/**
+ * @typedef {import('../../../apollo/fragments/post').Post} PostData
+ */
+
+const Main = styled.main`
+  margin: auto;
+  width: 100%;
+  height: 100vh;
+  background-color: white;
+`
+const StyledDonateLink = styled(DonateLink)`
+  margin: 20px auto 0;
+  ${({ theme }) => theme.breakpoint.md} {
+    margin: 12px auto 0;
+  }
+`
+const DateWrapper = styled.div`
+  margin-top: 16px;
+  ${({ theme }) => theme.breakpoint.md} {
+    margin-top: 20px;
+  }
+`
+const Date = styled.div`
+  width: fit-content;
+  height: auto;
+  font-size: 14px;
+  line-height: 1;
+  color: rgba(0, 0, 0, 0.5);
+  margin: 8px auto 0;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    line-height: 1.8;
+    margin: 0 auto;
+  }
+`
+
+/**
+ *
+ * @param {Object} param
+ * @param {PostData} param.postData
+ * @returns
+ */
+export default function StoryWideStyle({ postData }) {
+  const {
+    title = '',
+    heroImage = null,
+    heroVideo = null,
+    heroCaption = '',
+    updatedAt = '',
+    publishedDate = '',
+  } = postData
+
+  const updatedAtFormatTime = transformTimeDataIntoDotFormat(updatedAt)
+  const publishedDateFormatTime = transformTimeDataIntoDotFormat(publishedDate)
+  return (
+    <Main>
+      <article>
+        <HeroImageAndVideo
+          heroImage={heroImage}
+          heroVideo={heroVideo}
+          heroCaption={heroCaption}
+          title={title}
+        />
+        <DateWrapper>
+          <Date>更新時間 {updatedAtFormatTime}</Date>
+          <Date>發布時間 {publishedDateFormatTime}</Date>
+        </DateWrapper>
+        <StyledDonateLink />
+      </article>
+    </Main>
+  )
 }

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -49,6 +49,14 @@ const ContentWrapper = styled.section`
     border-bottom: 1px black solid;
   }
 `
+const StyledDonateBanner = styled(DonateBanner)`
+  margin-left: 10px;
+  margin-right: 10px;
+  ${({ theme }) => theme.breakpoint.md} {
+    margin-left: auto;
+    margin-right: auto;
+  }
+`
 
 /**
  *
@@ -85,9 +93,8 @@ export default function StoryWideStyle({ postData }) {
           <StyledDonateLink />
           <div>這是前言</div>
           <div>這是內文</div>
-          <div>
-            <DonateBanner />
-          </div>
+
+          <StyledDonateBanner />
         </ContentWrapper>
       </article>
     </Main>

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import { transformTimeDataIntoDotFormat } from '../../../utils'
 import DonateLink from '../shared/donate-link'
 import HeroImageAndVideo from './hero-image-and-video'
-
+import DonateBanner from '../shared/donate-banner'
 /**
  * @typedef {import('../../../apollo/fragments/post').Post} PostData
  */
@@ -38,6 +38,17 @@ const Date = styled.div`
     margin: 0 auto;
   }
 `
+const ContentWrapper = styled.section`
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+  padding-bottom: 20px;
+  border: none;
+  ${({ theme }) => theme.breakpoint.md} {
+    padding-bottom: 32px;
+    border-bottom: 1px black solid;
+  }
+`
 
 /**
  *
@@ -66,11 +77,18 @@ export default function StoryWideStyle({ postData }) {
           heroCaption={heroCaption}
           title={title}
         />
-        <DateWrapper>
-          <Date>更新時間 {updatedAtFormatTime}</Date>
-          <Date>發布時間 {publishedDateFormatTime}</Date>
-        </DateWrapper>
-        <StyledDonateLink />
+        <ContentWrapper>
+          <DateWrapper>
+            <Date>更新時間 {updatedAtFormatTime}</Date>
+            <Date>發布時間 {publishedDateFormatTime}</Date>
+          </DateWrapper>
+          <StyledDonateLink />
+          <div>這是前言</div>
+          <div>這是內文</div>
+          <div>
+            <DonateBanner />
+          </div>
+        </ContentWrapper>
       </article>
     </Main>
   )

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import styled from 'styled-components'
 import axios from 'axios'
 import client from '../../../apollo/apollo-client'
+import DraftRenderBlock from '../shared/draft-renderer-block'
 
 import {
   transformTimeDataIntoDotFormat,
@@ -53,18 +54,31 @@ const Date = styled.div`
 `
 const ContentWrapper = styled.section`
   width: 100%;
-  max-width: 640px;
+  max-width: 680px;
   margin: 0 auto;
-  padding-bottom: 20px;
+  padding: 0 20px 20px;
   border: none;
+
+  .content {
+    width: 100%;
+    margin: 20px auto 0;
+    max-width: 640px;
+  }
+
   ${({ theme }) => theme.breakpoint.md} {
-    padding-bottom: 32px;
+    padding: 0 0 32px;
+
     border-bottom: 1px black solid;
+    .content {
+      margin: 40px auto 0;
+    }
   }
 `
 const StyledDonateBanner = styled(DonateBanner)`
   margin-left: 10px;
   margin-right: 10px;
+  width: 100%;
+  max-width: 640px;
   ${({ theme }) => theme.breakpoint.md} {
     margin-left: auto;
     margin-right: auto;
@@ -100,8 +114,9 @@ export default function StoryWideStyle({ postData }) {
     manualOrderOfSections = [],
     relateds = [],
     slug = '',
+    content = null,
+    brief = null,
   } = postData
-
   const updatedAtFormatTime = transformTimeDataIntoDotFormat(updatedAt)
   const publishedDateFormatTime = transformTimeDataIntoDotFormat(publishedDate)
   const sectionsWithOrdered =
@@ -167,9 +182,10 @@ export default function StoryWideStyle({ postData }) {
             <Date>發布時間 {publishedDateFormatTime}</Date>
           </DateWrapper>
           <StyledDonateLink />
-          <div>這是前言</div>
-          <div>這是內文</div>
-
+          <section className="content">
+            <DraftRenderBlock rawContentBlock={brief} contentLayout="wide" />
+            <DraftRenderBlock rawContentBlock={content} contentLayout="wide" />
+          </section>
           <StyledDonateBanner />
         </ContentWrapper>
         <Aside>

--- a/packages/mirror-media-next/components/story/wide/related-article-list.js
+++ b/packages/mirror-media-next/components/story/wide/related-article-list.js
@@ -1,0 +1,202 @@
+//TODO: insert real Advertisement, not just fake
+
+import styled from 'styled-components'
+import Image from '@readr-media/react-image'
+import Link from 'next/link'
+
+/**
+ * @typedef {import('../../../apollo/fragments/post').HeroImage &
+ * {
+ *  id: string,
+ *  resized: {
+ *    original: string,
+ *    w480: string,
+ *    w800: string,
+ *    w1200: string,
+ *    w1600: string,
+ *    w2400: string
+ *  }
+ * } } HeroImage
+ */
+
+/**
+ * @typedef {import('../../../apollo/fragments/post').Related[]} Relateds
+ */
+
+const Wrapper = styled.section`
+  margin: 0 auto;
+  h2 {
+    font-size: 21px;
+    line-height: 1.5;
+    margin: 0 auto;
+    font-weight: 600;
+    text-align: center;
+  }
+  ${({ theme }) => theme.breakpoint.md} {
+    h2 {
+      display: none;
+    }
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    h2 {
+      font-weight: 500;
+
+      display: block;
+      font-size: 28px;
+    }
+  }
+`
+const ArticleWrapper = styled.ul`
+  margin: 16px auto 0px;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    background: transparent;
+    margin: 0px 11px 0px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 36px auto 0px;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+`
+
+const Article = styled.figure`
+  max-width: 280px;
+  margin: 0 auto 24px;
+
+  font-size: 18px;
+  line-height: 1.5;
+  color: rgba(0, 0, 0, 0.87);
+  font-weight: 400;
+  .article-image {
+    display: block;
+    height: 186.67px;
+  }
+  .article-title {
+    margin-top: 12px;
+  }
+
+  ${({ theme }) => theme.breakpoint.md} {
+    max-width: 100%;
+    height: 90px;
+    display: flex;
+    flex-direction: row-reverse;
+    justify-content: space-between;
+    color: #808080;
+    line-height: 1.3;
+    background-color: #eeeeee;
+    .article-image {
+      min-width: 90px;
+      max-width: 90px;
+      height: 100%;
+    }
+    .article-title {
+      margin-top: 0;
+      position: relative;
+      padding: 16px 0 0 25.75px;
+      &::before {
+        position: absolute;
+        content: '';
+        width: 7.72px;
+        height: 100%;
+        background-color: #808080;
+        left: 0;
+        top: 0;
+      }
+    }
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    height: fit-content;
+    width: 276px;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: center;
+    background-color: transparent;
+    color: rgba(0, 0, 0, 0.87);
+    font-weight: 500;
+    font-family: var(--notoserifTC-font);
+    line-height: 1.5;
+    margin-bottom: 36px;
+    .article-image {
+      display: block;
+      height: 186.67px;
+      width: 100%;
+      max-width: 276px;
+      min-width: 276px;
+    }
+    .article-title {
+      margin-top: 16px;
+      padding: 0;
+      &::before {
+        display: none;
+      }
+    }
+  }
+`
+
+const AdvertisementWrapper = styled.div`
+  height: 300px;
+  background-color: pink;
+  padding: 28px 0 10px;
+  ${({ theme }) => theme.breakpoint.md} {
+    padding: 20px 0 0;
+  }
+`
+
+/**
+ *
+ * @param {Object} props
+ * @param {Relateds} props.relateds
+ * @returns {JSX.Element}
+ */
+export default function RelatedArticleList({ relateds }) {
+  const relatedsArticleJsx = relateds.length ? (
+    <ArticleWrapper>
+      {relateds.map((related) => (
+        <li key={related.id}>
+          <Article>
+            <Link
+              href={`/story/${related.slug}`}
+              target="_blank"
+              className="article-image"
+            >
+              <Image
+                images={related.heroImage?.resized}
+                alt={related.title}
+                rwd={{
+                  mobile: '280px',
+                  tablet: '87px',
+                  laptop: '276px',
+                }}
+                width={'100%'}
+                height={'100%'}
+                defaultImage={'/images/default-og-img.png'}
+                loadingImage={'/images/loading.gif'}
+              />
+            </Link>
+
+            <figcaption className="article-title">
+              <Link href={`/story/${related.slug}`} target="_blank">
+                {related.title}
+              </Link>
+            </figcaption>
+          </Article>
+        </li>
+      ))}
+    </ArticleWrapper>
+  ) : null
+
+  return (
+    <Wrapper>
+      <h2>延伸閱讀</h2>
+      {relatedsArticleJsx}
+      <AdvertisementWrapper>
+        特企區塊施工中......
+        {/* micro ad */}
+        {/* popin */}
+      </AdvertisementWrapper>
+    </Wrapper>
+  )
+}

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",
-    "@mirrormedia/lilith-draft-renderer": "1.1.0-alpha.25",
+    "@mirrormedia/lilith-draft-renderer": "1.2.0-alpha.11",
     "@next/font": "^13.1.2",
     "@readr-media/react-image": "^1.5.1",
     "@svgr/webpack": "^6.3.1",

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -87,7 +87,7 @@ export default function Story({ postData }) {
       case 'style-normal':
         return <StoryNormalStyle postData={postData} />
       case 'style-wide':
-        return <StoryWideStyle test={'我是test的字串'} />
+        return <StoryWideStyle postData={postData} />
       case 'style-photography':
         return <StoryPhotographyStyle />
       case 'style-premium':

--- a/packages/mirror-media-next/styles/global-styles.js
+++ b/packages/mirror-media-next/styles/global-styles.js
@@ -10,7 +10,7 @@ const notosansTC = Noto_Sans_TC({
 })
 const notoserifTC = Noto_Serif_TC({
   subsets: ['latin'],
-  weight: ['500'],
+  weight: ['500', '700'],
 })
 
 export const GlobalStyles = createGlobalStyle`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,10 +1299,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@mirrormedia/lilith-draft-renderer@1.1.0-alpha.25":
-  version "1.1.0-alpha.25"
-  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.1.0-alpha.25.tgz#9893123b9cb97e362d3965b49ac04f9defdaadb5"
-  integrity sha512-+NyQR3nNe/Zm7ICmLJeB+XYvgXyGyroZGgf0A5BcRgt6iQJmPLXekR71bD0agHURfbf9HBv4gs6QXUqdt/OvoA==
+"@mirrormedia/lilith-draft-renderer@1.2.0-alpha.11":
+  version "1.2.0-alpha.11"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.11.tgz#84c10110ae32f5036d2d0568fc1f746118d30e8f"
+  integrity sha512-dtY5TlhYdpKucJQzDUCU3HEqKF1RSOb1bjuKeB9KSzZGXweDSjqrbJd0k14QbZZ3luJm58gbTwu331YQORZ9Tw==
   dependencies:
     "@readr-media/react-image" "^1.5.1"
     body-scroll-lock "3.1.5"


### PR DESCRIPTION
## Notable Change:
1. 更新套件版本 `@mirrormedia/lilith-draft-renderer`於`1.2.0-alpha.11`。
2. 新增story頁wide版型所需元件。
3. 調整story頁熱門文章邏輯，目前僅顯示前六筆資料。
4. 新增story頁共用元件[draft-renderer-block](https://github.com/mirror-media/Adam/pull/167/commits/3e37225e6bd57b38e3ae064a5d1e3f5a0d257dac)，用於render該版型的前言與內文。