### PR TITLE
feat(mm-next): adjust premium-header, add subtitle navigator if needed

### DIFF
--- a/packages/mirror-media-next/components/premium-header.js
+++ b/packages/mirror-media-next/components/premium-header.js
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react'
 import styled from 'styled-components'
 
 import SearchBarDesktop from './search-bar-desktop'
-
+import { Z_INDEX } from '../constants'
 import SearchBarInput from './search-bar-input'
 import Logo from './logo'
 import PremiumMobileSidebar from './premium-mobile-sidebar'
@@ -10,9 +10,23 @@ import PremiumNavSections from './premium-nav-sections'
 import PremiumMemberLoginButton from './premium-member-login-button'
 import { SEARCH_URL } from '../config/index.mjs'
 
+/**
+ * @typedef {import('./premium-mobile-sidebar').H2AndH3Block} H2AndH3Block
+ */
 const HeaderWrapper = styled.div`
   background-color: rgba(255, 255, 255, 1);
   margin: 0 auto;
+  ${
+    /**
+     * @param {Object} param
+     * @param {boolean} param.shouldSticky
+     */
+    ({ shouldSticky }) =>
+      shouldSticky &&
+      `position: sticky;
+    z-index: ${Z_INDEX.header};
+    top: 0;`
+  }
 `
 const HeaderTop = styled.div`
   display: flex;
@@ -158,9 +172,15 @@ const MobilePremiumMemberLoginButton = styled(PremiumMemberLoginButton)`
 /**
  * @param {Object} props
  * @param {PremiumHeaderData} props.premiumHeaderData
+ * @param {boolean} [props.shouldShowSubtitleNavigator]
+ * @param {H2AndH3Block[]} [props.h2AndH3Block]
  * @returns {React.ReactElement}
  */
