### PR TITLE
feat(mm-next/story): add header of wide layout

### DIFF
--- a/packages/mirror-media-next/components/story/shared/button-copy-link.js
+++ b/packages/mirror-media-next/components/story/shared/button-copy-link.js
@@ -7,8 +7,7 @@ import Image from 'next/image'
 const CopiedMessage = styled.div`
   position: fixed;
   top: 64px;
-  left: 50%;
-  transform: translateX(-50%);
+  left: calc((100vw - min(80vw, 480px)) / 2);
   color: #fff;
   background: rgba(0, 0, 0, 0.87);
   border-radius: 2px;

--- a/packages/mirror-media-next/components/story/wide/header.js
+++ b/packages/mirror-media-next/components/story/wide/header.js
@@ -1,0 +1,91 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+import Link from 'next/link'
+
+import LogoSvg from '../../../public/images/mirror-media-logo.svg'
+import HamburgerButton from '../../shared/hamburger-button'
+import CloseButton from '../../shared/close-button'
+/**
+ * @typedef {import('../../../type/theme').Theme} Theme
+ */
+
+const HeaderWrapper = styled.header`
+  position: fixed;
+  pointer-events: none;
+  z-index: 499;
+  width: 100%;
+  padding: 12px 12px 0 12px;
+  margin: 0 auto;
+  top: 0;
+  left: 0;
+  color: red;
+  background-color: transparent;
+  display: flex;
+  justify-content: space-between;
+  > * {
+    pointer-events: initial;
+  }
+  svg {
+    path {
+      fill: ${
+        /**
+         * @param {Object} param
+         * @param {Theme} [param.theme]
+         */
+        ({ theme }) => theme.color.brandColor.lightBlue
+      };
+    }
+  }
+`
+
+const SideBar = styled.section`
+  display: flex;
+  flex-direction: column;
+
+  position: fixed;
+  top: 0;
+
+  width: 100%;
+  height: 100%;
+  background-color: #3e3e3e;
+  font-size: 14px;
+  line-height: 1.5;
+  z-index: 539;
+  overflow-y: auto;
+  right: 0;
+  transform: ${
+    /** @param {{shouldShowSidebar: Boolean}} props */
+    ({ shouldShowSidebar }) =>
+      shouldShowSidebar ? 'translateX(0)' : 'translateX(100%)'
+  };
+
+  transition: transform 0.5s ease-in-out;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    width: 320px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
+  }
+`
+
+export default function Header() {
+  const [shouldOpenSideBar, setShouldOpenSideBar] = useState(false)
+  return (
+    <HeaderWrapper>
+      <Link href="/">
+        <LogoSvg></LogoSvg>
+      </Link>
+      <HamburgerButton
+        color="lightBlue"
+        handleOnClick={() => setShouldOpenSideBar((val) => !val)}
+      />
+
+      <SideBar shouldShowSidebar={shouldOpenSideBar}>
+        <CloseButton
+          handleOnClick={() => setShouldOpenSideBar((val) => !val)}
+        />
+      </SideBar>
+    </HeaderWrapper>
+  )
+}

--- a/packages/mirror-media-next/components/story/wide/header.js
+++ b/packages/mirror-media-next/components/story/wide/header.js
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import LogoSvg from '../../../public/images/mirror-media-logo.svg'
 import HamburgerButton from '../../shared/hamburger-button'
 import CloseButton from '../../shared/close-button'
+import NavSubtitleNavigator from './nav-subtitle-navigator'
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
  */
@@ -18,7 +19,6 @@ const HeaderWrapper = styled.header`
   margin: 0 auto;
   top: 0;
   left: 0;
-  color: red;
   background-color: transparent;
   display: flex;
   justify-content: space-between;
