### PR TITLE
feat(mm-next): bump `@mirrormedia/lilith-draft-renderer`, add header placeholder, mark time are in taipei timezone

### DIFF
--- a/packages/mirror-media-next/components/story/normal/article-info.js
+++ b/packages/mirror-media-next/components/story/normal/article-info.js
@@ -236,8 +236,8 @@ export default function ArticleInfo({
   ) : null
   return (
     <ArticleInfoContainer>
-      <Date>發布時間：{publishedDate}</Date>
-      <Date>更新時間：{updatedDate}</Date>
+      <Date>發布時間：{publishedDate} 臺北時間</Date>
+      <Date>更新時間：{updatedDate} 臺北時間</Date>
 
       {creditsJsx}
       <SocialMediaAndDonateLink>

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -333,6 +333,13 @@ const AdvertisementDableMobile = styled(AdvertisementDable)`
     width: 640px;
   }
 `
+const HeaderPlaceHolder = styled.header`
+  background-color: transparent;
+  height: 175px;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+`
 
 /**
  *
@@ -472,13 +479,17 @@ export default function StoryNormalStyle({ postData }) {
   }, [isHeaderDataLoaded])
   return (
     <>
-      <ShareHeader
-        pageLayoutType="default"
-        headerData={{
-          sectionsData: headerData.sectionsData,
-          topicsData: headerData.topicsData,
-        }}
-      ></ShareHeader>
+      {isHeaderDataLoaded ? (
+        <ShareHeader
+          pageLayoutType="default"
+          headerData={{
+            sectionsData: headerData.sectionsData,
+            topicsData: headerData.topicsData,
+          }}
+        ></ShareHeader>
+      ) : (
+        <HeaderPlaceHolder />
+      )}
 
       <PC_HD_Advertisement
         width="970px"

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -525,7 +525,7 @@ export default function StoryNormalStyle({ postData }) {
           <ArticleContent content={content} />
           <DateUnderContent>
             <span>更新時間｜</span>
-            <span className="time">{updatedTaipeiTime}</span>
+            <span className="time">{updatedTaipeiTime} 臺北時間</span>
           </DateUnderContent>
           <DonateBanner />
           <SocialNetworkServiceSmall />

--- a/packages/mirror-media-next/components/story/wide/credits.js
+++ b/packages/mirror-media-next/components/story/wide/credits.js
@@ -11,7 +11,7 @@ const Wrapper = styled.section`
   margin: 24px auto;
 `
 
-const Credits = styled.section`
+const CreditsWrapper = styled.section`
   font-size: 16px;
   font-weight: 400;
   display: flex;
@@ -116,20 +116,17 @@ const CREDIT_TITLE_NAME_MAP = {
 
 /**
  * @param {Object} props
- * @param {string} props.updatedDate
- * @param {string} props.publishedDate
  * @param {Credit[]} props.credits
- * @param {Tags} props.tags
  * @returns {JSX.Element}
  */
-export default function CreditsWra({ credits }) {
+export default function Credits({ credits }) {
   const shouldShowCredits = credits.some((credit) => {
     const [people] = Object.values(credit)
     return people.length !== 0 || (typeof people === 'string' && people.trim())
   })
 
   const creditsJsx = shouldShowCredits ? (
-    <Credits>
+    <CreditsWrapper>
       {credits.map((credit, index) => {
         const title = Object.keys(credit)
         const titleName = CREDIT_TITLE_NAME_MAP[title]
@@ -168,7 +165,7 @@ export default function CreditsWra({ credits }) {
           </CreditList>
         )
       })}
-    </Credits>
+    </CreditsWrapper>
   ) : null
 
   return <Wrapper>{creditsJsx}</Wrapper>

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -259,8 +259,8 @@ export default function StoryWideStyle({ postData }) {
             </NavSubtitleNavigator>
             <Credits credits={credits}></Credits>
             <DateWrapper>
-              <Date>更新時間 {updatedAtFormatTime}</Date>
-              <Date>發布時間 {publishedDateFormatTime}</Date>
+              <Date>更新時間 {updatedAtFormatTime} 臺北時間</Date>
+              <Date>發布時間 {publishedDateFormatTime} 臺北時間</Date>
             </DateWrapper>
             <StyledDonateLink />
             <section className="content">

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",
-    "@mirrormedia/lilith-draft-renderer": "1.2.0-alpha.14",
+    "@mirrormedia/lilith-draft-renderer": "1.2.0-alpha.18",
     "@next/font": "^13.1.2",
     "@readr-media/react-image": "^1.5.1",
     "@svgr/webpack": "^6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,10 +1299,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@mirrormedia/lilith-draft-renderer@1.2.0-alpha.14":
-  version "1.2.0-alpha.14"
-  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.14.tgz#fb0cad150b8f9d9422de90ebbb506d7da103cd26"
-  integrity sha512-LpJPkmo87P5Hp0A17H4zQ+dKlfG8oY5sQYhe17BEoK/jp8HI/5m9BiC7+xSizenuslcaYDM25ZdaOzX9HL3jUw==
+"@mirrormedia/lilith-draft-renderer@1.2.0-alpha.18":
+  version "1.2.0-alpha.18"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.18.tgz#453bf3f8eebc75c50d6f15d06d572f10eab510ef"
+  integrity sha512-9a3Hw3jCfXMBeRNseCThqrCDjvY5JxyZ7T55CZpQNFIoqXOzWfw3xAkwvOiInWIJM6JM834uSzO1SIVK5TeTRw==
   dependencies:
     "@readr-media/react-image" "^1.5.1"
     body-scroll-lock "3.1.5"


### PR DESCRIPTION
## Notable Change
1. 套件`@mirrormedia/lilith-draft-renderer`升至`1.2.0-alpha.18`，新套件調整了各個區塊的間距，以及取消了預載入圖片。
2. 針對文章頁一般樣式的header，新增了placeholder：由於文章頁一般樣式的header是在client side才會載入元件與抓取資料，如果使用者網路環境較差，會導致內文(server side就已經先抓取資料）先出現後，header才抓取完資料並載入，除了會導致CLS問題外，使用者體驗也較差。目前的解法是針對該區塊放置一個placeholder，只有當header的資料抓取完畢後，才會顯示header。placeholder的寬高與header一致，以避免CLS問題。
3. 調整元件Credits的jsDoc，刪除無用的`@param`
4. 將文章的發佈時間、更新時間都標註為「臺北時間」。