-export default function PremiumHeader({ premiumHeaderData }) {
+export default function PremiumHeader({
+  premiumHeaderData,
+  shouldShowSubtitleNavigator = false,
+  h2AndH3Block = [],
+}) {
   const [showSearchField, setShowSearchField] = useState(false)
   const [searchTerms, setSearchTerms] = useState('')
   const mobileSearchButtonRef = useRef(null)
@@ -206,7 +226,7 @@ export default function PremiumHeader({ premiumHeaderData }) {
   const sections = premiumHeaderData.sections
 
   return (
-    <HeaderWrapper>
+    <HeaderWrapper shouldSticky={shouldShowSubtitleNavigator}>
       <HeaderTop>
         {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
         <a href="/">
@@ -223,7 +243,11 @@ export default function PremiumHeader({ premiumHeaderData }) {
             <img src="/images/search-button-mobile.svg" alt="search-button" />
           </SearchButtonMobile>
           <MobilePremiumMemberLoginButton />
-          <PremiumMobileSidebar sections={sections} />
+          <PremiumMobileSidebar
+            sections={sections}
+            shouldShowSubtitleNavigator={shouldShowSubtitleNavigator}
+            h2AndH3Block={h2AndH3Block}
+          />
         </ActionWrapper>
       </HeaderTop>
       <HeaderBottom>

--- a/packages/mirror-media-next/components/premium-member-login-button.js
+++ b/packages/mirror-media-next/components/premium-member-login-button.js
@@ -70,7 +70,7 @@ const dropdownMenuItem = [
 
 /**
  * @param {Object} props
- * @param {string} props.className
+ * @param {string} [props.className]
  * @returns {React.ReactElement}
  */
 export default function PremiumMemberLoginButton({ className }) {

--- a/packages/mirror-media-next/components/premium-mobile-sidebar.js
+++ b/packages/mirror-media-next/components/premium-mobile-sidebar.js
@@ -2,7 +2,12 @@ import styled from 'styled-components'
 import React, { Fragment, useState, useRef } from 'react'
 import { sectionColors } from '../styles/sections-color'
 import useClickOutside from '../hooks/useClickOutside'
+import Link from 'next/link'
+import NavSubtitleNavigator from './story/shared/nav-subtitle-navigator'
 
+/**
+ * @typedef {import('./story/shared/nav-subtitle-navigator').H2AndH3Block} H2AndH3Block
+ */
 const SideBarButton = styled.button`
   user-select: none;
   display: block;
@@ -167,18 +172,35 @@ const Categories = styled.div`
     transition: all 0.5s ease-in-out;
   }
 `
-const SideBarTop = styled.div`
+const SideBarBottom = styled.div`
   padding: 24px;
-  margin-top: 108px;
+  margin-top: ${
+    /**
+     * @param {Object} param
+     * @param {boolean} param.isLargerMarginTop
+     */
+    ({ isLargerMarginTop }) => (isLargerMarginTop ? '108px' : 0)
+  };
+`
+const SideBarTop = styled.div`
+  background-color: #3e3e3e;
+
+  width: 100%;
 `
 
 /**
  *
  * @param {Object} props
  * @param {import('./premium-header').PremiumHeaderSection[]} props.sections
+ * @param {boolean} [props.shouldShowSubtitleNavigator]
+ * @param {H2AndH3Block[]} [props.h2AndH3Block]
  * @returns {React.ReactElement}
  */
-export default function PremiumMobileSidebar({ sections }) {
+export default function PremiumMobileSidebar({
+  sections,
+  shouldShowSubtitleNavigator = false,
+  h2AndH3Block = [],
+}) {
   const [openSidebar, setOpenSidebar] = useState(false)
   const [openSection, setOpenSection] = useState('')
   const sideBarRef = useRef(null)
@@ -194,7 +216,16 @@ export default function PremiumMobileSidebar({ sections }) {
         <i className="hamburger"></i>
       </SideBarButton>
       <SideBar shouldShowSidebar={openSidebar} ref={sideBarRef}>
-        <SideBarTop>
+        {shouldShowSubtitleNavigator && (
+          <SideBarTop>
+            <NavSubtitleNavigator
+              h2AndH3Block={h2AndH3Block}
+              componentStyle="side-bar"
+              handleCloseSideBar={() => setOpenSidebar(false)}
+            ></NavSubtitleNavigator>
+          </SideBarTop>
+        )}
+        <SideBarBottom isLargerMarginTop={!shouldShowSubtitleNavigator}>
           <CloseButton onClick={() => setOpenSidebar((val) => !val)}>
             <i className="close"></i>
           </CloseButton>
@@ -222,7 +253,7 @@ export default function PremiumMobileSidebar({ sections }) {
               </Categories>
             </Fragment>
           ))}
-        </SideBarTop>
+        </SideBarBottom>
       </SideBar>
     </>
   )

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react'
 import styled from 'styled-components'
-import ShareHeader from '../../shared/share-header'
 import DraftRenderBlock from '../shared/draft-renderer-block'
 import ArticleBrief from '../shared/brief'
 import { fetchHeaderDataInPremiumPageLayout } from '../../../utils/api'
@@ -15,6 +14,7 @@ import NavSubtitleNavigator from '../shared/nav-subtitle-navigator'
 import ButtonCopyLink from '../shared/button-copy-link'
 import ButtonSocialNetworkShare from '../shared/button-social-network-share'
 import DonateLink from '../shared/donate-link'
+import PremiumHeader from '../../premium-header'
 const { getContentBlocksH2H3 } = MirrorMedia
 /**
  * @typedef {import('../../../apollo/fragments/post').Post} PostData
@@ -186,12 +186,13 @@ export default function StoryPremiumStyle({ postData }) {
   return (
     <>
       {isHeaderDataLoaded ? (
-        <ShareHeader
-          pageLayoutType="premium"
-          headerData={{
-            sectionsData: headerData.sectionsData,
+        <PremiumHeader
+          premiumHeaderData={{
+            sections: headerData.sectionsData,
           }}
-        ></ShareHeader>
+          h2AndH3Block={h2AndH3Block}
+          shouldShowSubtitleNavigator={true}
+        ></PremiumHeader>
       ) : (
         <HeaderPlaceHolder />
       )}

--- a/packages/mirror-media-next/components/story/wide/header.js
+++ b/packages/mirror-media-next/components/story/wide/header.js
@@ -1,11 +1,7 @@
 import { useEffect, useState, useRef } from 'react'
 import styled from 'styled-components'
 import Link from 'next/link'
-import {
-  disableBodyScroll,
-  enableBodyScroll,
-  clearAllBodyScrollLocks,
-} from 'body-scroll-lock'
+import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock'
 import useClickOutside from '../../../hooks/useClickOutside'
 
 import LogoSvg from '../../../public/images/mirror-media-logo.svg'


### PR DESCRIPTION
## Notable Change
1. 因文章頁premium版型需要使用`subtitle-navigator`，故調整元件`premium-header`，新增一參數`shouldShowSubtitleNavigator`，用於改變部分樣式，並顯示元件`subtitle-navigator`。


## Need To Discuss
關於文章頁premium版型所使用的header，原有考慮三種製作方式：
1. 不管原有的premium-header，直接重刻一個，讓文章頁的header，與其他頁面的premium-header脫鉤。
2. 透過`children`將元件`subtitle-navigator`傳進既有的premium-header，也就是
```
//components/story/premium.js

....
<PremiumHeader>
    <SubtitleNavigator h2AndH3Block={h2AndH3Block} componentStyle='side-bar'/>
</PremiumHeader>

```
```
//components/premium-header.js

....
export default function PremiumHeader({children}){

return (
<HeaderWrapper>
    <PremiumSideBar>
    {children}
    </PremiumSideBar>
</HeaderWrapper>)
}
```
```
//components/premium-side-bar.js

....
export default function PremiumSideBar({children}){

return (
<>
    <SideBar>
    {children}
    </SideBar>
</>)
}
```
3. 改為傳入參數控制樣式以及是否該使用元件`subtitle-navigator`，也就是目前的做法。

由於premium header在文章頁與其他頁面的差異只有兩點：是否該顯示`subtitle-navigator`、部分樣式（[header要sticky](https://github.com/mirror-media/Adam/pull/204/commits/7770554dda4609ce3d7c2620214316b498a6362c#diff-5cb5c884028ffed4bc11ecd10477e5d70390e9877822328d70f703bd7164e6f1R24-R28)、[sidebar的margin要改變](https://github.com/mirror-media/Adam/pull/204/commits/7770554dda4609ce3d7c2620214316b498a6362c#diff-45f7eac90c659eef9798ce1231ca436ad8493c78c311b2930e7b5af6341c93e1R182)。所以第一個方法所新產生的文章頁header，與既有的premium-header，重複的程式碼太多，所以不考慮這個方法。
第二個方法則有某些缺點：
1. 由於`subtitle-navigator`需要在點擊小標後關閉sidebar，所以需要將關閉sidebar的function傳入`subtitle-navigator`中，但如果使用第一種方法的話，無法達成這個功能。
2. 雖然可以透過判斷「是否有傳入children」決定要header要不要sticky、sidebar的margin要不要改變，但如此一來，單就元件`premium-header`的角度，並無法知道傳入的`children`是什麼，也無法知道是什麼樣的children需要render這樣的樣式，我覺程式碼的閱讀性較差。

綜上所述，採用了第三種方法，但我不確定第三種方法有沒有什麼其他缺點，以及有哪邊可以改善的地方，所以想要討論一下。