### PR TITLE
refactor(mm-next): remove `getInitialProps`, render  header on each page

### DIFF
--- a/packages/mirror-media-next/axios/index.js
+++ b/packages/mirror-media-next/axios/index.js
@@ -1,0 +1,8 @@
+import axios from 'axios'
+import { API_TIMEOUT } from '../config/index.mjs'
+const axiosInstance = axios.create({
+  timeout: API_TIMEOUT,
+  method: 'get',
+})
+
+export default axiosInstance

--- a/packages/mirror-media-next/components/shared/share-header.js
+++ b/packages/mirror-media-next/components/shared/share-header.js
@@ -1,0 +1,61 @@
+import Header from '../header'
+import PremiumHeader from '../premium-header'
+
+/**
+ * @typedef {Object} HeaderData
+ * @property {Array} [sectionsData]
+ * @property {Array} [topicsData]
+ */
+
+const getDefaultHeader = (headerData) => {
+  const { sectionsData, topicsData } = headerData
+  if (!sectionsData || !sectionsData.length) {
+    console.warn('There is no sections data for header of default page layout')
+  } else if (!topicsData || !topicsData.length) {
+    console.warn('There is no topics data for header of default page layout')
+  }
+
+  return <Header sectionsData={sectionsData} topicsData={topicsData} />
+}
+const getPremiumHeader = (headerData) => {
+  const { sectionsData } = headerData
+  if (!sectionsData || !sectionsData.length) {
+    console.warn('There is no sections data for header of premium page layout')
+  }
+
+  return <PremiumHeader premiumHeaderData={{ sections: sectionsData }} />
+}
+
+/**
+ *
+ * @param {Object} props
+ * @param {'default' | 'premium' | 'empty'} props.pageLayoutType
+ * @param {HeaderData} props.headerData
+ * @returns {JSX.Element}
+ */
+export default function ShareHeader({
+  pageLayoutType = 'default',
+  headerData = {},
+}) {
+  const getheaderJsx = (pageLayoutType) => {
+    switch (pageLayoutType) {
+      case 'default': {
+        const defaultHeader = getDefaultHeader(headerData)
+        return defaultHeader
+      }
+      case 'premium': {
+        const premiumHeader = getPremiumHeader(headerData)
+        return premiumHeader
+      }
+      case 'empty':
+        return <></>
+      default: {
+        const defaultHeader = getDefaultHeader(headerData)
+        return defaultHeader
+      }
+    }
+  }
+  const headerJsx = getheaderJsx(pageLayoutType)
+
+  return headerJsx
+}

--- a/packages/mirror-media-next/pages/_app.js
+++ b/packages/mirror-media-next/pages/_app.js
@@ -2,39 +2,11 @@ import React, { useEffect } from 'react'
 import { GlobalStyles } from '../styles/global-styles'
 import { ThemeProvider } from 'styled-components'
 import { theme } from '../styles/theme'
-import Layout from '../components/layout'
-import axios from 'axios'
 import { ApolloProvider } from '@apollo/client'
 import client from '../apollo/apollo-client'
-import PremiumLayout from '../components/premium-layout'
 import * as gtag from '../utils/gtag'
 import TagManager from 'react-gtm-module'
 import { ENV, GTM_ID } from '../config/index.mjs'
-import {
-  URL_STATIC_COMBO_SECTIONS,
-  URL_STATIC_COMBO_TOPICS,
-  URL_STATIC_PREMIUM_SECTIONS,
-  API_TIMEOUT,
-} from '../config/index.mjs'
-
-function defaultGetLayout(page, sectionsData, topicsData, premiumHeaderData) {
-  const { isPremium } = page.props
-
-  return (
-    <>
-      {!isPremium && (
-        <Layout sectionsData={sectionsData} topicsData={topicsData}>
-          {page}
-        </Layout>
-      )}
-      {isPremium && (
-        <PremiumLayout premiumHeaderData={premiumHeaderData}>
-          {page}
-        </PremiumLayout>
-      )}
-    </>
-  )
-}
 
 /**
  *
@@ -46,13 +18,7 @@ function defaultGetLayout(page, sectionsData, topicsData, premiumHeaderData) {
  * @returns {React.ReactElement}
  */
 
