### PR TITLE
feat(mm-next): render header in story page normal layout

### DIFF
--- a/packages/mirror-media-next/components/shared/share-header.js
+++ b/packages/mirror-media-next/components/shared/share-header.js
@@ -30,7 +30,7 @@ const getPremiumHeader = (headerData) => {
  *
  * @param {Object} props
  * @param {'default' | 'premium' | 'empty'} props.pageLayoutType
- * @param {HeaderData} props.headerData
+ * @param {HeaderData} [props.headerData]
  * @returns {JSX.Element}
  */
 export default function ShareHeader({

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -8,7 +8,7 @@ import dynamic from 'next/dynamic'
 
 import { fetchPostBySlug } from '../../apollo/query/posts'
 import StoryNormalStyle from '../../components/story/normal'
-
+import ShareHeader from '../../components/shared/share-header'
 const StoryWideStyle = dynamic(() => import('../../components/story/wide'))
 const StoryPhotographyStyle = dynamic(() =>
   import('../../components/story/photography')
@@ -125,6 +125,7 @@ export default function Story({ postData }) {
   return (
     <>
       {headJsx}
+      <ShareHeader pageLayoutType="empty" />
       {!storyLayout && <MockLoading>Loading...</MockLoading>}
       <div style={{ display: `${storyLayout ? 'block' : 'none'}` }}>{jsx}</div>
     </>


### PR DESCRIPTION
## Notable Change
1. 調整元件`share-header`的jsDoc，使參數 `headerData`是可以不須傳入的。
2. 於文章頁一般樣式中，新增header元件。