### PR TITLE
feat(mm-next): show topics and flashnews in header, add new header  type in share-header

### DIFF
--- a/packages/mirror-media-next/components/flash-news.js
+++ b/packages/mirror-media-next/components/flash-news.js
@@ -8,7 +8,7 @@ const FlashNewsWrapper = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
-  margin: 8px auto 0;
+  margin: 0 auto;
   overflow: hidden;
   height: 21px;
   font-size: 12px;
@@ -16,7 +16,6 @@ const FlashNewsWrapper = styled.div`
   font-weight: 600;
   color: #054f77;
   ${({ theme }) => theme.breakpoint.xl} {
-    margin: 10px auto 0;
     height: 36px;
     font-size: 16px;
   }

--- a/packages/mirror-media-next/components/header.js
+++ b/packages/mirror-media-next/components/header.js
@@ -17,6 +17,8 @@ import MemberLoginButton from './member-login-button'
 import SearchBarInput from './search-bar-input'
 import MobileSidebar from './mobile-sidebar'
 import Logo from './logo'
+import SubscribeMagazine from './subscribe-magazine'
+import NavTopics from './nav-topics'
 import { SEARCH_URL } from '../config/index.mjs'
 
 const HeaderWrapper = styled.div`
@@ -115,6 +117,13 @@ const SearchInputWrapper = styled.div`
   }
 `
 
+const TopicsAndFlashNews = styled.section`
+  margin-top: 10px;
+`
+const TopicsAndSubscribe = styled.section`
+  display: flex;
+`
+
 /**
  * TODO: use typedef in `../apollo/fragments/section`
  * Should be done after fetch header data from new json file
@@ -139,9 +148,14 @@ function filterOutIsMemberOnlyCategoriesInNormalSection(section) {
  * @param {Object} props
  * @param {import('../type').Section[]} props.sectionsData
  * @param {import('../type').Topic[]} props.topicsData
+ * @param {JSX.Element} [props.children]
  * @returns {React.ReactElement}
  */
