### PR TITLE
feat(mm-next): add brief and content of amp page

### DIFF
--- a/packages/mirror-media-next/components/amp/amp-info.js
+++ b/packages/mirror-media-next/components/amp/amp-info.js
@@ -33,8 +33,7 @@ const DateRow = styled.p`
 
 /**
  * @param {Object} props
- * @property {Section[]} sections
- * @property {Section[]} manualOrderOfSections
+ * @property {Section} section
  * @property {string} title - post title
  * @property {string} publishedDate - post published date
  * @property {string} updatedAt - post updated date
@@ -42,19 +41,13 @@ const DateRow = styled.p`
  */
 export default function AmpInfo({
   title = '',
-  sections = [],
-  manualOrderOfSections = [],
+  section = {},
   publishedDate = '',
   updatedAt = '',
 }) {
   const publishedTaipeiTime = transformTimeDataIntoDotFormat(publishedDate)
   const updatedTaipeiTime = transformTimeDataIntoDotFormat(updatedAt)
 
-  const sectionsWithOrdered =
-    manualOrderOfSections && manualOrderOfSections.length
-      ? sortArrayWithOtherArrayId(sections, manualOrderOfSections)
-      : sections
-  const [section] = sectionsWithOrdered
   let sectionColor
   if (section) sectionColor = color.sectionsColor[section.slug]
 

--- a/packages/mirror-media-next/components/amp/amp-main.js
+++ b/packages/mirror-media-next/components/amp/amp-main.js
@@ -76,9 +76,9 @@ const TagsWrapper = styled.ul`
 const TagItem = styled(Link)`
   font-size: 14px;
   line-height: 20px;
-  color: ${({ theme }) => theme.color.brandColor.darkBlue}};
+  color: ${({ theme }) => theme.color.brandColor.darkBlue};
   padding: 4px 8px;
-  border: 1px solid ${({ theme }) => theme.color.brandColor.darkBlue}};
+  border: 1px solid ${({ theme }) => theme.color.brandColor.darkBlue};
   border-radius: 2px;
   margin-top: 8px;
   & + & {
@@ -93,7 +93,7 @@ const AmpBriefContainer = styled.section`
     margin-top: 52px;
   }
   * {
-    color: ${({ theme }) => theme.color.brandColor.darkBlue}};
+    color: ${({ theme }) => theme.color.brandColor.darkBlue};
   }
 `
 

--- a/packages/mirror-media-next/components/amp/amp-main.js
+++ b/packages/mirror-media-next/components/amp/amp-main.js
@@ -7,6 +7,7 @@ import AmpCredits from '../story/shared/credits'
 import AmpHero from './amp-hero'
 import AmpInfo from './amp-info'
 import ArticleBrief from '../story/shared/brief'
+import DraftRenderBlock from '../story/shared/draft-renderer-block'
 
 const MainWrapper = styled.div`
   margin-top: 24px;
@@ -96,6 +97,11 @@ const AmpBriefContainer = styled.section`
   }
 `
 
+const AmpContentContainer = styled.section`
+  padding: 0 20px;
+  margin-top: 36px;
+`
+
 /**
  * @typedef {import('../../apollo/fragments/post').Post} PostData
  */
@@ -126,7 +132,7 @@ export default function AmpMain({ postData }) {
     extend_byline = '',
     tags = [],
     brief = { blocks: [], entityMap: {} },
-    // content = { blocks: [], entityMap: {} },
+    content = { blocks: [], entityMap: {} },
   } = postData
 
   const writersWithOrdered =
@@ -185,6 +191,13 @@ export default function AmpMain({ postData }) {
           brief={brief}
         ></ArticleBrief>
       </AmpBriefContainer>
+      <AmpContentContainer>
+        <DraftRenderBlock
+          rawContentBlock={content}
+          contentLayout="normal"
+          wrapper={(children) => children}
+        />
+      </AmpContentContainer>
     </MainWrapper>
   )
 }

--- a/packages/mirror-media-next/components/amp/amp-main.js
+++ b/packages/mirror-media-next/components/amp/amp-main.js
@@ -135,6 +135,12 @@ export default function AmpMain({ postData }) {
     content = { blocks: [], entityMap: {} },
   } = postData
 
+  const sectionsWithOrdered =
+    manualOrderOfSections && manualOrderOfSections.length
+      ? sortArrayWithOtherArrayId(sections, manualOrderOfSections)
+      : sections
+  const [section] = sectionsWithOrdered
+
   const writersWithOrdered =
     manualOrderOfWriters && manualOrderOfWriters.length
       ? sortArrayWithOtherArrayId(writers, manualOrderOfWriters)
@@ -154,10 +160,9 @@ export default function AmpMain({ postData }) {
     <MainWrapper>
       <AmpInfo
         title={title}
-        sections={sections}
+        section={section}
         publishedDate={publishedDate}
         updatedAt={updatedAt}
-        manualOrderOfSections={manualOrderOfSections}
       />
       <SharesWrapper>
         <ButtonSocialNetworkShare type="facebook" />
@@ -186,10 +191,7 @@ export default function AmpMain({ postData }) {
         })}
       </TagsWrapper>
       <AmpBriefContainer>
-        <ArticleBrief
-          sectionSlug={sections?.[0]?.slug}
-          brief={brief}
-        ></ArticleBrief>
+        <ArticleBrief sectionSlug={section?.slug} brief={brief}></ArticleBrief>
       </AmpBriefContainer>
       <AmpContentContainer>
         <DraftRenderBlock rawContentBlock={content} contentLayout="normal" />

--- a/packages/mirror-media-next/components/amp/amp-main.js
+++ b/packages/mirror-media-next/components/amp/amp-main.js
@@ -6,6 +6,7 @@ import ButtonSocialNetworkShare from '../story/shared/button-social-network-shar
 import AmpCredits from '../story/shared/credits'
 import AmpHero from './amp-hero'
 import AmpInfo from './amp-info'
+import ArticleBrief from '../story/shared/brief'
 
 const MainWrapper = styled.div`
   margin-top: 24px;