-function MyApp({
-  Component,
-  pageProps,
-  sectionsData = [],
-  topicsData = [],
-  premiumHeaderData = {},
-}) {
+function MyApp({ Component, pageProps }) {
   //Temporarily enable google analytics and google tag manager only in dev and local environment.
   useEffect(() => {
     if (ENV === 'dev' || ENV === 'local') {
@@ -60,109 +26,16 @@ function MyApp({
       TagManager.initialize({ gtmId: GTM_ID })
     }
   }, [])
-  const getLayout = Component.getLayout || defaultGetLayout
   return (
     <>
       <GlobalStyles />
       <ApolloProvider client={client}>
         <ThemeProvider theme={theme}>
-          {getLayout(
-            <Component {...pageProps} />,
-            sectionsData,
-            topicsData,
-            premiumHeaderData
-          )}
+          <Component {...pageProps} />
         </ThemeProvider>
       </ApolloProvider>
     </>
   )
-}
-
-/**
- * TODO: add specific data structure for sectionsData and topicsData, not just an object of array.
- * @typedef {Object[]} Items
- */
-
-/**
- * @typedef {Object} DataRes
- * @property {Items} [_items]
- * @property {Object} [_endpoints]
- * @property {Object} [_endpoints.topics]
- * @property {Items} [_endpoints.topics._items]
- * @property {Object} _links
- * @property {Object} _meta
- */
-
-/**
- * @typedef {import('../components/premium-layout').PremiumHeaderData} PremiumHeaderData
- */
-
-/**
- *  @typedef {import('axios').AxiosResponse<DataRes>} AxiosResponse
- */
-
-/**
- * @async
- * @returns {Promise<{sectionsData: Items | [] ,topicsData: Items | []}>}
- */
-MyApp.getInitialProps = async () => {
-  try {
-    const responses = await Promise.allSettled([
-      axios({
-        method: 'get',
-        url: URL_STATIC_COMBO_SECTIONS,
-        timeout: API_TIMEOUT,
-      }),
-      axios({
-        method: 'get',
-        url: URL_STATIC_COMBO_TOPICS,
-        timeout: API_TIMEOUT,
-      }),
-      axios({
-        method: 'get',
-        url: URL_STATIC_PREMIUM_SECTIONS,
-        timeout: API_TIMEOUT,
-      }),
-    ])
-    /** @type {PromiseFulfilledResult<AxiosResponse>} */
-    const sectionsResponse = responses[0].status === 'fulfilled' && responses[0]
-    /** @type {PromiseFulfilledResult<AxiosResponse>} */
-    const topicsResponse = responses[1].status === 'fulfilled' && responses[1]
-    /** @type {PromiseFulfilledResult<PremiumHeaderData>} */
-    const premiumResponse = responses[2].status === 'fulfilled' && responses[2]
-
-    const sectionsData = Array.isArray(sectionsResponse?.value?.data?._items)
-      ? sectionsResponse?.value?.data?._items
-      : []
-
-    const topicsData = Array.isArray(
-      topicsResponse?.value?.data?._endpoints?.topics?._items
-    )
-      ? topicsResponse?.value?.data?._endpoints?.topics?._items
-      : []
-
-    const premiumHeaderData = premiumResponse?.value?.data || {}
-
-    console.log(
-      JSON.stringify({
-        severity: 'DEBUG',
-        message: `Successfully fetch sections and topics from ${URL_STATIC_COMBO_SECTIONS}, ${URL_STATIC_COMBO_TOPICS} and ${URL_STATIC_PREMIUM_SECTIONS}`,
-      })
-    )
-
-    return {
-      sectionsData,
-      topicsData,
-      premiumHeaderData,
-    }
-  } catch (error) {
-    console.log(JSON.stringify({ severity: 'ERROR', message: error.stack }))
-    return {
-      sectionsData: [],
-      topicsData: [],
-      premiumHeaderData: {},
-    }
-  }
 }
 
 export default MyApp

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -1,0 +1,59 @@
+import errors from '@twreporter/errors'
+import {
+  URL_STATIC_COMBO_SECTIONS,
+  URL_STATIC_PREMIUM_SECTIONS,
+  URL_STATIC_COMBO_TOPICS,
+} from '../../config/index.mjs'
+import axiosInstance from '../../axios/index.js'
+
+/**
+ * Creates an Axios request function that sends a GET request to the specified URL with a timeout.
+ * @param {string} requestUrl - The URL to send the request to.
+ 
+ */
+const createAxiosRequest = (requestUrl) => {
+  return () => axiosInstance(requestUrl)
+}
+
+const errorLogger = (errorMessage) => {
+  const annotatingAxiosError = errors.helpers.annotateAxiosError(errorMessage)
+  throw annotatingAxiosError
+}
+const fetchNormalSections = createAxiosRequest(URL_STATIC_COMBO_SECTIONS)
+const fetchTopics = createAxiosRequest(URL_STATIC_COMBO_TOPICS)
+
+const fetchPremiumSections = createAxiosRequest(URL_STATIC_PREMIUM_SECTIONS)
+
+const fetchHeaderDataInDefaultPageLayout = async () => {
+  let sectionsData = []
+  let topicsData = []
+  try {
+    const responses = await Promise.all([fetchNormalSections(), fetchTopics()])
+    if (responses[0]?.data?._items) {
+      sectionsData = responses[0]?.data?._items
+    }
+    if (responses[1]?.data?._endpoints?.topics?._items) {
+      topicsData = responses[1].data._endpoints.topics._items
+    }
+    return { sectionsData, topicsData }
+  } catch (err) {
+    errorLogger(err)
+  }
+}
+
+const fetchHeaderDataInPremiumPageLayout = async () => {
+  let sectionsData = []
+  try {
+    const response = await fetchPremiumSections()
+    if (response?.data?.sections) {
+      sectionsData = response?.data?.sections
+    }
+    return { sectionsData }
+  } catch (err) {
+    errorLogger(err)
+  }
+}
+export {
+  fetchHeaderDataInDefaultPageLayout,
+  fetchHeaderDataInPremiumPageLayout,
+}


### PR DESCRIPTION
## Notable Change

1. 依據先前的[討論結果](https://paper.dropbox.com/doc/mirror-media-next--B4DRmssdQby6Twi3OtTZPLg3Ag-4ycqmvBJILA9l7XU0Zt0G)，為了避免getInitialProps的缺點、以及發多餘的request，所以將header改為由各自頁面自行render，並移除`_app.js`的`getInitialProps`。
2. 新增元件`share-header`，會依據傳入的參數`pageLayoutType`，決定要render哪一種header。目前共有三種：default header、premium header、empty header。頁面可依據使用的情境、決定要顯示哪一種header。
3. 因為不同類型的header，所需要的資料不同，所以當該資料有缺時，會透過console.warn提醒沒有資料傳入。（比如説，default header會需要參數`sectionsData`與`topicsData`，如果任一參數沒有傳入時，會提醒沒有資料）
4. 除了元件`share-header`會共用以外，抓取header資料的函式也會共用，所以於`utils`資料夾中新增一檔案`/axios/index.js`，並在其中新增抓取[各種類型header的函式](https://github.com/mirror-media/Adam/pull/174/commits/77afca8e7aebd97edd47d58a844294fab698080e#diff-a644e568f8ce883a3f03ac424297d66b6a86917913ee0412e2d871e80d36ac4aR103-R104)。也一併針對錯誤處理，寫了[error logger](https://github.com/mirror-media/Adam/pull/174/commits/77afca8e7aebd97edd47d58a844294fab698080e#diff-a644e568f8ce883a3f03ac424297d66b6a86917913ee0412e2d871e80d36ac4aR24)。
5. 因為不確定大家各自的進度為何，為了避免程式碼conflict，所以只有修改首頁跟category頁，讓這兩頁透過getServersideProps抓取header所需資料，以及顯示各自頁面需要的header。
6. 目前來不及補上元件`share-header`的jsDoc，之後會在一併補上。

## Question
主要想針對utils/axios/index，有幾個問題想討論：
1. Naming convention：不太確定用於發request的函式，是否該放在utils，還是在放在另外的資料夾？如果該放在utils的話，叫`axios`是否適切？
2. 我原本打算由各自使用抓取資料函式（`fetchHeaderDataInDefaultPageLayout`、`fetchHeaderDataInPremiumPageLayout`）的程式碼，自行決定是否該處理錯誤與印出error。但後來想想，發現這樣太麻煩了，所以改為由函式自行handle。不知道目前處理錯誤的方式，是否有地方需要調整？