@@ -47,7 +47,7 @@ const SideBar = styled.section`
 
   width: 100%;
   height: 100%;
-  background-color: #3e3e3e;
+  background-color: pink;
   font-size: 14px;
   line-height: 1.5;
   z-index: 539;
@@ -69,7 +69,7 @@ const SideBar = styled.section`
   }
 `
 
-export default function Header() {
+export default function Header({ h2AndH3Block = [] }) {
   const [shouldOpenSideBar, setShouldOpenSideBar] = useState(false)
   return (
     <HeaderWrapper>
@@ -84,6 +84,11 @@ export default function Header() {
       <SideBar shouldShowSidebar={shouldOpenSideBar}>
         <CloseButton
           handleOnClick={() => setShouldOpenSideBar((val) => !val)}
+        />
+        <NavSubtitleNavigator
+          h2AndH3Block={h2AndH3Block}
+          componentStyle="side-bar"
+          handleCloseSideBar={() => setShouldOpenSideBar(false)}
         />
       </SideBar>
     </HeaderWrapper>

--- a/packages/mirror-media-next/components/story/wide/header.js
+++ b/packages/mirror-media-next/components/story/wide/header.js
@@ -1,6 +1,11 @@
-import { useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import styled from 'styled-components'
 import Link from 'next/link'
+import {
+  disableBodyScroll,
+  enableBodyScroll,
+  clearAllBodyScrollLocks,
+} from 'body-scroll-lock'
 
 import LogoSvg from '../../../public/images/mirror-media-logo.svg'
 import HamburgerButton from '../../shared/hamburger-button'
@@ -70,7 +75,21 @@ const SideBar = styled.section`
 `
 
 export default function Header({ h2AndH3Block = [] }) {
+  const sideBarRef = useRef(null)
   const [shouldOpenSideBar, setShouldOpenSideBar] = useState(false)
+
+  useEffect(() => {
+    const sideBar = sideBarRef.current
+    if (!sideBar) {
+      return
+    }
+    if (shouldOpenSideBar) {
+      disableBodyScroll(sideBar)
+    } else {
+      enableBodyScroll(sideBar)
+    }
+    return () => clearAllBodyScrollLocks()
+  }, [shouldOpenSideBar])
   return (
     <HeaderWrapper>
       <Link href="/">
@@ -81,7 +100,7 @@ export default function Header({ h2AndH3Block = [] }) {
         handleOnClick={() => setShouldOpenSideBar((val) => !val)}
       />
 
-      <SideBar shouldShowSidebar={shouldOpenSideBar}>
+      <SideBar shouldShowSidebar={shouldOpenSideBar} ref={sideBarRef}>
         <CloseButton
           handleOnClick={() => setShouldOpenSideBar((val) => !val)}
         />

--- a/packages/mirror-media-next/components/story/wide/header.js
+++ b/packages/mirror-media-next/components/story/wide/header.js
@@ -6,6 +6,7 @@ import {
   enableBodyScroll,
   clearAllBodyScrollLocks,
 } from 'body-scroll-lock'
+import useClickOutside from '../../../hooks/useClickOutside'
 
 import LogoSvg from '../../../public/images/mirror-media-logo.svg'
 import HamburgerButton from '../../shared/hamburger-button'
@@ -77,7 +78,9 @@ const SideBar = styled.section`
 export default function Header({ h2AndH3Block = [] }) {
   const sideBarRef = useRef(null)
   const [shouldOpenSideBar, setShouldOpenSideBar] = useState(false)
-
+  useClickOutside(sideBarRef, () => {
+    setShouldOpenSideBar(false)
+  })
   useEffect(() => {
     const sideBar = sideBarRef.current
     if (!sideBar) {

--- a/packages/mirror-media-next/components/story/wide/header.js
+++ b/packages/mirror-media-next/components/story/wide/header.js
@@ -54,34 +54,42 @@ const SocialMedia = styled.li`
     margin-right: 10px;
   }
 `
-const SideBar = styled.section`
-  display: flex;
-  flex-direction: column;
-
+const SideBarModal = styled.section`
   position: fixed;
   top: 0;
 
   width: 100%;
   height: 100%;
-  background-color: #3e3e3e;
+  background-color: transparent;
   font-size: 14px;
   line-height: 1.5;
   z-index: 539;
   overflow-y: auto;
   right: 0;
-  transform: ${
-    /** @param {{shouldShowSidebar: Boolean}} props */
+  ${
+    /**
+     * @param {{shouldShowSidebar: Boolean}} props
+     */
     ({ shouldShowSidebar }) =>
-      shouldShowSidebar ? 'translateX(0)' : 'translateX(100%)'
+      shouldShowSidebar
+        ? 'transform: translateX(0%)'
+        : 'transform: translateX(100%)'
   };
-
+  overflow-x: hidden;
   transition: transform 0.5s ease-in-out;
 
-  ${({ theme }) => theme.breakpoint.md} {
-    width: 320px;
-  }
   ${({ theme }) => theme.breakpoint.xl} {
     display: none;
+  }
+`
+
+const SideBar = styled.section`
+  width: 100%;
+  height: 100%;
+  background-color: #3e3e3e;
+  margin-left: auto;
+  ${({ theme }) => theme.breakpoint.md} {
+    width: 320px;
   }
 `
 
@@ -112,22 +120,23 @@ export default function Header({ h2AndH3Block = [] }) {
         color="lightBlue"
         handleOnClick={() => setShouldOpenSideBar((val) => !val)}
       />
-
-      <SideBar shouldShowSidebar={shouldOpenSideBar} ref={sideBarRef}>
-        <CloseButton
-          handleOnClick={() => setShouldOpenSideBar((val) => !val)}
-        />
-        <NavSubtitleNavigator
-          h2AndH3Block={h2AndH3Block}
-          componentStyle="side-bar"
-          handleCloseSideBar={() => setShouldOpenSideBar(false)}
-        />
-        <SocialMedia>
-          <ButtonSocialNetworkShare type="facebook" width={28} height={28} />
-          <ButtonSocialNetworkShare type="line" width={28} height={28} />
-          <ButtonCopyLink width={28} height={28} />
-        </SocialMedia>
-      </SideBar>
+      <SideBarModal shouldShowSidebar={shouldOpenSideBar}>
+        <SideBar ref={sideBarRef}>
+          <CloseButton
+            handleOnClick={() => setShouldOpenSideBar((val) => !val)}
+          />
+          <NavSubtitleNavigator
+            h2AndH3Block={h2AndH3Block}
+            componentStyle="side-bar"
+            handleCloseSideBar={() => setShouldOpenSideBar(false)}
+          />
+          <SocialMedia>
+            <ButtonSocialNetworkShare type="facebook" width={28} height={28} />
+            <ButtonSocialNetworkShare type="line" width={28} height={28} />
+            <ButtonCopyLink width={28} height={28} />
+          </SocialMedia>
+        </SideBar>
+      </SideBarModal>
     </HeaderWrapper>
   )
 }

--- a/packages/mirror-media-next/components/story/wide/header.js
+++ b/packages/mirror-media-next/components/story/wide/header.js
@@ -12,6 +12,8 @@ import LogoSvg from '../../../public/images/mirror-media-logo.svg'
 import HamburgerButton from '../../shared/hamburger-button'
 import CloseButton from '../../shared/close-button'
 import NavSubtitleNavigator from './nav-subtitle-navigator'
+import ButtonSocialNetworkShare from '../shared/button-social-network-share'
+import ButtonCopyLink from '../shared/button-copy-link'
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
  */
@@ -43,7 +45,15 @@ const HeaderWrapper = styled.header`
     }
   }
 `
-
+const SocialMedia = styled.li`
+  display: flex;
+  margin-bottom: 24px;
+  padding-left: 24px;
+  padding-right: 24px;
+  a {
+    margin-right: 10px;
+  }
+`
 const SideBar = styled.section`
   display: flex;
   flex-direction: column;
@@ -53,7 +63,7 @@ const SideBar = styled.section`
 
   width: 100%;
   height: 100%;
-  background-color: pink;
+  background-color: #3e3e3e;
   font-size: 14px;
   line-height: 1.5;
   z-index: 539;
@@ -112,6 +122,11 @@ export default function Header({ h2AndH3Block = [] }) {
           componentStyle="side-bar"
           handleCloseSideBar={() => setShouldOpenSideBar(false)}
         />
+        <SocialMedia>
+          <ButtonSocialNetworkShare type="facebook" width={28} height={28} />
+          <ButtonSocialNetworkShare type="line" width={28} height={28} />
+          <ButtonCopyLink width={28} height={28} />
+        </SocialMedia>
       </SideBar>
     </HeaderWrapper>
   )

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -13,14 +13,16 @@ import {
   sortArrayWithOtherArrayId,
 } from '../../../utils'
 import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
+
+import Header from './header'
 import DonateLink from '../shared/donate-link'
 import HeroImageAndVideo from './hero-image-and-video'
 import Credits from './credits'
-
 import DonateBanner from '../shared/donate-banner'
 import RelatedArticleList from './related-article-list'
 import AsideArticleList from './aside-article-list'
 import NavSubtitleNavigator from './nav-subtitle-navigator'
+
 import Divider from '../shared/divider'
 import ButtonCopyLink from '../shared/button-copy-link'
 import ButtonSocialNetworkShare from '../shared/button-social-network-share'
@@ -34,7 +36,7 @@ import { fetchAsidePosts } from '../../../apollo/query/posts'
 const Main = styled.main`
   margin: auto;
   width: 100%;
-  height: 100vh;
+
   background-color: white;
 `
 const StyledDonateLink = styled(DonateLink)`
@@ -224,59 +226,69 @@ export default function StoryWideStyle({ postData }) {
   const h2AndH3Block = getContentBlocksH2H3(content)
 
   return (
-    <Main>
-      <article>
-        <HeroImageAndVideo
-          heroImage={heroImage}
-          heroVideo={heroVideo}
-          heroCaption={heroCaption}
-          title={title}
-        />
-        <ContentWrapper>
-          <NavSubtitleNavigator h2AndH3Block={h2AndH3Block}>
-            <SocialMediaAndDonateLink>
-              <SocialMedia>
-                <ButtonSocialNetworkShare
-                  type="facebook"
-                  width={28}
-                  height={28}
-                />
-                <ButtonSocialNetworkShare type="line" width={28} height={28} />
-                <ButtonCopyLink width={28} height={28} />
-              </SocialMedia>
-              {/* <li>
+    <>
+      <Header h2AndH3Block={h2AndH3Block} />
+      <Main>
+        <article>
+          <HeroImageAndVideo
+            heroImage={heroImage}
+            heroVideo={heroVideo}
+            heroCaption={heroCaption}
+            title={title}
+          />
+          <ContentWrapper>
+            <NavSubtitleNavigator h2AndH3Block={h2AndH3Block}>
+              <SocialMediaAndDonateLink>
+                <SocialMedia>
+                  <ButtonSocialNetworkShare
+                    type="facebook"
+                    width={28}
+                    height={28}
+                  />
+                  <ButtonSocialNetworkShare
+                    type="line"
+                    width={28}
+                    height={28}
+                  />
+                  <ButtonCopyLink width={28} height={28} />
+                </SocialMedia>
+                {/* <li>
                 <DonateLink />
               </li> */}
-            </SocialMediaAndDonateLink>
-          </NavSubtitleNavigator>
-          <Credits credits={credits}></Credits>
-          <DateWrapper>
-            <Date>更新時間 {updatedAtFormatTime}</Date>
-            <Date>發布時間 {publishedDateFormatTime}</Date>
-          </DateWrapper>
-          <StyledDonateLink />
-          <section className="content">
-            <DraftRenderBlock rawContentBlock={brief} contentLayout="wide" />
-            <DraftRenderBlock rawContentBlock={content} contentLayout="wide" />
-          </section>
+              </SocialMediaAndDonateLink>
+            </NavSubtitleNavigator>
+            <Credits credits={credits}></Credits>
+            <DateWrapper>
+              <Date>更新時間 {updatedAtFormatTime}</Date>
+              <Date>發布時間 {publishedDateFormatTime}</Date>
+            </DateWrapper>
+            <StyledDonateLink />
+            <section className="content">
+              <DraftRenderBlock rawContentBlock={brief} contentLayout="wide" />
+              <DraftRenderBlock
+                rawContentBlock={content}
+                contentLayout="wide"
+              />
+            </section>
 
-          <StyledDonateBanner />
-        </ContentWrapper>
-        <Aside>
-          <RelatedArticleList relateds={relatedsWithOrdered} />
-          <AsideArticleList
-            heading="最新文章"
-            fetchArticle={handleFetchLatestNews}
-            renderAmount={6}
-          />
-          <Divider />
-          <AsideArticleList
-            heading="熱門文章"
-            fetchArticle={handleFetchPopularNews}
-            renderAmount={6}
-          />
-        </Aside>
-      </article>
-    </Main>
+            <StyledDonateBanner />
+          </ContentWrapper>
+          <Aside>
+            <RelatedArticleList relateds={relatedsWithOrdered} />
+            <AsideArticleList
+              heading="最新文章"
+              fetchArticle={handleFetchLatestNews}
+              renderAmount={6}
+            />
+            <Divider />
+            <AsideArticleList
+              heading="熱門文章"
+              fetchArticle={handleFetchPopularNews}
+              renderAmount={6}
+            />
+          </Aside>
+        </article>
+      </Main>
+    </>
   )
 }

--- a/packages/mirror-media-next/components/story/wide/nav-subtitle-navigator.js
+++ b/packages/mirror-media-next/components/story/wide/nav-subtitle-navigator.js
@@ -1,27 +1,112 @@
 import { useEffect, useState } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 /**
  * @typedef {Pick<import('../../../type/draft-js').DraftBlock, 'key' | 'text' | 'type'> & { type: 'header-two' | 'header-three'}} H2AndH3Block
  */
 
-const NavWrapper = styled.section`
+/**
+ * @typedef {import('../../../type/theme').Theme} Theme
+ */
+
+/**
+ * @typedef {'side-index' | 'side-bar'} ComponentStyle
+ */
+
+const navWrapperSideIndex = css`
   position: absolute;
   top: 0;
   left: calc((100vw - 100%) / 2 * -1);
   width: calc((100vw - 100%) / 2);
   height: 100%;
 `
-const NavItem = styled.li`
-  margin-bottom: 8px;
+const navWrapperSideMenu = css`
+  min-height: 50%;
+  background-color: #3e3e3e;
+  padding: 24px;
+`
+
+const NavWrapper = styled.section`
+  ${
+    /**
+     * @param {{componentStyle: ComponentStyle}} Object
+     */
+    ({ componentStyle }) => {
+      switch (componentStyle) {
+        case 'side-index':
+          return navWrapperSideIndex
+        case 'side-bar':
+          return navWrapperSideMenu
+        default:
+        case 'side-index':
+          return navWrapperSideIndex
+      }
+    }
+  }
+`
+
+const navItemSideIndex = css`
   color: rgba(0, 0, 0, 0.87);
-  font-weight: 500;
-  cursor: pointer;
+
   ${
     /**
      * @param {Object} param
-     * @param {'header-two' | 'header-three'} param.headerType
      * @param {boolean} param.isActive
+     * @param {Theme} param.theme
+     */
+    ({ isActive, theme }) =>
+      isActive &&
+      `
+    color: ${theme.color.brandColor.darkBlue};
+    text-decoration: underline;
+    `
+  }
+`
+
+const navItemSideMenu = css`
+  color: ${({ theme }) => theme.color.brandColor.lightBlue};
+  position: relative;
+  margin-left: 28px;
+  width: 168px;
+  &::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: -20px;
+    width: 8px;
+    height: 8px;
+    transform: translateY(-50%);
+    border-radius: 50%;
+    background-color: ${({ theme }) => theme.color.brandColor.lightBlue};
+  }
+
+  ${
+    /**
+     * @param {{isActive: boolean}} param
+     */
+    ({ isActive }) =>
+      isActive &&
+      `
+        color: white;
+        &::before{
+          background-color: white;
+        }
+      `
+  }
+`
+
+const NavItem = styled.li`
+  margin-bottom: 8px;
+  font-weight: 500;
+  cursor: pointer;
+
+  ${
+    /**
+     * @param {Object} param
+     * @param {boolean} param.isActive
+     * @param {ComponentStyle} param.componentStyle
+     * @param {'header-two' | 'header-three'} param.headerType
+     * @param {Theme} param.theme
      */
     ({ headerType }) => {
       switch (headerType) {
@@ -43,15 +128,22 @@ const NavItem = styled.li`
       }
     }
   }
