### PR TITLE
feat(mm-next): add shared component `tags`, render tags in story wide layout

### DIFF
--- a/packages/mirror-media-next/components/story/normal/article-info.js
+++ b/packages/mirror-media-next/components/story/normal/article-info.js
@@ -4,6 +4,7 @@ import Image from 'next/image'
 import ButtonCopyLink from '../shared/button-copy-link'
 import DonateLink from '../shared/donate-link'
 import ButtonSocialNetworkShare from '../shared/button-social-network-share'
+import Tags from '../shared/tags'
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
  */
@@ -53,30 +54,6 @@ const CreditList = styled.span`
 
   .no-link {
     color: rgba(52, 73, 94, 1);
-  }
-`
-
-const Tag = styled.a`
-  font-size: 14px;
-  line-height: 20px;
-  padding: 4px 8px;
-  border-radius: 2px;
-  background-color: ${
-    /**
-     * @param {{theme:Theme}} param
-     */
-    ({ theme }) => theme.color.brandColor.darkBlue
-  };
-  color: white;
-  font-weight: 400;
-`
-const Tags = styled.div`
-  display: flex;
-  gap: 12px 8px;
-  flex-wrap: wrap;
-  margin-top: 20px;
-  ${({ theme }) => theme.breakpoint.md} {
-    margin-top: 25.5px;
   }
 `
 
@@ -187,7 +164,6 @@ export default function ArticleInfo({
     return people.length !== 0 || (typeof people === 'string' && people.trim())
   })
 
