### PR TITLE
feat(externals): add externals `partnerSlug` page

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/external.js
+++ b/packages/mirror-media-next/apollo/fragments/external.js
@@ -1,0 +1,44 @@
+import { gql } from '@apollo/client'
+import { partner } from './partner'
+
+/**
+ * @typedef {import('./partner').Partner} Partner
+ */
+
+/**
+ * @typedef {Object} GenericExternal
+ * @property {string} id
+ * @property {string} slug
+ * @property {Partner} partner
+ * @property {string} title
+ * @property {string} state
+ * @property {string} publishedDate
+ * @property {string} extend_byline
+ * @property {string} thumb
+ * @property {string} brief
+ * @property {string} content
+ * @property {string} source
+ * @property {string} createdAt
+ * @property {string} updatedAt
+ * @property {string} createdBy
+ * @property {string} updatedBy
+ */
+
+/**
+ * @typedef {Pick<GenericExternal, 'id' | 'slug' | 'title' | 'thumb' | 'brief' | 'content' | 'partner'>} External
+ */
+
+export const external = gql`
+  ${partner}
+  fragment external on External {
+    id
+    slug
+    title
+    thumb
+    brief
+    content
+    partner {
+      ...partner
+    }
+  }
+`

--- a/packages/mirror-media-next/apollo/fragments/partner.js
+++ b/packages/mirror-media-next/apollo/fragments/partner.js
@@ -1,0 +1,41 @@
+import { gql } from '@apollo/client'
+
+/**
+ * @typedef {Object} PasswordState
+ * @property {boolean} isSet
+ */
+
+/**
+ * @typedef {Object} User
+ * @property {string} id
+ * @property {string} name
+ * @property {string} email
+ * @property {PasswordState} password
+ * @property {string} role
+ * @property {boolean} isProtected
+ */
+
+/**
+ * @typedef {Object} GenericPartner
+ * @property {string} id
+ * @property {string} slug
+ * @property {string} name
+ * @property {string} website
+ * @property {boolean} public
+ * @property {string} createdAt
+ * @property {string} updatedAt
+ * @property {string} createdBy
+ * @property {string} updatedBy
+ */
+
+/**
+ * @typedef {Pick<GenericPartner, 'id' | 'slug' | 'name'>} Partner
+ */
+
+export const partner = gql`
+  fragment partner on Partner {
+    id
+    slug
+    name
+  }
+`

--- a/packages/mirror-media-next/apollo/query/externals.js
+++ b/packages/mirror-media-next/apollo/query/externals.js
@@ -1,0 +1,24 @@
+import { gql } from '@apollo/client'
+import { external } from '../fragments/external'
+
+const fetchExternalsByPartnerSlug = gql`
+  ${external}
+  query (
+    $take: Int
+    $skip: Int
+    $orderBy: [ExternalOrderByInput!]!
+    $filter: ExternalWhereInput!
+  ) {
+    externals(take: $take, skip: $skip, orderBy: $orderBy, where: $filter) {
+      ...external
+    }
+  }
+`
+
+const fetchExternalCounts = gql`
+  query ($filter: ExternalWhereInput!) {
+    externalsCount(where: $filter)
+  }
+`
+
+export { fetchExternalsByPartnerSlug, fetchExternalCounts }

--- a/packages/mirror-media-next/apollo/query/partner.js
+++ b/packages/mirror-media-next/apollo/query/partner.js
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client'
+import { partner } from '../fragments/partner'
+
+const fetchPartnerBySlug = gql`
+  ${partner}
+  query fetchPartnerBySlug($slug: String) {
+    partner(where: { slug: $slug }) {
+      ...partner
+    }
+  }
+`
+
+export { fetchPartnerBySlug }

