### PR TITLE
fix(mm-next): fix problem of `findLastIndex` not working in some broswer

### DIFF
--- a/packages/mirror-media-next/components/story/shared/nav-subtitle-navigator.js
+++ b/packages/mirror-media-next/components/story/shared/nav-subtitle-navigator.js
@@ -261,11 +261,15 @@ export default function NavSubtitleNavigator({
 
         if (item && item.isIntersecting !== isIntersecting) {
           item.isIntersecting = isIntersecting
-          const lastIndex = visibleSubtitles.findLastIndex(
+
+          //Find the visible subtitle and select its key, if there is multiple subtitle are visible, then select the last one.
+          const reverseArray = [...visibleSubtitles].reverse()
+          const lastIndex = reverseArray.findIndex(
             (item) => item.isIntersecting
           )
+
           if (lastIndex !== -1) {
-            const lastKey = visibleSubtitles[lastIndex].key
+            const lastKey = reverseArray[lastIndex].key
             setCurrentIndex(lastKey)
           }
         }


### PR DESCRIPTION
## Notable Change
依據[Can I Use網站的統計](https://caniuse.com/mdn-javascript_builtins_array_findlastindex)，由於 `findLastIndex`使用率只有約90%，且Safari只有至15.4後才支援。而元件subtitle-navigator使用了該函式，導致在較舊版的Safari會報錯。
此PR將`findLastIndex`移除，改為先將陣列反轉後透過`findIndex`實作原有功能。（反轉陣列用的[reverse()](https://caniuse.com/?search=reverse)，與[findIndex](https://caniuse.com/array-find-index)使用率皆有97%以上）