### PR TITLE
feat(mm-next/utils): adjust `transformTimeData`, return date of `UTC+8` timezone

### DIFF
--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -20,6 +20,7 @@
     "@twreporter/errors": "^1.1.2",
     "axios": "^1.2.0",
     "cors": "^2.8.5",
+    "dayjs": "^1.11.7",
     "graphql": "^16.6.0",
     "next": "^13.0.7",
     "react": "18.2.0",

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -1,3 +1,6 @@
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+
 /**
  * @typedef {import('../type/raw-data.typedef').RawData} RawData
  */
@@ -162,43 +165,31 @@ const transformRawDataToArticleInfo = (rawData) => {
 }
 
 /**
- * Transform params `time` into `YYYY.MM.DD HH:MM 臺北時間` || `YYYY/MM/DD HH:MM` pattern
- * depend on the type 'dot' or 'slash'
+ * Transform params `time` into different pattern
+ * depend on the type 'dot' or 'slash' or 'slashWithTime'
  * If `time` is not a valid date, this function will return undefined
  * @param {string} time
  * @param {'dot' | 'slash'| 'slashWithTime'} format
  * @returns {string | undefined}
  */
 const transformTimeData = (time, format) => {
-  const timeData = new Date(time)
-  const timestamp = timeData.getTime()
-  if (isNaN(timestamp)) {
+  dayjs.extend(utc)
+
+  const timeData = dayjs(time).utcOffset(8)
+
+  if (!timeData.isValid()) {
     return undefined
   } else {
-    const year = timeData.getFullYear()
-    const month = timeData.getMonth() + 1
-    const date = timeData.getDate()
-    const hour = timeData.getHours()
-    const minute = timeData.getMinutes()
-    const formattedUnit = (unit) => {
-      if (unit < 10) {
-        return `0${unit}`
-      } else {
-        return unit
-      }
-    }
-
     switch (format) {
       case 'dot':
-        return `${year}.${formattedUnit(month)}.${formattedUnit(
-          date
-        )} ${formattedUnit(hour)}:${formattedUnit(minute)}`
+        return timeData.format('YYYY.MM.DD HH:mm')
+
       case 'slash':
-        return `${year}/${formattedUnit(month)}/${formattedUnit(date)} `
+        return timeData.format('YYYY/MM/DD')
+
       case 'slashWithTime':
-        return `${year}/${formattedUnit(month)}/${formattedUnit(
-          date
-        )} ${formattedUnit(hour)}:${formattedUnit(minute)}`
+        return timeData.format('YYYY/MM/DD HH:mm')
+
       default:
         return undefined
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2530,6 +2530,11 @@ date-fns@^2.29.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
+dayjs@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
+  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
+
 debug@2.6.9, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
## Notable Change:
原本在函式`transfromTimeData`中，計算年、月、日等時間是依據變數`timeData`，而`timeData`是依據`new Date(time)`而來的。
但是在創建`Date`時，會使用機器的本地時區，所以可能會有server-side與client-side不一致的問題。
再加上需求方僅需要台北時區，所以該將函式回傳的值，都設定為台北時區(UTC+8)。
如果使用原生Javascript的 `Date`，要將回傳的值設定為台北時區(UTC+8)，又同時符合我們需要的格式，會蠻麻煩的，所以這邊直接使用套件dayjs，幫我們將日期設定為台北時間，且同時符合我們需要的格式。