### PR TITLE
feat(story): add `adult-only-warning` in story page

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -117,6 +117,7 @@ export const asideListingPost = gql`
  * @property {PostState} state - post state, different states will have different post access of viewing
  * @property {'article'| 'wide' | 'projects' | 'photography' | 'script' | 'campaign' | 'readr'} style - what kind of article style is
  * @property {boolean} isMember - whether this post is a member article
+ * @property {boolean} isAdult - whether this post only adults can read
  * @property {Section[] | null } sections - which sections does this post belong to
  * @property {Section[] | null} manualOrderOfSections - sections with adjusted order
  * @property {Pick<Category, 'id' | 'name'  | 'slug'>[] } categories - which categories does this post belong to
@@ -154,6 +155,7 @@ export const post = gql`
 
     style
     isMember
+    isAdult
     publishedDate
     updatedAt
     sections {

--- a/packages/mirror-media-next/components/story/shared/adult-only-warning.js
+++ b/packages/mirror-media-next/components/story/shared/adult-only-warning.js
@@ -1,0 +1,145 @@
+import styled from 'styled-components'
+import { Z_INDEX } from '../../../constants'
+import NextLink from 'next/link'
+import { useState, useEffect, useRef } from 'react'
+import {
+  disableBodyScroll,
+  enableBodyScroll,
+  clearAllBodyScrollLocks,
+} from 'body-scroll-lock'
+
+const Wrapper = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.9);
+  z-index: ${Z_INDEX.top};
+`
+
+const WarningContent = styled.div`
+  width: 90%;
+  max-width: 500px;
+  padding: 20px;
+  background-color: #fafafa;
+  border-radius: 10px;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    padding: 30px;
+  }
+
+  p {
+    color: #333;
+    font-size: 16px;
+    text-align: justify;
+    line-height: 1.5;
+    margin: 25px 0;
+  }
+`
+
+const WarningTitle = styled.h2`
+  padding: 0 0 20px;
+  color: #34495e;
+  font-size: 26px;
+  line-height: 1.5;
+  text-align: center;
+  border-bottom: 1px solid #d9d9d9;
+`
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0 16px;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    justify-content: flex-end;
+  }
+
+  button {
+    display: inline-block;
+    font-size: 14px;
+    padding: 10px 18px;
+    background: #ffffff;
+    border: 1px solid #c1c2c5;
+    border-radius: 5px;
+  }
+
+  .agree-button {
+    color: #fff;
+    background: #1087a8;
+    border: none;
+
+    &:hover {
+      background: #0e7ea0;
+    }
+  }
+`
+
+/**
+ *
+ * @param {Object} props
+ * @param {boolean} props.isAdult
+ * @returns {JSX.Element}
+ */
+
+export default function AdultOnlyWarning({ isAdult = false }) {
+  const [isAgreed, setIsAgreed] = useState(false)
+
+  const shouldShowAdultWarning = Boolean(isAdult && !isAgreed)
+
+  const warningRef = useRef(null)
+
+  useEffect(() => {
+    const adultWarning = warningRef.current
+
+    if (adultWarning) {
+      disableBodyScroll(adultWarning)
+    } else {
+      enableBodyScroll(adultWarning)
+    }
+
+    return () => {
+      clearAllBodyScrollLocks()
+    }
+  }, [shouldShowAdultWarning])
+
+  const adultOnlyJsx = shouldShowAdultWarning ? (
+    <Wrapper ref={warningRef}>
+      <WarningContent>
+        <WarningTitle>
+          您即將進入之內容
+          <br />
+          需滿十八歲方可瀏覽
+        </WarningTitle>
+
+        <p>
+          根據「電腦網路內容分級處理辦法」第六條第三款規定，本網站已於各限制級網頁依照台灣網站分級推廣基金會之規定標示。若您尚未年滿十八歲，請點選離開。若您已滿十八歲，亦不可將本區之內容派發、傳閱、出售、出租、交給或借予年齡未滿18歲的人士瀏覽，或將本網站內容向該人士出示、播放或放映。
+        </p>
+
+        <ButtonWrapper>
+          <button
+            className="agree-button"
+            onClick={() => {
+              setIsAgreed(true)
+            }}
+            aria-label="是，我已年滿十八歲"
+          >
+            是，我已年滿十八歲
+          </button>
+          <NextLink href="/" aria-label="離開">
+            <button>離開</button>
+          </NextLink>
+        </ButtonWrapper>
+      </WarningContent>
+    </Wrapper>
+  ) : null
+
+  return <>{adultOnlyJsx}</>
+}

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -7,6 +7,7 @@ import Head from 'next/head'
 import dynamic from 'next/dynamic'
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import WineWarning from '../../components/story/shared/wine-warning'
+import AdultOnlyWarning from '../../components/story/shared/adult-only-warning'
 
 import { fetchPostBySlug } from '../../apollo/query/posts'
 import StoryNormalStyle from '../../components/story/normal'
@@ -84,6 +85,7 @@ export default function Story({ postData }) {
     title = '',
     style = 'article',
     isMember = false,
+    isAdult = false,
     categories = [],
   } = postData
 
@@ -136,6 +138,7 @@ export default function Story({ postData }) {
       {!storyLayout && <MockLoading>Loading...</MockLoading>}
       <div style={{ display: `${storyLayout ? 'block' : 'none'}` }}>{jsx}</div>
       <WineWarning categories={categories} />
+      <AdultOnlyWarning isAdult={isAdult} />
     </>
   )
 }


### PR DESCRIPTION
## 需求說明
- 當 `Posts` 的「18禁」欄位被勾選時，頁面需出現警示屏蔽頁面，如選取「離開」則導回週刊首頁。

## 調整
- 新增 `adult-only-warning` 元件，傳入 `isAdult` 判斷是否出現警示屏蔽頁面。
- 配合上述調整，`Post` 的 query 與 JSdoc 新增 `isAdult` 參數。
- 當警示出現時，使用 `body-scroll-lock` 禁止頁面被上下滑動。
- 使用 `constants/ Z_INDEX.top` ，設定警示訊息高於頁面一切資訊。