### PR TITLE
feat(mm-next): update sections color, render content and brief in story `premium` layout

### DIFF
--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -9,7 +9,7 @@ import axios from 'axios'
 import errors from '@twreporter/errors'
 import MockAdvertisement from '../../../components/mock-advertisement'
 import ArticleInfo from '../../../components/story/normal/article-info'
-import ArticleBrief from '../../../components/story/normal/brief'
+import ArticleBrief from '../shared/brief'
 import AsideArticleList from '../../../components/story/normal/aside-article-list'
 import FbPagePlugin from '../../../components/story/normal/fb-page-plugin'
 import SocialNetworkService from '../../../components/story/normal/social-network-service'
@@ -53,7 +53,7 @@ import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
  */
 
 /**
- * @typedef {import('./brief').Brief} Brief
+ * @typedef {import('../shared/brief').Brief} Brief
  */
 /**
  * @typedef {import('./article-content').Content} Content

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -1,3 +1,62 @@
-export default function StoryPremiumStyle() {
-  return <div>這是Premium版型</div>
+import styled from 'styled-components'
+import DraftRenderBlock from '../shared/draft-renderer-block'
+import ArticleBrief from '../shared/brief'
+/**
+ * @typedef {import('../../../apollo/fragments/post').Post} PostData
+ */
+
+const Main = styled.main`
+  width: 100%;
+  margin: auto;
+`
+
+const ContentWrapper = styled.section`
+  width: 100%;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 0 20px 20px;
+  border: none;
+  position: relative;
+  .content {
+    width: 100%;
+    margin: 20px auto 0;
+    max-width: 640px;
+  }
+
+  ${({ theme }) => theme.breakpoint.md} {
+    padding: 0 0 32px;
+
+    border-bottom: 1px black solid;
+    .content {
+      margin: 40px auto 0;
+    }
+  }
+`
+/**
+ *
+ * @param {Object} props
+ * @param {PostData} props.postData
+ * @returns {JSX.Element}
+ */
+export default function StoryPremiumStyle({ postData }) {
+  const { content, brief } = postData
+  return (
+    <Main>
+      <article>
+        <ContentWrapper>
+          <section className="content">
+            <ArticleBrief
+              sectionSlug="member"
+              brief={brief}
+              contentLayout="premium"
+            ></ArticleBrief>
+            <DraftRenderBlock
+              contentLayout="premium"
+              rawContentBlock={content}
+            ></DraftRenderBlock>
+          </section>
+        </ContentWrapper>
+      </article>
+    </Main>
+  )
 }

--- a/packages/mirror-media-next/components/story/shared/brief.js
+++ b/packages/mirror-media-next/components/story/shared/brief.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import DraftRenderBlock from '../shared/draft-renderer-block'
+import DraftRenderBlock from './draft-renderer-block'
 
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
@@ -25,10 +25,11 @@ const BriefContainer = styled.div`
   font-weight: 500;
   font-size: 18px;
   line-height: 36px;
+
   ${({ theme }) => theme.breakpoint.md} {
     font-weight: 400;
     font-size: 19.2px;
-    padding: 19.2px 48.6px 20.8px 28.4px;
+    padding: 24px 32px;
   }
   *,
   *::before,
@@ -38,20 +39,22 @@ const BriefContainer = styled.div`
 `
 
 /**
- *
+ * Component for render brief in `normal` and `premium` story layout
  * @param {Object} props
  * @param {Brief} props.brief
  * @param {String} [props.sectionSlug]
+ * @param { 'normal' | 'wide' | 'photography' | 'premium' } [props.contentLayout]
  * @returns {JSX.Element}
  */
 export default function ArticleBrief({
   brief = { blocks: [], entityMap: {} },
   sectionSlug = '',
+  contentLayout = 'normal',
 }) {
   return (
     <DraftRenderBlock
       rawContentBlock={brief}
-      contentLayout="normal"
+      contentLayout={contentLayout}
       wrapper={(children) => (
         <BriefContainer sectionSlug={sectionSlug}>{children}</BriefContainer>
       )}

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",
-    "@mirrormedia/lilith-draft-renderer": "1.2.0-alpha.18",
+    "@mirrormedia/lilith-draft-renderer": "1.2.0-alpha.20",
     "@next/font": "^13.1.2",
     "@readr-media/react-image": "^1.5.1",
     "@svgr/webpack": "^6.3.1",

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -91,7 +91,7 @@ export default function Story({ postData }) {
       case 'style-photography':
         return <StoryPhotographyStyle />
       case 'style-premium':
-        return <StoryPremiumStyle />
+        return <StoryPremiumStyle postData={postData} />
       default:
         return <StoryNormalStyle postData={postData} />
     }

--- a/packages/mirror-media-next/styles/theme/color.js
+++ b/packages/mirror-media-next/styles/theme/color.js
@@ -6,18 +6,18 @@ const brandColor = {
   gray: '#888888',
 }
 const sectionsColor = {
-  member: '#e51731',
+  member: '#000000',
   news: '#61B8C6',
   entertainment: '#D43E96',
   businessmoney: '#07B53B',
-  people: '#efa256', //not updated yet
+  people: '#E8C15E',
   videohub: '#B9B9B9',
-  international: '#911f27', //not updated yet
-  foodtravel: '#eac151', //not updated yet
+  international: '#911F56',
+  foodtravel: '#FF9598',
   mafalda: '#8F39CE',
   culture: '#A8CF68',
   carandwatch: '#1877F2',
-  external: '#30bac8', //not updated yet
+  external: '#2ECDA7',
   mirrorcolumn: '#B79479',
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,10 +1299,10 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@mirrormedia/lilith-draft-renderer@1.2.0-alpha.18":
-  version "1.2.0-alpha.18"
-  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.18.tgz#453bf3f8eebc75c50d6f15d06d572f10eab510ef"
-  integrity sha512-9a3Hw3jCfXMBeRNseCThqrCDjvY5JxyZ7T55CZpQNFIoqXOzWfw3xAkwvOiInWIJM6JM834uSzO1SIVK5TeTRw==
+"@mirrormedia/lilith-draft-renderer@1.2.0-alpha.20":
+  version "1.2.0-alpha.20"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.20.tgz#f880607d14ac5b330e3d8bd64dd68384f48ad318"
+  integrity sha512-FpUROIRbL21gl/OBOPszsYCuaG3uAxhRVWRotBoIaNfU4AoTz3sPhNAA8sxW4yPkz/HrMYUh1cXo2IE6S2/oYA==
   dependencies:
     "@readr-media/react-image" "^1.5.1"
     body-scroll-lock "3.1.5"


### PR DESCRIPTION
## Notable Change
1. 更新sections color設定集
2. 將story頁元件`ArticleBrief`移至`shared`，以用於顯示一般版型與premium版型的前言，並新增props `contentLayout`，以用於控制需要顯示哪種版型的draft-renderer。
3. 套件`@mirrormedia/lilith-draft-renderer`升版，該套件版本更新了premium版型的樣式。