--- a/packages/mirror-media-next/components/external/external-articles.js
+++ b/packages/mirror-media-next/components/external/external-articles.js
@@ -1,0 +1,79 @@
+import styled from 'styled-components'
+import client from '../../apollo/apollo-client'
+
+import InfiniteScrollList from '../infinite-scroll-list'
+import Image from 'next/legacy/image'
+import LoadingPage from '../../public/images/loading_page.gif'
+import ExternalList from './external-list'
+import { fetchExternalsByPartnerSlug } from '../../apollo/query/externals'
+
+const Loading = styled.div`
+  margin: 20px auto 0;
+  padding: 0 0 20px;
+  text-align: center;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 64px auto 0;
+    padding: 0 0 64px;
+  }
+`
+
+/**
+ * @typedef {import('../../apollo/fragments/external').External} External
+ * @typedef {import('../../apollo/fragments/partner').Partner} Partner
+ */
+
+/**
+ *
+ * @param {Object} props
+ * @param {number} props.externalsCount
+ * @param {External[]} props.externals
+ * @param {Pick<Partner, 'id' | 'slug' | 'name'>} props.partner
+ * @param {number} props.renderPageSize
+ * @returns {React.ReactElement}
+ */
+export default function ExternalArticles({
+  externalsCount,
+  externals,
+  partner,
+  renderPageSize,
+}) {
+  async function fetchExternalsFromPage(page) {
+    try {
+      const response = await client.query({
+        query: fetchExternalsByPartnerSlug,
+        variables: {
+          take: renderPageSize * 2,
+          skip: (page - 1) * renderPageSize * 2,
+          orderBy: { publishedDate: 'desc' },
+          filter: {
+            state: { equals: 'published' },
+            partner: { slug: { equals: partner.slug } },
+          },
+        },
+      })
+      return response.data.posts
+    } catch (error) {
+      console.error(error)
+    }
+    return
+  }
+
+  const loader = (
+    <Loading key={0}>
+      <Image src={LoadingPage} alt="loading page"></Image>
+    </Loading>
+  )
+
+  return (
+    <InfiniteScrollList
+      initialList={externals}
+      renderAmount={renderPageSize}
+      fetchCount={Math.ceil(externalsCount / renderPageSize)}
+      fetchListInPage={fetchExternalsFromPage}
+      loader={loader}
+    >
+      {(renderList) => <ExternalList renderList={renderList} />}
+    </InfiniteScrollList>
+  )
+}

--- a/packages/mirror-media-next/components/external/external-articles.js
+++ b/packages/mirror-media-next/components/external/external-articles.js
@@ -52,7 +52,7 @@ export default function ExternalArticles({
           },
         },
       })
-      return response.data.posts
+      return response.data.externals
     } catch (error) {
       console.error(error)
     }

--- a/packages/mirror-media-next/components/external/external-list-item.js
+++ b/packages/mirror-media-next/components/external/external-list-item.js
@@ -1,6 +1,5 @@
 import styled from 'styled-components'