@@ -84,6 +85,17 @@ const TagItem = styled(Link)`
   }
 `
 
+const AmpBriefContainer = styled.section`
+  & > * {
+    background: rgba(0, 0, 0, 0);
+    padding: 0 44px;
+    margin-top: 52px;
+  }
+  * {
+    color: ${({ theme }) => theme.color.brandColor.darkBlue}};
+  }
+`
+
 /**
  * @typedef {import('../../apollo/fragments/post').Post} PostData
  */
@@ -113,7 +125,7 @@ export default function AmpMain({ postData }) {
     vocals = [],
     extend_byline = '',
     tags = [],
-    // brief = { blocks: [], entityMap: {} },
+    brief = { blocks: [], entityMap: {} },
     // content = { blocks: [], entityMap: {} },
   } = postData
 
@@ -167,6 +179,12 @@ export default function AmpMain({ postData }) {
           )
         })}
       </TagsWrapper>
+      <AmpBriefContainer>
+        <ArticleBrief
+          sectionSlug={sections?.[0]?.slug}
+          brief={brief}
+        ></ArticleBrief>
+      </AmpBriefContainer>
     </MainWrapper>
   )
 }

--- a/packages/mirror-media-next/components/amp/amp-main.js
+++ b/packages/mirror-media-next/components/amp/amp-main.js
@@ -192,11 +192,7 @@ export default function AmpMain({ postData }) {
         ></ArticleBrief>
       </AmpBriefContainer>
       <AmpContentContainer>
-        <DraftRenderBlock
-          rawContentBlock={content}
-          contentLayout="normal"
-          wrapper={(children) => children}
-        />
+        <DraftRenderBlock rawContentBlock={content} contentLayout="normal" />
       </AmpContentContainer>
     </MainWrapper>
   )


### PR DESCRIPTION
### 描述
- 新增 amp 的前言和內文。
- 先採用 normal 版型，之後會根據錯誤訊息從 draft-renderer 那邊更改成 amp 版型。