### PR TITLE
refactor(external): modify `external` page structure

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/external.js
+++ b/packages/mirror-media-next/apollo/fragments/external.js
@@ -25,8 +25,22 @@ import { partner } from './partner'
  */
 
 /**
- * @typedef {Pick<GenericExternal, 'id' | 'slug' | 'title' | 'thumb' | 'brief' | 'content' | 'partner'>} External
+ * @typedef {Pick<GenericExternal, 'id' | 'slug' | 'partner' |  'title' | 'thumb' | 'brief' | 'content' | 'publishedDate' | 'extend_byline' | 'updatedAt' >} External
  */
+
+/**
+ * @typedef {Pick<GenericExternal, 'id' | 'slug' | 'title' | 'thumb' | 'brief' >} ListingExternal
+ */
+
+export const listingExternal = gql`
+  fragment listingExternal on External {
+    id
+    slug
+    title
+    thumb
+    brief
+  }
+`
 
 export const external = gql`
   ${partner}
@@ -37,6 +51,8 @@ export const external = gql`
     thumb
     brief
     content
+    publishedDate
+    extend_byline
     partner {
       ...partner
     }

--- a/packages/mirror-media-next/apollo/query/externals.js
+++ b/packages/mirror-media-next/apollo/query/externals.js
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client'
-import { external } from '../fragments/external'
+import { listingExternal, external } from '../fragments/external'
 
 const fetchExternalsByPartnerSlug = gql`
-  ${external}
+  ${listingExternal}
   query (
     $take: Int
     $skip: Int
@@ -10,7 +10,7 @@ const fetchExternalsByPartnerSlug = gql`
     $filter: ExternalWhereInput!
   ) {
     externals(take: $take, skip: $skip, orderBy: $orderBy, where: $filter) {
-      ...external
+      ...listingExternal
     }
   }
 `

--- a/packages/mirror-media-next/apollo/query/partner.js
+++ b/packages/mirror-media-next/apollo/query/partner.js
@@ -4,7 +4,7 @@ import { partner } from '../fragments/partner'
 const fetchPartnerBySlug = gql`
   ${partner}
   query fetchPartnerBySlug($slug: String) {
-    partner(where: { slug: $slug }) {
+    partners(where: { slug: { equals: $slug }, public: { equals: true } }) {
       ...partner
     }
   }

--- a/packages/mirror-media-next/components/externals/external-list-item.js
+++ b/packages/mirror-media-next/components/externals/external-list-item.js
@@ -14,11 +14,6 @@ const ImageContainer = styled.div`
   width: 100%;
   height: 214px;
 
-  img {
-    object-fit: cover;
-    filter: unset;
-  }
-
   ${({ theme }) => theme.breakpoint.xl} {
     height: 147px;
   }
@@ -70,31 +65,32 @@ const ItemBrief = styled.div`
 `
 
 /**
- * @typedef {import('../../apollo/fragments/external').External} External
+ * @typedef {import('../../apollo/fragments/external').ListingExternal} ListingExternal
  */
 
 /**
  * @param {Object} props
- * @param {External} props.item
+ * @param {ListingExternal} props.item
  * @returns {React.ReactElement}
  */
 export default function ExternalListItem({ item }) {
-  const IMAGES_URL = { original: item.thumb }
+  const { thumb = '', slug = '', title = '', brief = '' } = item
+  const IMAGES_URL = { original: thumb }
 
   return (
-    <ItemWrapper href={`/external/${item.slug}`} target="_blank">
+    <ItemWrapper href={`/external/${slug}`} target="_blank">
       <ImageContainer>
         <Image
           images={IMAGES_URL}
-          alt={item.title}
+          alt={title}
           loadingImage="/images/loading.gif"
           defaultImage="/images/default-og-img.png"
           rwd={{ tablet: '320px', desktop: '220px' }}
         />
       </ImageContainer>
       <ItemDetail>
-        <ItemTitle>{item.title}</ItemTitle>
-        <ItemBrief>{item.brief}</ItemBrief>
+        <ItemTitle>{title}</ItemTitle>
+        <ItemBrief>{brief}</ItemBrief>
       </ItemDetail>
     </ItemWrapper>
   )

--- a/packages/mirror-media-next/components/externals/externals-articles.js
+++ b/packages/mirror-media-next/components/externals/externals-articles.js
@@ -1,11 +1,11 @@
 import styled from 'styled-components'
-import client from '~/apollo/apollo-client'
+import client from '../../apollo/apollo-client'
 
 import InfiniteScrollList from '../infinite-scroll-list'
 import Image from 'next/legacy/image'
-import LoadingPage from '~/public/images/loading_page.gif'
+import LoadingPage from '../../public/images/loading_page.gif'
 import ExternalList from './externals-list'
-import { fetchExternalsByPartnerSlug } from '~/apollo/query/externals'
+import { fetchExternalsByPartnerSlug } from '../../apollo/query/externals'
 
 const Loading = styled.div`
   margin: 20px auto 0;

--- a/packages/mirror-media-next/components/externals/externals-articles.js
+++ b/packages/mirror-media-next/components/externals/externals-articles.js
@@ -1,11 +1,11 @@
 import styled from 'styled-components'
-import client from '../../apollo/apollo-client'
+import client from '~/apollo/apollo-client'
 
 import InfiniteScrollList from '../infinite-scroll-list'
 import Image from 'next/legacy/image'
-import LoadingPage from '../../public/images/loading_page.gif'
-import ExternalList from './external-list'
-import { fetchExternalsByPartnerSlug } from '../../apollo/query/externals'
+import LoadingPage from '~/public/images/loading_page.gif'
+import ExternalList from './externals-list'
+import { fetchExternalsByPartnerSlug } from '~/apollo/query/externals'
 
 const Loading = styled.div`
   margin: 20px auto 0;
@@ -19,7 +19,7 @@ const Loading = styled.div`
 `
 
 /**
- * @typedef {import('../../apollo/fragments/external').External} External
+ * @typedef {import('../../apollo/fragments/external').ListingExternal} ListingExternal
  * @typedef {import('../../apollo/fragments/partner').Partner} Partner
  */
 
@@ -27,8 +27,8 @@ const Loading = styled.div`
  *
  * @param {Object} props
  * @param {number} props.externalsCount
- * @param {External[]} props.externals
- * @param {Pick<Partner, 'id' | 'slug' | 'name'>} props.partner
+ * @param {ListingExternal[]} props.externals
+ * @param {Partner} props.partner
  * @param {number} props.renderPageSize
  * @returns {React.ReactElement}
  */

--- a/packages/mirror-media-next/components/externals/externals-list.js
+++ b/packages/mirror-media-next/components/externals/externals-list.js
@@ -18,12 +18,12 @@ const ItemContainer = styled.div`
 `
 
 /**
- * @typedef {import('../../apollo/fragments/external').External} External
+ * @typedef {import('../../apollo/fragments/external').ListingExternal} ListingExternal
  */
 
 /**
  * @param {Object} props
- * @param {External[]} props.renderList
+ * @param {ListingExternal[]} props.renderList
  * @returns {React.ReactElement}
  */
 export default function ExternalList({ renderList }) {

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -5,7 +5,7 @@ import client from '../../apollo/apollo-client'
 import ExternalArticles from '../../components/externals/externals-articles'
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
-import Layout from '~/components/shared/layout'
+import Layout from '../../components/shared/layout'
 
 import {
   fetchExternalsByPartnerSlug,

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -2,11 +2,10 @@ import errors from '@twreporter/errors'
 import styled from 'styled-components'
 
 import client from '../../apollo/apollo-client'
-import ExternalArticles from '../../components/external/external-articles'
+import ExternalArticles from '../../components/externals/externals-articles'
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
-import ShareHeader from '../../components/shared/share-header'
-import Footer from '../../components/shared/footer'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import Layout from '~/components/shared/layout'
 
 import {
   fetchExternalsByPartnerSlug,
@@ -53,13 +52,13 @@ const PartnerTitle = styled.h1`
 const RENDER_PAGE_SIZE = 12
 
 /**
- * @typedef {import('../../apollo/fragments/external').External} External
+ * @typedef {import('../../apollo/fragments/external').ListingExternal} ListingExternal
  * @typedef {import('../../apollo/fragments/partner').Partner} Partner
  */
 
 /**
  * @param {Object} props
- * @param {External[]} props.externals
+ * @param {ListingExternal[]} props.externals
  * @param {number} props.externalsCount
  * @param {Object} props.headerData
  * @param {Partner} props.partner
@@ -74,17 +73,21 @@ export default function ExternalPartner({
 }) {
   return (
     <>
-      <ShareHeader pageLayoutType="default" headerData={headerData} />
-      <PartnerContainer>
-        <PartnerTitle>{partner?.name}</PartnerTitle>
-        <ExternalArticles
-          externalsCount={externalsCount}
-          externals={externals}
-          partner={partner}
-          renderPageSize={RENDER_PAGE_SIZE}
-        />
-      </PartnerContainer>
-      <Footer />
+      <Layout
+        head={{ title: `${partner?.name}分類報導` }}
+        header={{ type: 'default', data: headerData }}
+        footer={{ type: 'default' }}
+      >
+        <PartnerContainer>
+          <PartnerTitle>{partner?.name}</PartnerTitle>
+          <ExternalArticles
+            externalsCount={externalsCount}
+            externals={externals}
+            partner={partner}
+            renderPageSize={RENDER_PAGE_SIZE}
+          />
+        </PartnerContainer>
+      </Layout>
     </>
   )
 }
@@ -92,8 +95,8 @@ export default function ExternalPartner({
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ query, req }) {
-  const partnerSlug = query.partnerSlug
+export async function getServerSideProps({ params, req }) {
+  const { partnerSlug } = params
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}
   if (traceHeader && !Array.isArray(traceHeader)) {
@@ -104,6 +107,7 @@ export async function getServerSideProps({ query, req }) {
   }
 
   const responses = await Promise.allSettled([
+    fetchHeaderDataInDefaultPageLayout(), //fetch header data
     client.query({
       query: fetchExternalsByPartnerSlug,
       variables: {
@@ -166,47 +170,40 @@ export async function getServerSideProps({ query, req }) {
     }
   })
 
-  /** @type {External[]} */
+  const headerData =
+    'sectionsData' in handledResponses[0]
+      ? handledResponses[0]
+      : {
+          sectionsData: [],
+          topicsData: [],
+        }
+  const sectionsData = Array.isArray(headerData.sectionsData)
+    ? headerData.sectionsData
+    : []
+  const topicsData = Array.isArray(headerData.topicsData)
+    ? headerData.topicsData
+    : []
+
+  /** @type {ListingExternal[]} */
   const externals =
-    'data' in handledResponses[0]
-      ? handledResponses[0]?.data?.externals || []
+    'data' in handledResponses[1]
+      ? handledResponses[1]?.data?.externals || []
       : []
 
   /** @type {number} */
   const externalsCount =
-    'data' in handledResponses[1]
-      ? handledResponses[1]?.data?.externalsCount || 0
+    'data' in handledResponses[2]
+      ? handledResponses[2]?.data?.externalsCount || 0
       : 0
 
   /** @type {Partner} */
   const partner =
-    'data' in handledResponses[2]
-      ? handledResponses[2]?.data?.partner || {}
+    'data' in handledResponses[3]
+      ? handledResponses[3]?.data?.partners[0] || {}
       : {}
 
-  // fetch header data
-  let sectionsData = []
-  let topicsData = []
-  try {
-    const headerData = await fetchHeaderDataInDefaultPageLayout()
-    if (Array.isArray(headerData.sectionsData)) {
-      sectionsData = headerData.sectionsData
-    }
-    if (Array.isArray(headerData.topicsData)) {
-      topicsData = headerData.topicsData
-    }
-  } catch (err) {
-    const annotatingAxiosError = errors.helpers.annotateAxiosError(err)
-    console.error(
-      JSON.stringify({
-        severity: 'ERROR',
-        message: errors.helpers.printAll(annotatingAxiosError, {
-          withStack: true,
-          withPayload: true,
-        }),
-        ...globalLogFields,
-      })
-    )
+  if (!Object.keys(partner).length) {
+    return { notFound: true }
   }
 
   const props = {


### PR DESCRIPTION
## Notable Change
- 新增 `ListingExternal` type 給 external 列表頁使用 ; 原有 `External` 則改為 external 文章頁使用。
- query `partner` 新增對於 `public` 的篩選條件。
- 調整元件架構：
   - `/components/externals` 存放列表頁資料（ warmlife. [partnerslug] )。
   - `/components/external` 存放 external 文章頁資料。
- `/[partnerslug]` 頁面修正：
   - 使用 `<Layout>` 元件取代原有 header. footer。
   - 當搜尋的 `partnerslug` 不存在或未公開，導向 404。