### PR TITLE
feat(mm-next): add component `subtitle-navigator`

### DIFF
--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -4,6 +4,9 @@ import axios from 'axios'
 import client from '../../../apollo/apollo-client'
 import DraftRenderBlock from '../shared/draft-renderer-block'
 
+import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
+const { getContentBlocksH2H3 } = MirrorMedia
+
 import {
   transformTimeDataIntoDotFormat,
   sortArrayWithOtherArrayId,
@@ -168,6 +171,8 @@ export default function StoryWideStyle({ postData }) {
     }
   }
 
+  const h2AndH3Block = getContentBlocksH2H3(content)
+
   return (
     <Main>
       <article>
@@ -178,7 +183,9 @@ export default function StoryWideStyle({ postData }) {
           title={title}
         />
         <ContentWrapper>
-          <NavSubtitleNavigator></NavSubtitleNavigator>
+          <NavSubtitleNavigator
+            h2AndH3Block={h2AndH3Block}
+          ></NavSubtitleNavigator>
           <DateWrapper>
             <Date>更新時間 {updatedAtFormatTime}</Date>
             <Date>發布時間 {publishedDateFormatTime}</Date>

--- a/packages/mirror-media-next/components/story/wide/nav-subtitle-navigator.js
+++ b/packages/mirror-media-next/components/story/wide/nav-subtitle-navigator.js
@@ -7,6 +7,36 @@ const NavWrapper = styled.section`
   width: calc((100vw - 100%) / 2);
   height: 100%;
 `
+const NavItem = styled.li`
+  margin-bottom: 8px;
+  color: rgba(0, 0, 0, 0.87);
+  font-weight: 500;
+  cursor: pointer;
+  ${
+    /**
+     * @param {{headerType: 'header-two' | 'header-three'}} param
+     */
+    ({ headerType }) => {
+      switch (headerType) {
+        case 'header-two':
+          return `  
+        font-size: 18px;
+        line-height: 1.5;
+        `
+        case 'header-three':
+          return `
+        font-size: 14px;
+        line-height: 2;
+        `
+        default:
+          return `  
+        font-size: 18px;
+        line-height: 1.5;
+        `
+      }
+    }
+  }
+`
 const Nav = styled.nav`
   display: none;
   ${({ theme }) => theme.breakpoint.xl} {
@@ -18,51 +48,38 @@ const Nav = styled.nav`
     width: 168px;
     height: auto;
   }
-  li {
-    margin-bottom: 8px;
-    color: rgba(0, 0, 0, 0.87);
-    font-weight: 500;
-
-    &.h2 {
-      font-size: 18px;
-      line-height: 1.5;
-    }
-    &.h3 {
-      font-size: 14px;
-      line-height: 2;
-    }
-    &.active {
-      color: ${({ theme }) => theme.color.brandColor.darkBlue};
-      text-decoration: underline;
-    }
-  }
 `
 /**
  * TODO: add feature for scroll into certain subtitle
  * @returns {JSX.Element}
  */
-export default function NavSubtitleNavigator() {
+export default function NavSubtitleNavigator({ h2AndH3Block = [] }) {
+  const handleOnClick = (key) => {
+    const target = document.querySelector(`[data-offset-key*="${key}"]`)
+    if (!target) {
+      return
+    }
+    target.scrollIntoView({ behavior: 'smooth' })
+  }
+
   return (
     <NavWrapper>
-      <Nav>
-        <ul>
-          <li className="h2">
-            <p>堅持非營利　評價中肯鄉民擁戴</p>
-          </li>
-          <li className="h3 active">
-            <p>突然變殺人凶手　滿腹委屈</p>
-          </li>
-          <li className="h3">
-            <p>沈大俠有話直說　遭人誤解</p>
-          </li>
-          <li className="h3">
-            <p>工作中投射缺憾　渴望父愛</p>
-          </li>
-          <li className="h3">
-            <p>不再蹚司法渾水　專注醫療</p>
-          </li>
-        </ul>
-      </Nav>
+      {h2AndH3Block.length ? (
+        <Nav>
+          <ul>
+            {h2AndH3Block.map((item) => (
+              <NavItem
+                headerType={item.type}
+                key={item.key}
+                onClick={() => handleOnClick(item.key)}
+              >
+                {/* {item.text} */}
+                <a href={`#header-${item.key}`}>{item.text}</a>
+              </NavItem>
+            ))}
+          </ul>
+        </Nav>
+      ) : null}
     </NavWrapper>
   )
 }

--- a/packages/mirror-media-next/components/story/wide/nav-subtitle-navigator.js
+++ b/packages/mirror-media-next/components/story/wide/nav-subtitle-navigator.js
@@ -1,4 +1,9 @@
+import { useEffect, useState } from 'react'
 import styled from 'styled-components'
