### PR TITLE
feat(mm-next/header): add `href` in `section`

### DIFF
--- a/packages/mirror-media-next/components/header.js
+++ b/packages/mirror-media-next/components/header.js
@@ -156,8 +156,8 @@ function filterOutIsMemberOnlyCategoriesInNormalSection(section) {
  * @param {import('../apollo/fragments/section').Section} section
  * @return {SectionWithHrefTemp}
  */
-function getCategoryHref(section) {
-  const getHref = (sectionSlug, categorySlug) => {
+function getSectionAndCategoryHref(section) {
+  const getCategoryHref = (sectionSlug, categorySlug) => {
     if (sectionSlug === 'videohub') {
       return `/video_category/${categorySlug}`
     }
@@ -166,14 +166,28 @@ function getCategoryHref(section) {
     }
     return `/category/${categorySlug}`
   }
-  const getCategoryContainHref = (section, categories) => {
+
+  /**
+   *
+   * @param {string} sectionSlug
+   * @returns {string}
+   */
+  const getSectionHref = (sectionSlug) => {
+    if (sectionSlug === 'member') {
+      return `/premiumsection/${sectionSlug}`
+    } else {
+      return `/section/${sectionSlug}`
+    }
+  }
+  const getCategoryWithHref = (section, categories) => {
     return categories.map((category) => {
-      return { ...category, href: getHref(section.slug, category.slug) }
+      return { ...category, href: getCategoryHref(section.slug, category.slug) }
     })
   }
   const newSection = {
     ...section,
-    categories: getCategoryContainHref(section, section.categories),
+    href: getSectionHref(section.slug),
+    categories: getCategoryWithHref(section, section.categories),
   }
   return newSection
 }
@@ -237,7 +251,7 @@ export default function Header({
   const sections =
     sectionsData
       .map(filterOutIsMemberOnlyCategoriesInNormalSection)
-      .map(getCategoryHref) ?? []
+      .map(getSectionAndCategoryHref) ?? []
   const topics = topicsData.slice(0, 9)
 
   return (

--- a/packages/mirror-media-next/components/mobile-sidebar.js
+++ b/packages/mirror-media-next/components/mobile-sidebar.js
@@ -15,9 +15,8 @@ import CloseButton from './shared/close-button'
  */
 
 /**
- * @typedef {Omit<Section, 'categories'> & { categories: Array.<SectionWithCategory & { href: string }> }} SectionWithHrefTemp
+ * @typedef {Omit<Section, 'categories' > & {href: string, categories: Array.<SectionWithCategory & { href: string }> }} SectionWithHrefTemp
  */
-
 /**
  * @typedef {Pick<import('../apollo/fragments/topic').Topic, 'id' | 'name'>[]} Topics
  */
@@ -250,10 +249,10 @@ export default function MobileSidebar({
             ))}
             <Topic href={`/section/topic`}>更多</Topic>
           </Topics>
-          {sections.map(({ id, slug, categories, name }) => (
+          {sections.map(({ id, slug, categories, name, href }) => (
             <Fragment key={id}>
               <Section color={sectionColors[slug]}>
-                <Link style={{ width: '50%' }} href={`/section/${slug}`}>
+                <Link style={{ width: '50%' }} href={href}>
                   <h3>{name}</h3>
                 </Link>
                 <SectionToggle

--- a/packages/mirror-media-next/components/nav-sections.js
+++ b/packages/mirror-media-next/components/nav-sections.js
@@ -15,7 +15,7 @@ import Logo from './logo'
  */
 
 /**
- * @typedef {Omit<Section, 'categories'> & { categories: Array.<SectionWithCategory & { href: string }> }} SectionWithHrefTemp
+ * @typedef {Omit<Section, 'categories' > & {href: string, categories: Array.<SectionWithCategory & { href: string }> }} SectionWithHrefTemp
  */
 const SectionsWrapper = styled.nav`
   font-size: 14px;
@@ -153,7 +153,7 @@ export default function NavSections({ sections = [] }) {
             color={sectionColors[section.slug]}
             className={section.slug}
           >
-            <SectionLink href={`/section/${section.slug}`}>
+            <SectionLink href={section.href}>
               <h2>{section.name}</h2>
             </SectionLink>
             <SectionDropDown>


### PR DESCRIPTION
## Notable Change
1. 於元件`header`的陣列`sections`中，針對每一元素新增一屬性`href`，該屬性會依據`section.slug`，新增對應的字串。如果section.slug的值為`member`，則會生成`/premiumsection/${section.slug}`，反之則為`/section/${section.slug}`。
2. 將子元件nav-section與mobile-side的相應`<a>`，其屬性href從`/section/${section.slug}`改為使用`section.href`。
4. 因不確定需求上，是否需要將頁面`/section/member`redirect到`premiumsection/member`，故暫時未實作該頁面的redirect。