-  const shouldShowTags = tags && tags.length
   const creditsJsx = shouldShowCredits ? (
     <Credits>
       {credits.map((credit, index) => {
@@ -224,16 +200,12 @@ export default function ArticleInfo({
       })}
     </Credits>
   ) : null
-
-  const tagsJsx = shouldShowTags ? (
-    <Tags>
-      {tags.map((tag) => (
-        <Tag key={tag.id} href={`/tag/${tag.slug}`} target="_blank">
-          {tag.name}
-        </Tag>
-      ))}
-    </Tags>
-  ) : null
+  const StyledTags = styled(Tags)`
+    margin-top: 20px;
+    ${({ theme }) => theme.breakpoint.md} {
+      margin-top: 25.5px;
+    }
+  `
   return (
     <ArticleInfoContainer>
       <Date>發布時間：{publishedDate} 臺北時間</Date>
@@ -256,7 +228,7 @@ export default function ArticleInfo({
         </SocialMedia>
         <DonateLink />
       </SocialMediaAndDonateLink>
-      {tagsJsx}
+      <StyledTags tags={tags} />
     </ArticleInfoContainer>
   )
 }

--- a/packages/mirror-media-next/components/story/shared/tags.js
+++ b/packages/mirror-media-next/components/story/shared/tags.js
@@ -1,0 +1,83 @@
+import styled from 'styled-components'
+
+/**
+ * @typedef {import('../../../apollo/fragments/tag').Tag[]}Tags
+ */
+
+/**
+ * @typedef {import('../../../type/theme').Theme} Theme
+ */
+
+const TagsWrapper = styled.section`
+  display: flex;
+  justify-content: start;
+  width: 100%;
+  flex-wrap: wrap;
+  /* gap: 8px; */
+  .tag {
+    font-size: 14px;
+    line-height: 20px;
+    padding: 4px 8px;
+    margin-bottom: 8px;
+    margin-right: 8px;
+    border-radius: 2px;
+    background-color: ${
+      /**
+       * @param {{theme:Theme}} param
+       */
+      ({ theme }) => theme.color.brandColor.darkBlue
+    };
+
+    background-color: #000;
+    color: white;
+    font-weight: 400;
+  }
+`
+const Tag = styled.a`
+  font-size: 14px;
+  line-height: 20px;
+  padding: 4px 8px;
+  margin-bottom: 8px;
+  margin-right: 8px;
+  border-radius: 2px;
+  background-color: ${
+    /**
+     * @param {{theme:Theme, tagColor: ?string}} param
+     */
+    ({ theme, tagColor }) =>
+      tagColor && theme.color.brandColor[tagColor]
+        ? `${theme.color.brandColor[tagColor]}`
+        : '#000'
+  };
+
+  color: white;
+  font-weight: 400;
+`
+/**
+ *
+ * @param {Object} props
+ * @param {Tags} props.tags
+ * @param {string} [props.tagColor]
+ * @param {string} [props.className] - Attribute for updating style by styled-component
+ * @returns {JSX.Element}
+ */
+export default function Tags({ tags, tagColor = 'darkBlue', className = '' }) {
+  const shouldShowTags = tags && tags.length
+  const tagsJsx = shouldShowTags ? (
+    <TagsWrapper className={className}>
+      {tags.map((tag) => (
+        <Tag
+          tagColor={tagColor}
+          key={tag.id}
+          href={`/tag/${tag.slug}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {tag.name}
+        </Tag>
+      ))}
+    </TagsWrapper>
+  ) : null
+
+  return <>{tagsJsx}</>
+}

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -7,7 +7,6 @@ import client from '../../../apollo/apollo-client'
 import DraftRenderBlock from '../shared/draft-renderer-block'
 import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
 const { getContentBlocksH2H3 } = MirrorMedia
-
 import {
   transformTimeDataIntoDotFormat,
   sortArrayWithOtherArrayId,
@@ -22,6 +21,7 @@ import DonateBanner from '../shared/donate-banner'
 import RelatedArticleList from './related-article-list'
 import AsideArticleList from './aside-article-list'
 import NavSubtitleNavigator from './nav-subtitle-navigator'
+import MoreInfoAndTag from './more-info-and-tag'
 
 import Divider from '../shared/divider'
 import ButtonCopyLink from '../shared/button-copy-link'
@@ -33,6 +33,9 @@ import { fetchAsidePosts } from '../../../apollo/query/posts'
  * @typedef {import('../../../apollo/fragments/post').Post} PostData
  */
 
+/**
+ * @typedef {import('../../../type/theme').Theme} Theme
+ */
 const Main = styled.main`
   margin: auto;
   width: 100%;
@@ -74,12 +77,9 @@ const ContentWrapper = styled.section`
   .content {
     width: 100%;
     margin: 20px auto 0;
-    max-width: 640px;
   }
 
   ${({ theme }) => theme.breakpoint.md} {
-    padding: 0 0 32px;
-
     border-bottom: 1px black solid;
     .content {
       margin: 40px auto 0;
@@ -87,14 +87,9 @@ const ContentWrapper = styled.section`
   }
 `
 const StyledDonateBanner = styled(DonateBanner)`
-  margin-left: 10px;
-  margin-right: 10px;
+  margin-left: auto;
+  margin-right: auto;
   width: 100%;
-  max-width: 640px;
-  ${({ theme }) => theme.breakpoint.md} {
-    margin-left: auto;
-    margin-right: auto;
-  }
 `
 const Aside = styled.aside`
   width: 100%;
@@ -153,6 +148,7 @@ export default function StoryWideStyle({ postData }) {
     slug = '',
     content = null,
     brief = null,
+    tags = [],
   } = postData
   const updatedAtFormatTime = transformTimeDataIntoDotFormat(updatedAt)
   const publishedDateFormatTime = transformTimeDataIntoDotFormat(publishedDate)
@@ -270,7 +266,7 @@ export default function StoryWideStyle({ postData }) {
                 contentLayout="wide"
               />
             </section>
-
+            <MoreInfoAndTag tags={tags} />
             <StyledDonateBanner />
           </ContentWrapper>
           <Aside>

--- a/packages/mirror-media-next/components/story/wide/more-info-and-tag.js
+++ b/packages/mirror-media-next/components/story/wide/more-info-and-tag.js
@@ -1,0 +1,67 @@
+import styled from 'styled-components'
+import Link from 'next/link'
+import Tags from '../shared/tags'
+/**
+ * @typedef {import('../../../type/theme').Theme} Theme
+ */
+
+/**
+ * @typedef {import('../../../apollo/fragments/tag').Tag[]}Tags
+ */
+
+const Wrapper = styled.section`
+  margin-top: 32px;
+  .copyright-warning {
+    color: rgba(0, 0, 0, 0.5);
+    font-size: 14px;
+    line-height: 1.8;
+  }
+  .more-info {
+    display: none;
+    ${
+      /**
+       * @param {{theme: Theme}} param
+       */
+      ({ theme }) => theme.breakpoint.md
+    } {
+      display: block;
+      margin-top: 8px;
+      color: rgba(0, 0, 0, 0.5);
+      font-size: 14px;
+      line-height: 1.8;
+    }
+    .link {
+      color: ${({ theme }) => theme.color.brandColor.darkBlue};
+    }
+  }
+`
+const StyledTags = styled(Tags)`
+  margin-top: 32px;
+`
+/**
+ *
+ * @param {Object} props
+ * @param {Tags} props.tags
+ * @returns {JSX.Element}
+ */
+export default function MoreInfoAndTag({ tags }) {
+  return (
+    <Wrapper>
+      <p className="copyright-warning">
+        本新聞文字、照片、影片專供鏡週刊會員閱覽，未經鏡週刊授權，任何媒體、社群網站、論壇等均不得引用、改寫、轉貼，以免訟累。
+      </p>
+      <p className="more-info">
+        更多內容，歡迎
+        <Link className="link" href="/papermag">
+          訂閱鏡週刊
+        </Link>
+        、
+        <Link className="link" href="/story/webauthorize">
+          了解內容授權資訊
+        </Link>
+        。
+      </p>
+      <StyledTags tags={tags}></StyledTags>
+    </Wrapper>
+  )
+}


### PR DESCRIPTION
## Notable Change
1. 新增共用元件`tags`，用於顯示story頁的標籤
2. 使用該元件於story頁一般版型與wide版型