-export default function Header({ sectionsData = [], topicsData = [] }) {
+export default function Header({
+  sectionsData = [],
+  topicsData = [],
+  children = null,
+}) {
   const [showSearchField, setShowSearchField] = useState(false)
   const [searchTerms, setSearchTerms] = useState('')
   const mobileSearchButtonRef = useRef(null)
@@ -246,6 +260,13 @@ export default function Header({ sectionsData = [], topicsData = [] }) {
           />
         </SearchInputWrapper>
         <NavSections sections={sections} />
+        <TopicsAndFlashNews>
+          {children}
+          <TopicsAndSubscribe>
+            <NavTopics topics={topics} />
+            <SubscribeMagazine />
+          </TopicsAndSubscribe>
+        </TopicsAndFlashNews>
       </HeaderBottom>
     </HeaderWrapper>
   )

--- a/packages/mirror-media-next/components/shared/share-header.js
+++ b/packages/mirror-media-next/components/shared/share-header.js
@@ -1,10 +1,13 @@
+//TODO: add jsDoc of param  on component `Share-Header`
+
 import Header from '../header'
 import PremiumHeader from '../premium-header'
-
+import FlashNews from '../flash-news'
 /**
  * @typedef {Object} HeaderData
  * @property {Array} [sectionsData]
  * @property {Array} [topicsData]
+ * @property {Array} [flashNewsData]
  */
 
 const getDefaultHeader = (headerData) => {
@@ -16,6 +19,30 @@ const getDefaultHeader = (headerData) => {
   }
 
   return <Header sectionsData={sectionsData} topicsData={topicsData} />
+}
+const getDefaultHeaderWithFlashNews = (headerData) => {
+  const { sectionsData, topicsData, flashNewsData } = headerData
+  if (!sectionsData || !sectionsData.length) {
+    console.warn('There is no sections data for header of default page layout')
+  } else if (!topicsData || !topicsData.length) {
+    console.warn('There is no topics data for header of default page layout')
+  } else if (!flashNewsData || !flashNewsData.length) {
+    console.warn(
+      'There is no flash news data for header of default page layout'
+    )
+  }
+  const flashNews = flashNewsData.map(({ slug, title }) => {
+    return {
+      title,
+      slug,
+      href: `/story/${slug}`,
+    }
+  })
+  return (
+    <Header sectionsData={sectionsData} topicsData={topicsData}>
+      <FlashNews flashNews={flashNews} />
+    </Header>
+  )
 }
 const getPremiumHeader = (headerData) => {
   const { sectionsData } = headerData
@@ -29,8 +56,9 @@ const getPremiumHeader = (headerData) => {
 /**
  *
  * @param {Object} props
- * @param {'default' | 'premium' | 'empty'} props.pageLayoutType
+ * @param {'default' | 'default-with-flash-news' | 'premium' | 'empty' } props.pageLayoutType
  * @param {HeaderData} [props.headerData]
+ * @param {JSX.Element | null} [props.children]
  * @returns {JSX.Element}
  */
 export default function ShareHeader({
@@ -42,6 +70,11 @@ export default function ShareHeader({
       case 'default': {
         const defaultHeader = getDefaultHeader(headerData)
         return defaultHeader
+      }
+      case 'default-with-flash-news': {
+        const defaultHeaderWithFlashNews =
+          getDefaultHeaderWithFlashNews(headerData)
+        return defaultHeaderWithFlashNews
       }
       case 'premium': {
         const premiumHeader = getPremiumHeader(headerData)

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -3,7 +3,7 @@
 //TODO: add typedef of editor choice data
 //TODO: add component to add html head dynamically, not jus write head in every pag
 //TODO: add jsDoc of `props.sectionsData`
-import React, { useMemo } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import axios from 'axios'
 import errors from '@twreporter/errors'
@@ -19,9 +19,7 @@ import {
 } from '../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../utils/api'
 import { transformRawDataToArticleInfo } from '../utils'
-import FlashNews from '../components/flash-news'
-import NavTopics from '../components/nav-topics'
-import SubscribeMagazine from '../components/subscribe-magazine'
+
 import EditorChoice from '../components/editor-choice'
 import LatestNews from '../components/latest-news'
 import ShareHeader from '../components/shared/share-header'
@@ -34,10 +32,6 @@ const IndexContainer = styled.main`
     height: 500vh;
   }
   margin: 0 auto;
-`
-
-const IndexTop = styled.div`
-  display: flex;
 `
 
 /**
@@ -59,34 +53,18 @@ export default function Home({
   latestNewsTimestamp,
   sectionsData = [],
 }) {
-  const flashNews = flashNewsData.map(({ slug, title }) => {
-    return {
-      title,
-      slug,
-      href: `/story/${slug}`,
-    }
-  })
   const editorChoice = transformRawDataToArticleInfo(editorChoicesData)
-  const topics = useMemo(
-    () => topicsData.filter((topic) => topic.isFeatured).slice(0, 9) ?? [],
-    [topicsData]
-  )
 
   return (
     <>
       <ShareHeader
-        pageLayoutType="default"
-        headerData={{ sectionsData: sectionsData, topicsData }}
+        pageLayoutType="default-with-flash-news"
+        headerData={{ sectionsData, topicsData, flashNewsData }}
       />
       <Head>
         <title>鏡週刊 Mirror Media</title>
       </Head>
       <IndexContainer>
-        <FlashNews flashNews={flashNews} />
-        <IndexTop>
-          <NavTopics topics={topics} />
-          <SubscribeMagazine />
-        </IndexTop>
         <EditorChoice editorChoice={editorChoice}></EditorChoice>
         <LatestNews
           latestNewsData={latestNewsData}


### PR DESCRIPTION
## Notable Change
1. 因需求需要於首頁中顯示快訊，但位置需要於section與topics的中間，所以針對share-header，新增一個type為 `default-with-flash-news`，並於該元件中使用快訊元件。
2. 當pageLayout為`default-with-flash-news`時，會依據傳入的`headerData.flashNewsData`，將其傳入元件`flash-news`，並將該元件傳入另一元件`header`
4. 調整元件header，使其能顯示topics與傳入的flashnews。