+  ${({ componentStyle }) => {
+    switch (componentStyle) {
+      case 'side-index':
+        return navItemSideIndex
 
-  ${({ isActive, theme }) =>
-    isActive &&
-    `
-    color: ${theme.color.brandColor.darkBlue};
-    text-decoration: underline;
-    `}
+      case 'side-bar':
+        return navItemSideMenu
+
+      default:
+      case 'side-index':
+        return navItemSideIndex
+    }
+  }}
 `
-const Nav = styled.nav`
+
+const navSideIndex = css`
   display: none;
   ${({ theme }) => theme.breakpoint.xl} {
     display: block;
@@ -63,16 +155,48 @@ const Nav = styled.nav`
     height: auto;
   }
 `
+const navSideMenu = css`
+  display: block;
+`
+
+const Nav = styled.nav`
+  ${
+    /**
+     * @param {Object} param
+     * @param {ComponentStyle} [param.componentStyle]
+     */
+    ({ componentStyle }) => {
+      switch (componentStyle) {
+        case 'side-index':
+          return navSideIndex
+        case 'side-bar':
+          return navSideMenu
+        default:
+        case 'side-index':
+          return navSideIndex
+      }
+    }
+  }
+`
+
+/**
+ * @callback HandleCloseSideBar
+ * @return {void | import('react').SetStateAction<boolean> }
+ */
 
 /**
  * @param {Object} props
  * @param {H2AndH3Block[]} props.h2AndH3Block
+ * @param {ComponentStyle} [props.componentStyle]
  * @param {JSX.Element} [props.children]
+ * @param {HandleCloseSideBar} [props.handleCloseSideBar]
  * @returns {JSX.Element}
  */
 export default function NavSubtitleNavigator({
   h2AndH3Block = [],
+  componentStyle = 'side-index',
   children = null,
+  handleCloseSideBar = () => {},
 }) {
   const [currentIndex, setCurrentIndex] = useState(undefined)
   const handleOnClick = (key) => {
@@ -84,10 +208,14 @@ export default function NavSubtitleNavigator({
     const { scrollY, innerHeight } = window
 
     const y = top + height * 0.5 + scrollY - innerHeight * 0.5
+
     scrollTo({
       top: y,
       behavior: 'smooth',
     })
+    if (componentStyle === 'side-bar') {
+      handleCloseSideBar()
+    }
   }
 
   useEffect(() => {
@@ -155,13 +283,14 @@ export default function NavSubtitleNavigator({
   }, [h2AndH3Block])
 
   return (
-    <NavWrapper>
-      <Nav>
+    <NavWrapper componentStyle={componentStyle}>
+      <Nav componentStyle={componentStyle}>
         {children}
         {h2AndH3Block.length ? (
           <ul>
             {h2AndH3Block.map((item) => (
               <NavItem
+                componentStyle={componentStyle}
                 isActive={
                   currentIndex ? currentIndex.includes(item.key) : false
                 }

--- a/packages/mirror-media-next/components/story/wide/nav-subtitle-navigator.js
+++ b/packages/mirror-media-next/components/story/wide/nav-subtitle-navigator.js
@@ -21,9 +21,8 @@ const navWrapperSideIndex = css`
   height: 100%;
 `
 const navWrapperSideMenu = css`
-  min-height: 50%;
   background-color: #3e3e3e;
-  padding: 24px;
+  padding: 24px 24px 20px;
 `
 
 const NavWrapper = styled.section`

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -19,6 +19,7 @@
     "@svgr/webpack": "^6.3.1",
     "@twreporter/errors": "^1.1.2",
     "axios": "^1.2.0",
+    "body-scroll-lock": "3.1.5",
     "cors": "^2.8.5",
     "dayjs": "^1.11.7",
     "graphql": "^16.6.0",


### PR DESCRIPTION
## Notable Change
1. 新增文章頁wide版型header。
2. wide版型header共有以下功能：
   - 左上角點擊icon後會回至首頁。
   - 右上腳為漢堡按鈕，點擊後會展開sidebar。
   - sidebar具有側欄索引功能，點擊後會跳至對應h2、h3。
   - 具有SNS分享功能、以及複製連結功能。
   - 當sidebar開啟時，會暫停body的滑動功能。
   - 當點擊sidebar外側時，或sidebar右上角的關閉按鈕時，會關閉sidebar。
   - 開啟/關閉 sidebar有0.5秒的位移動畫。