-import NextImage from 'next/image'
-import { useState } from 'react'
+import Image from '@readr-media/react-image'
 
 const ItemWrapper = styled.a`
   display: block;
@@ -80,21 +79,17 @@ const ItemBrief = styled.div`
  * @returns {React.ReactElement}
  */
 export default function ExternalListItem({ item }) {
-  const [itemImage, setItemImage] = useState(item.thumb)
+  const IMAGES_URL = { original: item.thumb }
 
   return (
     <ItemWrapper href={`/external/${item.slug}`} target="_blank">
       <ImageContainer>
-        <NextImage
-          src={itemImage}
+        <Image
+          images={IMAGES_URL}
           alt={item.title}
-          fill={true}
-          placeholder="blur"
-          blurDataURL="/images/loading.gif"
-          onError={() => {
-            setItemImage('/images/default-og-img.png')
-          }}
-          sizes="100%"
+          loadingImage="/images/loading.gif"
+          defaultImage="/images/default-og-img.png"
+          rwd={{ tablet: '320px', desktop: '220px' }}
         />
       </ImageContainer>
       <ItemDetail>

--- a/packages/mirror-media-next/components/external/external-list-item.js
+++ b/packages/mirror-media-next/components/external/external-list-item.js
@@ -1,0 +1,105 @@
+import styled from 'styled-components'
+import NextImage from 'next/image'
+import { useState } from 'react'
+
+const ItemWrapper = styled.a`
+  display: block;
+  position: relative;
+  width: 100%;
+  margin: 0 auto;
+  font-size: 18px;
+`
+
+const ImageContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: 214px;
+
+  img {
+    object-fit: cover;
+    filter: unset;
+  }
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    height: 147px;
+  }
+`
+
+const ItemDetail = styled.div`
+  margin: 20px 20px 36px 20px;
+  ${({ theme }) => theme.breakpoint.md} {
+    margin: 20px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 8px 8px 40px 8px;
+  }
+`
+
+const ItemTitle = styled.div`
+  color: #054f77;
+  line-height: 25px;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    height: 75px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    font-size: 18px;
+  }
+`
+
+const ItemBrief = styled.div`
+  font-size: 16px;
+  color: #979797;
+  margin-top: 20px;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    margin-top: 16px;
+  }
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin-top: 20px;
+    -webkit-line-clamp: 4;
+  }
+`
+
+/**
+ * @typedef {import('../../apollo/fragments/external').External} External
+ */
+
+/**
+ * @param {Object} props
+ * @param {External} props.item
+ * @returns {React.ReactElement}
+ */
+export default function ExternalListItem({ item }) {
+  const [itemImage, setItemImage] = useState(item.thumb)
+
+  return (
+    <ItemWrapper href={`/external/${item.slug}`} target="_blank">
+      <ImageContainer>
+        <NextImage
+          src={itemImage}
+          alt={item.title}
+          fill={true}
+          placeholder="blur"
+          blurDataURL="/images/loading.gif"
+          onError={() => {
+            setItemImage('/images/default-og-img.png')
+          }}
+        />
+      </ImageContainer>
+      <ItemDetail>
+        <ItemTitle>{item.title}</ItemTitle>
+        <ItemBrief>{item.brief}</ItemBrief>
+      </ItemDetail>
+    </ItemWrapper>
+  )
+}

--- a/packages/mirror-media-next/components/external/external-list-item.js
+++ b/packages/mirror-media-next/components/external/external-list-item.js
@@ -94,6 +94,7 @@ export default function ExternalListItem({ item }) {
           onError={() => {
             setItemImage('/images/default-og-img.png')
           }}
+          sizes="100%"
         />
       </ImageContainer>
       <ItemDetail>

--- a/packages/mirror-media-next/components/external/external-list.js
+++ b/packages/mirror-media-next/components/external/external-list.js
@@ -1,0 +1,37 @@
+import styled from 'styled-components'
+import ExternalListItem from './external-list-item'
+
+const ItemContainer = styled.div`
+  display: grid;
+  grid-template-columns: 320px;
+  justify-content: center;
+  row-gap: 20px;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    grid-template-columns: repeat(2, 320px);
+    gap: 20px 32px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    grid-template-columns: repeat(4, 220px);
+    gap: 36px 48px;
+  }
+`
+
+/**
+ * @typedef {import('../../apollo/fragments/external').External} External
+ */
+
+/**
+ * @param {Object} props
+ * @param {External[]} props.renderList
+ * @returns {React.ReactElement}
+ */
+export default function ExternalList({ renderList }) {
+  return (
+    <ItemContainer>
+      {renderList.map((item) => (
+        <ExternalListItem key={item.id} item={item} />
+      ))}
+    </ItemContainer>
+  )
+}

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -1,0 +1,220 @@
+import errors from '@twreporter/errors'
+import styled from 'styled-components'
+
+import client from '../../apollo/apollo-client'
+import ExternalArticles from '../../components/external/external-articles'
+import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import ShareHeader from '../../components/shared/share-header'
+import Footer from '../../components/footer'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+
+import {
+  fetchExternalsByPartnerSlug,
+  fetchExternalCounts,
+} from '../../apollo/query/externals'
+import { fetchPartnerBySlug } from '../../apollo/query/partner'
+
+/**
+ * @typedef {import('../../type/theme').Theme} Theme
+ */
+
+const PartnerContainer = styled.main`
+  width: 320px;
+  margin: 0 auto;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    width: 672px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    width: 1024px;
+    padding: 0;
+  }
+`
+const PartnerTitle = styled.h1`
+  margin: 20px 0 16px 16px;
+  font-size: 16px;
+  line-height: 1.15;
+  font-weight: 500;
+
+  color: ${({ theme }) => theme.color.brandColor.lightBlue};
+
+  ${({ theme }) => theme.breakpoint.md} {
+    margin: 20px 0 24px;
+    font-size: 20.8px;
+    font-weight: 600;
+  }
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 24px 0 28px;
+    font-size: 28px;
+  }
+`
+
+const RENDER_PAGE_SIZE = 12
+
+/**
+ * @typedef {import('../../apollo/fragments/external').External} External
+ * @typedef {import('../../apollo/fragments/partner').Partner} Partner
+ */
+
+/**
+ * @param {Object} props
+ * @param {External[]} props.externals
+ * @param {number} props.externalsCount
+ * @param {Object} props.headerData
+ * @param {Partner} props.partner
+ * @returns {React.ReactElement}
+ */
+
+export default function ExternalPartner({
+  externalsCount,
+  externals,
+  partner,
+  headerData,
+}) {
+  return (
+    <>
+      <ShareHeader pageLayoutType="default" headerData={headerData} />
+      <PartnerContainer>
+        <PartnerTitle>{partner?.name}</PartnerTitle>
+        <ExternalArticles
+          externalsCount={externalsCount}
+          externals={externals}
+          partner={partner}
+          renderPageSize={RENDER_PAGE_SIZE}
+        />
+      </PartnerContainer>
+      <Footer />
+    </>
+  )
+}
+
+/**
+ * @type {import('next').GetServerSideProps}
+ */
+export async function getServerSideProps({ query, req }) {
+  const partnerSlug = query.partnerSlug
+  const traceHeader = req.headers?.['x-cloud-trace-context']
+  let globalLogFields = {}
+  if (traceHeader && !Array.isArray(traceHeader)) {
+    const [trace] = traceHeader.split('/')
+    globalLogFields[
+      'logging.googleapis.com/trace'
+    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
+  }
+
+  const responses = await Promise.allSettled([
+    client.query({
+      query: fetchExternalsByPartnerSlug,
+      variables: {
+        take: RENDER_PAGE_SIZE * 2,
+        skip: 0,
+        orderBy: { publishedDate: 'desc' },
+        filter: {
+          state: { equals: 'published' },
+          partner: { slug: { equals: partnerSlug } },
+        },
+      },
+    }),
+    client.query({
+      query: fetchExternalCounts,
+      variables: {
+        filter: {
+          state: { equals: 'published' },
+          partner: { slug: { equals: partnerSlug } },
+        },
+      },
+    }),
+    client.query({
+      query: fetchPartnerBySlug,
+      variables: { slug: partnerSlug },
+    }),
+  ])
+
+  const handledResponses = responses.map((response) => {
+    if (response.status === 'fulfilled') {
+      return response.value
+    } else if (response.status === 'rejected') {
+      const { graphQLErrors, clientErrors, networkError } = response.reason
+      const annotatingError = errors.helpers.wrap(
+        response.reason,
+        'UnhandledError',
+        'Error occurs while getting section page data'
+      )
+
+      console.log(
+        JSON.stringify({
+          severity: 'ERROR',
+          message: errors.helpers.printAll(
+            annotatingError,
+            {
+              withStack: true,
+              withPayload: true,
+            },
+            0,
+            0
+          ),
+          debugPayload: {
+            graphQLErrors,
+            clientErrors,
+            networkError,
+          },
+          ...globalLogFields,
+        })
+      )
+      return
+    }
+  })
+
+  /** @type {External[]} */
+  const externals =
+    'data' in handledResponses[0]
+      ? handledResponses[0]?.data?.externals || []
+      : []
+
+  /** @type {number} */
+  const externalsCount =
+    'data' in handledResponses[1]
+      ? handledResponses[1]?.data?.externalsCount || 0
+      : 0
+
+  /** @type {Partner} */
+  const partner =
+    'data' in handledResponses[2]
+      ? handledResponses[2]?.data?.partner || {}
+      : {}
+
+  // fetch header data
+  let sectionsData = []
+  let topicsData = []
+  try {
+    const headerData = await fetchHeaderDataInDefaultPageLayout()
+    if (Array.isArray(headerData.sectionsData)) {
+      sectionsData = headerData.sectionsData
+    }
+    if (Array.isArray(headerData.topicsData)) {
+      topicsData = headerData.topicsData
+    }
+  } catch (err) {
+    const annotatingAxiosError = errors.helpers.annotateAxiosError(err)
+    console.error(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(annotatingAxiosError, {
+          withStack: true,
+          withPayload: true,
+        }),
+        ...globalLogFields,
+      })
+    )
+  }
+
+  const props = {
+    externalsCount,
+    externals,
+    partner,
+    headerData: { sectionsData, topicsData },
+  }
+
+  return { props }
+}


### PR DESCRIPTION
## 需求說明
- 頁面 `/externals/[partnerSlug]`：透過在網頁路徑中指定 partner 的 `slug`，能導向作者為該 partner 的 `externals` 文章列表頁。

## Notable Change
- 新增 `partner` 的相關 fragment 與 query 設定：[679b291](https://github.com/mirror-media/Adam/commit/679b29163a05c52ab12e027fc122cea457e25ddd)

   - JSdoc 的部分，統一在 `fragment` 內設定 `GenericPartner`，詳列出所有 property，再透過 Pick 取用實作上會使用到的 property，另設定為 typedef `Partner`。目的是為了讓未來優化/統整各個 Generic type 時，可以直接取用 `GenericPartner`，不需再花時間整理。

- 新增 `external` 的相關 fragment 與 query 設定： [ef5fd59](https://github.com/mirror-media/Adam/commit/ef5fd59aad169dca63cf362193a51e4aa5663670)

   - JSdoc 的部分，統一在 `fragment` 內設定 `GenericExternal`，再透過 Pick 取用實作上會使用到的 property，另設定為 typedef `External`。
   
- 新增 `/externals/[partnerSlug]` 頁面：[a6264ec](https://github.com/mirror-media/Adam/commit/a6264ec85831d7a9fadb4575fbe337aa518ab16a)

   - 因爲此頁面 UI 與 `/section/topic` 相同，因此在程式碼架構上參考該頁面設定。
   - 因為 `externals` 中並無 `postsCount` 資料，因此會多打一個 api 以取得 `externalsCount` 總篇數資訊。
   
- 新增 `external-articles` 等相關元件： [803d0d5](https://github.com/mirror-media/Adam/commit/803d0d5a495287997975af0bfae60dc686d34618)
   - 考量到 `externals` 文章的資料結構與一般 `posts` 有差異（ex: 沒有 `section`、`category` 欄位） ，JSDoc 的架構也不相同，因此另外新增 `externals` 專屬的 list-item 等元件。
   - 因 `externals` 中沒有 `section` 欄位資料，因此移除文章卡片上的 `ItemSection`，不顯示各文章分類資訊。
   
## TODO
- [x] 等 PR #222 merge 後，須將 `/externals/[partnerSlug]` 頁面版型改用 `<Layout>` 代替。