+
+/**
+ * @typedef {Pick<import('../../../type/draft-js').DraftBlock, 'key' | 'text' | 'type'> & { type: 'header-two' | 'header-three'}} H2AndH3Block
+ */
 
 const NavWrapper = styled.section`
   position: absolute;
@@ -14,7 +19,9 @@ const NavItem = styled.li`
   cursor: pointer;
   ${
     /**
-     * @param {{headerType: 'header-two' | 'header-three'}} param
+     * @param {Object} param
+     * @param {'header-two' | 'header-three'} param.headerType
+     * @param {boolean} param.isActive
      */
     ({ headerType }) => {
       switch (headerType) {
@@ -36,6 +43,13 @@ const NavItem = styled.li`
       }
     }
   }
+
+  ${({ isActive, theme }) =>
+    isActive &&
+    `
+    color: ${theme.color.brandColor.darkBlue};
+    text-decoration: underline;
+    `}
 `
 const Nav = styled.nav`
   display: none;
@@ -51,16 +65,90 @@ const Nav = styled.nav`
 `
 /**
  * TODO: add feature for scroll into certain subtitle
+ * @param {Object} props
+ * @param {H2AndH3Block[]} props.h2AndH3Block
  * @returns {JSX.Element}
  */
 export default function NavSubtitleNavigator({ h2AndH3Block = [] }) {
+  const [currentIndex, setCurrentIndex] = useState(undefined)
   const handleOnClick = (key) => {
     const target = document.querySelector(`[data-offset-key*="${key}"]`)
     if (!target) {
       return
     }
-    target.scrollIntoView({ behavior: 'smooth' })
+    const { top, height } = target.getBoundingClientRect()
+    const { scrollY, innerHeight } = window
+
+    const y = top + height * 0.5 + scrollY - innerHeight * 0.5
+    scrollTo({
+      top: y,
+      behavior: 'smooth',
+    })
   }
+
+  useEffect(() => {
+    let observer
+    if (h2AndH3Block.length) {
+      const targets = h2AndH3Block.map((item) =>
+        //TODO: use `forwardRef` to get ref of component which render article content, and querySelect element inside of it,
+        //not just use `document.body.querySelector`.
+        document.body.querySelector(`[data-offset-key*="${item.key}"]`)
+      )
+
+      /**
+       * An Array to keep track of which subtitle is currently visible on the viewport.
+       * Each object in the array has the following properties:
+       *   - key: the key of the subtitle
+       *   - isVisible: a boolean that indicates whether the subtitle is currently visible on the viewport
+       */
+      const visibleSubtitles = h2AndH3Block.map((item) => {
+        return {
+          key: item.key,
+          isIntersecting: false,
+        }
+      })
+      /**
+       * Updates the current subtitle index based on the changes of the visibility of the subtitles.
+       * @param {string} offsetKey - the offset key of the subtitle element
+       * @param {boolean} isIntersecting - a boolean that indicates whether the subtitle is currently visible on the viewport
+       */
+      const updateCurrentIndexIfVisible = (offsetKey, isIntersecting) => {
+        const item = visibleSubtitles.find((item) =>
+          offsetKey.includes(item.key)
+        )
+
+        if (item && item.isIntersecting !== isIntersecting) {
+          item.isIntersecting = isIntersecting
+          const lastIndex = visibleSubtitles.findLastIndex(
+            (item) => item.isIntersecting
+          )
+          if (lastIndex !== -1) {
+            const lastKey = visibleSubtitles[lastIndex].key
+            setCurrentIndex(lastKey)
+          }
+        }
+      }
+
+      const callback = (entries) => {
+        entries.forEach((entry) => {
+          updateCurrentIndexIfVisible(
+            entry.target.dataset.offsetKey,
+            entry.isIntersecting
+          )
+        })
+      }
+      observer = new IntersectionObserver(callback, {
+        threshold: 0.5,
+        rootMargin: '50% 0px -50% 0px',
+      })
+      targets.forEach((item) => observer.observe(item))
+    }
+    return () => {
+      if (observer) {
+        observer.disconnect()
+      }
+    }
+  }, [h2AndH3Block])
 
   return (
     <NavWrapper>
@@ -69,11 +157,13 @@ export default function NavSubtitleNavigator({ h2AndH3Block = [] }) {
           <ul>
             {h2AndH3Block.map((item) => (
               <NavItem
+                isActive={
+                  currentIndex ? currentIndex.includes(item.key) : false
+                }
                 headerType={item.type}
                 key={item.key}
                 onClick={() => handleOnClick(item.key)}
               >
-                {/* {item.text} */}
                 <a href={`#header-${item.key}`}>{item.text}</a>
               </NavItem>
             ))}

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",
-    "@mirrormedia/lilith-draft-renderer": "1.2.0-alpha.11",
+    "@mirrormedia/lilith-draft-renderer": "1.2.0-alpha.14",
     "@next/font": "^13.1.2",
     "@readr-media/react-image": "^1.5.1",
     "@svgr/webpack": "^6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,10 +1299,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@mirrormedia/lilith-draft-renderer@1.2.0-alpha.11":
-  version "1.2.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.11.tgz#84c10110ae32f5036d2d0568fc1f746118d30e8f"
-  integrity sha512-dtY5TlhYdpKucJQzDUCU3HEqKF1RSOb1bjuKeB9KSzZGXweDSjqrbJd0k14QbZZ3luJm58gbTwu331YQORZ9Tw==
+"@mirrormedia/lilith-draft-renderer@1.2.0-alpha.14":
+  version "1.2.0-alpha.14"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.14.tgz#fb0cad150b8f9d9422de90ebbb506d7da103cd26"
+  integrity sha512-LpJPkmo87P5Hp0A17H4zQ+dKlfG8oY5sQYhe17BEoK/jp8HI/5m9BiC7+xSizenuslcaYDM25ZdaOzX9HL3jUw==
   dependencies:
     "@readr-media/react-image" "^1.5.1"
     body-scroll-lock "3.1.5"


### PR DESCRIPTION
## Notable Change:
1. 新增元件`subtitle-navigator`。
2. 該元件共有三個功能：
   - 使用h2、h3的文字內容以及offsetKey，建立側欄索引。（該文字內容為透過`@mirrormedia/draft-renderer`中的utils函式`getContentBlocksH2H3`所取得。
   - 點擊索引，將滑動至對應的h2、h3小標。
   - 標記目前顯示的h2、h3小標，並顯示特殊樣式。
 