### PR TITLE
feat(story): add `redirect` determination in story page

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -139,6 +139,7 @@ export const asideListingPost = gql`
  * @property {Related[] | null} manualOrderOfRelateds related articles with adjusted order
  * @property {boolean} isFeatured
  * @property {import('./tag').Tag[]} tags
+ * @property {string} redirect - post redirect slug or external url
  */
 
 export const post = gql`
@@ -206,5 +207,6 @@ export const post = gql`
       }
     }
     manualOrderOfRelateds
+    redirect
   }
 `

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -174,21 +174,27 @@ export async function getServerSideProps({ params, req }) {
     const redirectData = postData?.redirect.trim()
 
     if (redirectData.length > 0) {
-      if (redirectData.charAt(0) === '/') {
-        const redirectSlug = redirectData.substring(1).trim()
+      if (
+        redirectData.startsWith('https://') ||
+        redirectData.startsWith('http://')
+      ) {
         return {
           redirect: {
-            destination: `${redirectSlug} `,
+            destination: `${redirectData} `,
+            permanent: false,
+          },
+        }
+      } else if (redirectData.startsWith('www.')) {
+        return {
+          redirect: {
+            destination: `https://${redirectData}`,
             permanent: false,
           },
         }
       } else {
-        const formattedRedirectUrl = redirectData.startsWith('http')
-          ? redirectData
-          : `https://${redirectData}`
         return {
           redirect: {
-            destination: `${formattedRedirectUrl}`,
+            destination: `/story/${redirectData} `,
             permanent: false,
           },
         }

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -170,6 +170,31 @@ export async function getServerSideProps({ params, req }) {
       return { notFound: true }
     }
 
+    //redirect to specific slug or external url
+    const redirectData = postData?.redirect.trim()
+
+    if (redirectData.length > 0) {
+      if (redirectData.charAt(0) === '/') {
+        const redirectSlug = redirectData.substring(1).trim()
+        return {
+          redirect: {
+            destination: `${redirectSlug} `,
+            permanent: false,
+          },
+        }
+      } else {
+        const formattedRedirectUrl = redirectData.startsWith('http')
+          ? redirectData
+          : `https://${redirectData}`
+        return {
+          redirect: {
+            destination: `${formattedRedirectUrl}`,
+            permanent: false,
+          },
+        }
+      }
+    }
+
     return {
       props: {
         postData,

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -174,7 +174,7 @@ export async function getServerSideProps({ params, req }) {
     const redirect = postData?.redirect
 
     if (redirect && redirect.trim()) {
-      const redirectHref = postData?.redirect.trim()
+      const redirectHref = redirect.trim()
       if (
         redirectHref.startsWith('https://') ||
         redirectHref.startsWith('http://')

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -171,30 +171,31 @@ export async function getServerSideProps({ params, req }) {
     }
 
     //redirect to specific slug or external url
-    const redirectData = postData?.redirect.trim()
+    const redirect = postData?.redirect
 
-    if (redirectData.length > 0) {
+    if (redirect && redirect.trim()) {
+      const redirectHref = postData?.redirect.trim()
       if (
-        redirectData.startsWith('https://') ||
-        redirectData.startsWith('http://')
+        redirectHref.startsWith('https://') ||
+        redirectHref.startsWith('http://')
       ) {
         return {
           redirect: {
-            destination: `${redirectData} `,
+            destination: `${redirectHref} `,
             permanent: false,
           },
         }
-      } else if (redirectData.startsWith('www.')) {
+      } else if (redirectHref.startsWith('www.')) {
         return {
           redirect: {
-            destination: `https://${redirectData}`,
+            destination: `https://${redirectHref}`,
             permanent: false,
           },
         }
       } else {
         return {
           redirect: {
-            destination: `/story/${redirectData} `,
+            destination: `/story/${redirectHref} `,
             permanent: false,
           },
         }


### PR DESCRIPTION
## 需求說明
- 當 `Posts` 的「廣編文轉址 slug」欄位有資料時，進行轉址：

   - 當填寫 `/[slugname]` 時，導向至對應的指令 slug 頁面。
   - 當填寫內容為「外連網址」時，導向至對應網址。
   - [asana task](https://app.asana.com/0/1181156545719626/1204510728090477/f)

## 調整
- `Post` 的 query 與 JSdoc 新增 `redirect` 參數。
- 於 `story/[slug]` 的 getServerSideProps 階段，取得 `postData` 的 `redirect` 資訊，並實作以下判斷：

   - 移除 `redirect` 資料字串內頭尾空白，避免使用者誤填「 `'   '` 」的狀況。
   - 如 `redirect` 資料以 ' / ' 為首，判斷為導向指定 `slug`，檢查＋移除頭尾空白，並導向 `/story/[redirectSlug]`。
   - 如 `redirect` 資料沒有以 ' / ' 為首，判斷為導向「外部網址」，並進行 `http` 檢查，避免使用者填入不包含 `http`、`https` 的網址資料，卻無法順利轉址的狀況。（ ex: www.youtube.com/ ）
   