### PR TITLE
feat(external): add `external` slug page

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/external.js
+++ b/packages/mirror-media-next/apollo/fragments/external.js
@@ -13,11 +13,11 @@ import { partner } from './partner'
  * @property {string} title
  * @property {string} state
  * @property {string} publishedDate
- * @property {string} extend_byline
- * @property {string} thumb
+ * @property {string} extend_byline - author
+ * @property {string} thumb - heroImage URL
  * @property {string} brief
  * @property {string} content
- * @property {string} source
+ * @property {string} source - original article URL
  * @property {string} createdAt
  * @property {string} updatedAt
  * @property {string} createdBy
@@ -56,5 +56,6 @@ export const external = gql`
     partner {
       ...partner
     }
+    updatedAt
   }
 `

--- a/packages/mirror-media-next/apollo/query/externals.js
+++ b/packages/mirror-media-next/apollo/query/externals.js
@@ -21,4 +21,15 @@ const fetchExternalCounts = gql`
   }
 `
 
-export { fetchExternalsByPartnerSlug, fetchExternalCounts }
+const fetchExternalBySlug = gql`
+  ${external}
+  query ($slug: String) {
+    externals(
+      where: { slug: { equals: $slug }, state: { equals: "published" } }
+    ) {
+      ...external
+    }
+  }
+`
+
+export { fetchExternalsByPartnerSlug, fetchExternalCounts, fetchExternalBySlug }

--- a/packages/mirror-media-next/components/external/external-article-info.js
+++ b/packages/mirror-media-next/components/external/external-article-info.js
@@ -1,0 +1,133 @@
+import styled from 'styled-components'
+import Link from 'next/link'
+import Image from 'next/image'
+import ButtonCopyLink from '../../components/story/shared/button-copy-link'
+import DonateLink from '../../components/story/shared/donate-link'
+import ButtonSocialNetworkShare from '../../components/story/shared/button-social-network-share'
+import { getCreditsHtml } from '../../utils/external'
+
+/**
+ * @typedef {import('~/type/theme').Theme} Theme
+ */
+
+const Date = styled.div`
+  width: fit-content;
+  height: auto;
+  font-size: 14px;
+  line-height: 1;
+  color: #a1a1a1;
+  margin-bottom: 8px;
+  ${({ theme }) => theme.breakpoint.md} {
+    display: none;
+  }
+`
+
+const SocialMedia = styled.div`
+  display: flex;
+  gap: 10px;
+  padding: 0;
+  position: relative;
+  margin-bottom: 20px;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    padding: 0 40px;
+    margin-bottom: 0px;
+    &::before,
+    &::after {
+      position: absolute;
+      content: '';
+      background-color: #a1a1a1;
+      width: 1px;
+      height: 16px;
+      transform: translateY(-50%);
+      top: 50%;
+    }
+    &::before {
+      left: 20px;
+    }
+    &::after {
+      right: 20px;
+    }
+  }
+`
+
+const SocialMediaAndDonateLink = styled.div`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 20px;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    margin-top: 40px;
+    flex-direction: row;
+    align-items: center;
+  }
+  .link-to-index {
+    display: none;
+    ${({ theme }) => theme.breakpoint.md} {
+      display: block;
+    }
+  }
+`
+
+const ArticleInfoContainer = styled.div`
+  border-left: 2px ${({ theme }) => theme.color.brandColor.darkBlue} solid;
+  padding-left: 24px;
+  margin: 32px 0;
+  ${({ theme }) => theme.breakpoint.md} {
+    border: none;
+    padding-left: 0px;
+    margin: 0 0 24px;
+  }
+`
+
+const ExternalCredit = styled.div`
+  margin: 25px 0px;
+  text-align: left;
+  color: rgb(52, 73, 94);
+  line-height: 1.5;
+
+  a {
+    color: #0b4fa2;
+  }
+`
+
+/**
+ * @param {Object} props
+ * @param {string} props.updatedDate
+ * @param {string} props.publishedDate
+ * @param {string} props.credits
+ * @returns {JSX.Element}
+ */
+export default function ArticleInfo({ updatedDate, publishedDate, credits }) {
+  const creditJsx = credits.length > 0 && (
+    <ExternalCredit>文｜{getCreditsHtml(credits)} </ExternalCredit>
+  )
+
+  return (
+    <ArticleInfoContainer>
+      <Date>發布時間：{publishedDate} 臺北時間</Date>
+      <Date>更新時間：{updatedDate} 臺北時間</Date>
+
+      {creditJsx}
+
+      <SocialMediaAndDonateLink>
+        <Link className="link-to-index" href="/">
+          <Image
+            width={35}
+            height={35}
+            alt="go-to-index-page"
+            src="/images/logo-circle@2x.png"
+          ></Image>
+        </Link>
+        <SocialMedia>
+          <ButtonSocialNetworkShare type="facebook" />
+          <ButtonSocialNetworkShare type="line" />
+          <ButtonCopyLink />
+        </SocialMedia>
+        <DonateLink />
+      </SocialMediaAndDonateLink>
+    </ArticleInfoContainer>
+  )
+}

--- a/packages/mirror-media-next/components/external/external-hero-image.js
+++ b/packages/mirror-media-next/components/external/external-hero-image.js
@@ -1,0 +1,54 @@
+import CustomImage from '@readr-media/react-image'
+import styled from 'styled-components'
+
+const Wrapper = styled.figure`
+  margin: 20px 0 0;
+  ${({ theme }) => theme.breakpoint.md} {
+    margin: 0 0 34px;
+  }
+`
+
+const HeroImage = styled.figure`
+  position: relative;
+  width: 100%;
+  height: 58.75vw;
+  .readr-media-react-image {
+    object-position: center center;
+  }
+
+  ${({ theme }) => theme.breakpoint.md} {
+    width: 640px;
+    height: 428px;
+  }
+`
+
+/**
+ * @typedef {import('../../apollo/fragments/photo').Resized} Resized
+ */
+/**
+ * @param {Object} props
+ * @param {Resized} props.images
+ * @param {string} props.title
+ * @param {string} [props.className]
+ * @returns
+ */
+export default function ExternalHeroImage({
+  images = {},
+  title = '',
+  className = '',
+}) {
+  return (
+    <Wrapper className={className}>
+      <HeroImage>
+        <CustomImage
+          images={images}
+          loadingImage={'/images/loading@4x.gif'}
+          defaultImage={'/images/default-og-img.png'}
+          alt={title}
+          objectFit={'cover'}
+          priority={true}
+        />
+      </HeroImage>
+    </Wrapper>
+  )
+}

--- a/packages/mirror-media-next/components/external/external-normal-style.js
+++ b/packages/mirror-media-next/components/external/external-normal-style.js
@@ -2,7 +2,7 @@
 //TODO: refactor jsx structure, make it more readable.
 
 import { useCallback } from 'react'
-import client from '~/apollo/apollo-client'
+import client from '../../apollo/apollo-client'
 import styled, { css } from 'styled-components'
 import Link from 'next/link'
 import axios from 'axios'
@@ -18,7 +18,7 @@ import MagazineInviteBanner from '../../components/story/shared/magazine-invite-
 // import ArticleContent from '../../components/story/normal/article-content'
 import ExternalHeroImage from '../../components/external/external-hero-image'
 import Divider from '../../components/story/shared/divider'
-import { transformTimeDataIntoDotFormat } from '~/utils'
+import { transformTimeDataIntoDotFormat } from '../../utils'
 import { fetchAsidePosts } from '../../apollo/query/posts'
 import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../config/index.mjs'
 import {
@@ -377,7 +377,7 @@ export default function ExternalNormalStyle({ external }) {
       console.error(err)
       return []
     }
-  }, [slug])
+  }, [slug, EXTERNAL_DEFAULT_SECTION.slug])
 
   /**
    * @returns {Promise<AsideArticleData[] | []>}

--- a/packages/mirror-media-next/components/external/external-normal-style.js
+++ b/packages/mirror-media-next/components/external/external-normal-style.js
@@ -1,0 +1,539 @@
+//TODO: adjust margin and padding of all margin and padding after implement advertisement.
+//TODO: refactor jsx structure, make it more readable.
+
+import { useCallback } from 'react'
+import client from '~/apollo/apollo-client'
+import styled, { css } from 'styled-components'
+import Link from 'next/link'
+import axios from 'axios'
+import MockAdvertisement from '../../components/mock-advertisement'
+import ExternalArticleInfo from '../../components/external/external-article-info'
+import ArticleBrief from '../../components/story/shared/brief'
+import AsideArticleList from '../../components/story/normal/aside-article-list'
+import FbPagePlugin from '../../components/story/normal/fb-page-plugin'
+import SocialNetworkService from '../../components/story/normal/social-network-service'
+import SubscribeInviteBanner from '../../components/story/normal/subscribe-invite-banner'
+import DonateBanner from '../../components/story/shared/donate-banner'
+import MagazineInviteBanner from '../../components/story/shared/magazine-invite-banner'
+// import ArticleContent from '../../components/story/normal/article-content'
+import ExternalHeroImage from '../../components/external/external-hero-image'
+import Divider from '../../components/story/shared/divider'
+import { transformTimeDataIntoDotFormat } from '~/utils'
+import { fetchAsidePosts } from '../../apollo/query/posts'
+import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../config/index.mjs'
+import {
+  transformStringToDraft,
+  getExternalSectionTitle,
+} from '../../utils/external'
+
+/**
+ * @typedef {import('../../type/theme').Theme} Theme
+ */
+/**
+ * @typedef {import('../../components/story/normal/aside-article-list').ArticleData} AsideArticleData
+ */
+/**
+ * @typedef {import('../../apollo/fragments/external').External} External
+ */
+
+const sectionColor = css`
+  ${
+    /**
+     * @param {Object} props
+     * @param {String} [props.sectionSlug]
+     * @param {Theme} [props.theme]
+     */
+    ({ sectionSlug, theme }) =>
+      sectionSlug && theme.color.sectionsColor[sectionSlug]
+        ? theme.color.sectionsColor[sectionSlug]
+        : 'black'
+  };
+`
+
+const PC_HD_Advertisement = styled(MockAdvertisement)`
+  display: none;
+  margin: 24px auto;
+  text-align: center;
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: block;
+  }
+`
+const PC_R1_Advertisement = styled(MockAdvertisement)`
+  display: none;
+  margin: 0 auto;
+  text-align: center;
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: block;
+  }
+`
+const PC_R2_Advertisement = styled(MockAdvertisement)`
+  display: none;
+  margin: 20px auto;
+  text-align: center;
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: block;
+  }
+`
+const M_AT3_Advertisement = styled(MockAdvertisement)`
+  margin: 0 -20px;
+  width: 100vw;
+  max-width: 336px;
+  @media (min-width: 336px) {
+    margin: 0 auto;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
+  }
+`
+
+const Title = styled.h1`
+  margin: 0 auto;
+  width: 100%;
+  text-align: center;
+  font-weight: 400;
+  font-size: 24px;
+  line-height: 34px;
+  ${({ theme }) => theme.breakpoint.md} {
+    font-weight: 500;
+    font-size: 32px;
+    line-height: 1.25;
+    text-align: left;
+  }
+`
+const Main = styled.main`
+  margin: 20px auto 0;
+  width: 100%;
+  height: auto;
+  max-width: 1200px;
+  padding: 0 20px;
+  ${({ theme }) => theme.breakpoint.md} {
+    padding: 0 64px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 24px auto 0;
+    display: flex;
+    flex-direction: row;
+    align-items: start;
+    justify-content: space-between;
+    padding: 0 40px 0 77px;
+  }
+`
+const Article = styled.article`
+  max-width: 640px;
+  margin: 0 auto;
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 35px 0 0 0;
+  }
+`
+
+const ExternalSection = styled.div`
+  color: ${
+    /**
+     * @param {Object} props
+     * @param {Boolean} [props.shouldShowSectionColor]
+     */
+    ({ shouldShowSectionColor }) => shouldShowSectionColor && sectionColor
+  };
+
+  margin-left: 4px;
+  padding-left: 8px;
+  position: relative;
+  font-size: 16px;
+  line-height: 1.5;
+  text-align: center;
+  ${({ theme }) => theme.breakpoint.md} {
+    font-size: 18px;
+    line-height: 25px;
+    text-align: left;
+  }
+  &::before {
+    display: none;
+
+    ${({ theme }) => theme.breakpoint.md} {
+      display: block;
+      position: absolute;
+      content: '';
+      background-color: ${
+        /**
+         * @param {Object} props
+         * @param {Boolean} [props.shouldShowSectionColor]
+         */
+        ({ shouldShowSectionColor }) => shouldShowSectionColor && sectionColor
+      };
+
+      left: -4px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 4px;
+      height: 20px;
+    }
+  }
+`
+
+const Date = styled.div`
+  width: fit-content;
+  height: auto;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #a1a1a1;
+  display: none;
+  ${({ theme }) => theme.breakpoint.md} {
+    display: block;
+  }
+`
+const DateUnderContent = styled(Date)`
+  color: ${({ theme }) => theme.color.brandColor.darkBlue};
+  font-size: 16px;
+  line-height: 1.15;
+  margin-top: 32px;
+  .time {
+    color: ${({ theme }) => theme.color.brandColor.lightBlue};
+  }
+`
+const SectionAndDate = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 4px;
+  ${({ theme }) => theme.breakpoint.md} {
+    justify-content: space-between;
+    margin-bottom: 10px;
+  }
+`
+
+const StyledExternalHeroImage = styled(ExternalHeroImage)``
+const InfoAndHero = styled.div`
+  display: flex;
+  flex-direction: column;
+  ${({ theme }) => theme.breakpoint.md} {
+    ${StyledExternalHeroImage} {
+      order: 10;
+    }
+  }
+`
+const SocialNetworkServiceSmall = styled(SocialNetworkService)`
+  display: none;
+  ${({ theme }) => theme.breakpoint.md} {
+    display: flex;
+    margin-top: 20px;
+  }
+`
+const SocialNetworkServiceLarge = styled(SocialNetworkService)`
+  display: flex;
+  margin-top: 20px;
+  margin-bottom: 24px;
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
+  }
+`
+const StoryMoreInfo = styled.p`
+  font-size: 18px;
+  line-height: 1.5;
+  color: black;
+  margin: 0 auto;
+  text-align: center;
+  a {
+    color: ${({ theme }) => theme.color.brandColor.lightBlue};
+    border-bottom: 1px solid ${({ theme }) => theme.color.brandColor.lightBlue};
+  }
+`
+
+const StoryEnd = styled.section`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin: 60px auto 0;
+  padding: 0 23.5px;
+  ${({ theme }) => theme.breakpoint.md} {
+    width: 640px;
+
+    margin-top: 24px auto 0;
+    gap: 16px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    gap: 36px;
+    padding: 0;
+  }
+`
+const StoryEndMobileTablet = styled(StoryEnd)`
+  display: flex;
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
+  }
+`
+const StoryEndDesktop = styled(StoryEnd)`
+  display: none;
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: flex;
+  }
+`
+const Aside = styled.aside`
+  width: 100%;
+  ${({ theme }) => theme.breakpoint.xl} {
+    width: 365px;
+  }
+`
+
+const AsideFbPagePlugin = styled(FbPagePlugin)`
+  display: none;
+  text-align: center;
+  height: 500px;
+  margin: 20px 0;
+  ${
+    /**
+     * @param {Object} param
+     * @param {Theme} param.theme
+     */
+    ({ theme }) => theme.breakpoint.md
+  } {
+    display: block;
+  }
+`
+const AdvertisementDable = styled.div`
+  text-align: center;
+  background-color: #eeeeee;
+`
+const AdvertisementDableDesktop = styled(AdvertisementDable)`
+  display: none;
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: block;
+    width: 640px;
+    margin: 0 auto;
+  }
+`
+const AdvertisementDableMobile = styled(AdvertisementDable)`
+  display: block;
+  margin: 0 auto;
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
+    width: 640px;
+  }
+`
+
+/**
+ *
+ * @param {Object} props
+ * @param {External} props.external
+ * @returns {JSX.Element}
+ */
+export default function ExternalNormalStyle({ external }) {
+  const {
+    id = '',
+    slug = '',
+    title = '',
+    thumb = '',
+    brief = '',
+    // content = '',
+    partner = {},
+    publishedDate = '',
+    updatedAt = '',
+    extend_byline = '',
+  } = external
+
+  //Note: Although the `externals` post does not have `section` field, the default value for the external page is "news".
+  const EXTERNAL_DEFAULT_SECTION = { name: '時事', slug: 'news' }
+
+  //Note: The `heroImage` data in the `externals` post does not have `resized` property, only a single URL link. Here rewrite it into the format of "resized" for the "heroImage".
+  const EXTERNAL_IMAGES_URL = {
+    original: thumb,
+    w480: '',
+    w800: '',
+    w1200: '',
+    w1600: '',
+    w2400: '',
+  }
+
+  const publishedTaipeiTime = transformTimeDataIntoDotFormat(publishedDate)
+  const updatedTaipeiTime = transformTimeDataIntoDotFormat(updatedAt)
+
+  const externalSectionTitle = getExternalSectionTitle(partner)
+  const externalBrief = transformStringToDraft(id, brief)
+
+  //Note: Since the `external` page has a default `section` value, the section color will be determined based on the value of sectionTitle.
+  const shouldShowSectionColor = Boolean(
+    EXTERNAL_DEFAULT_SECTION.slug && externalSectionTitle
+  )
+
+  /**
+   * @returns {Promise<AsideArticleData[] | []>}
+   */
+  const handleFetchLatestNews = useCallback(async () => {
+    try {
+      /**
+       * @type {import('@apollo/client').ApolloQueryResult<{posts: AsideArticleData[]}>}
+       */
+      const res = await client.query({
+        query: fetchAsidePosts,
+        variables: {
+          take: 6,
+          sectionSlug: EXTERNAL_DEFAULT_SECTION.slug,
+          storySlug: slug,
+        },
+      })
+      return res.data?.posts
+    } catch (err) {
+      console.error(err)
+      return []
+    }
+  }, [slug])
+
+  /**
+   * @returns {Promise<AsideArticleData[] | []>}
+   */
+  const handleFetchPopularNews = async () => {
+    try {
+      /**
+       * @type {import('axios').AxiosResponse<AsideArticleData[] | []>}>}
+       */
+      const { data } = await axios({
+        method: 'get',
+        url: URL_STATIC_POPULAR_NEWS,
+        timeout: API_TIMEOUT,
+      })
+      return data.filter((data) => data).slice(0.6)
+    } catch (err) {
+      return []
+    }
+  }
+
+  return (
+    <>
+      <PC_HD_Advertisement
+        width="970px"
+        height="250px"
+        text="PC_HD 970*250"
+      ></PC_HD_Advertisement>
+      <Main>
+        <Article>
+          <SectionAndDate>
+            <ExternalSection
+              sectionSlug={EXTERNAL_DEFAULT_SECTION.slug}
+              shouldShowSectionColor={shouldShowSectionColor}
+            >
+              {externalSectionTitle}
+            </ExternalSection>
+            <Date>{publishedTaipeiTime} 臺北時間</Date>
+          </SectionAndDate>
+          <Title>{title}</Title>
+          <InfoAndHero>
+            <StyledExternalHeroImage
+              images={EXTERNAL_IMAGES_URL}
+              title={title}
+            />
+            <ExternalArticleInfo
+              updatedDate={updatedTaipeiTime}
+              publishedDate={publishedTaipeiTime}
+              credits={extend_byline}
+            />
+          </InfoAndHero>
+
+          <ArticleBrief brief={externalBrief} />
+
+          {/* <ArticleContent content={content} /> */}
+
+          <DateUnderContent>
+            <span>更新時間｜</span>
+            <span className="time">{updatedTaipeiTime} 臺北時間</span>
+          </DateUnderContent>
+          <DonateBanner />
+          <SocialNetworkServiceSmall />
+          <SubscribeInviteBanner />
+
+          <M_AT3_Advertisement
+            text="M_AT3 336*280"
+            width="336px"
+            height="280px"
+            className="ad"
+          />
+          <SocialNetworkServiceLarge
+            shouldShowLargePagePlugin={true}
+            flexDirection="column"
+          />
+          <M_AT3_Advertisement
+            text="M_E1 336*280"
+            width="336px"
+            height="280px"
+            className="ad"
+          />
+          <AdvertisementDableMobile>
+            dable廣告(手機版)施工中......
+          </AdvertisementDableMobile>
+
+          <StoryEndDesktop>
+            <StoryMoreInfo>
+              更多內容，歡迎&nbsp;
+              <Link href="/papermag" target="_blank">
+                鏡週刊紙本雜誌
+              </Link>
+              、
+              <Link href="/subscribe" target="_blank">
+                鏡週刊數位訂閱
+              </Link>
+              、
+              <Link href="/story/webauthorize/" target="_blank">
+                了解內容授權資訊
+              </Link>
+              。
+            </StoryMoreInfo>
+            <MagazineInviteBanner />
+            <AdvertisementDableDesktop>
+              dable廣告 (桌機版) 施工中......
+            </AdvertisementDableDesktop>
+          </StoryEndDesktop>
+        </Article>
+        <Aside>
+          <PC_R1_Advertisement
+            text="PC_R1 300*600"
+            width="300px"
+            height="600px"
+            className="ad"
+          ></PC_R1_Advertisement>
+          <AsideArticleList
+            heading="最新文章"
+            fetchArticle={handleFetchLatestNews}
+            shouldReverseOrder={false}
+            renderAmount={6}
+          ></AsideArticleList>
+
+          <PC_R2_Advertisement
+            text="PC_R2 300*600"
+            width="300px"
+            height="600px"
+            className="ad"
+          ></PC_R2_Advertisement>
+          <Divider />
+          <AsideArticleList
+            heading="熱門文章"
+            fetchArticle={handleFetchPopularNews}
+            shouldReverseOrder={false}
+            renderAmount={6}
+          ></AsideArticleList>
+          <AsideFbPagePlugin></AsideFbPagePlugin>
+        </Aside>
+      </Main>
+      <StoryEndMobileTablet>
+        <StoryMoreInfo>
+          更多內容，歡迎&nbsp;
+          <Link href="/papermag" target="_blank">
+            鏡週刊紙本雜誌
+          </Link>
+          、
+          <Link href="/subscribe" target="_blank">
+            鏡週刊數位訂閱
+          </Link>
+          、
+          <Link href="/story/webauthorize/" target="_blank">
+            了解內容授權資訊
+          </Link>
+          。
+        </StoryMoreInfo>
+        <MagazineInviteBanner />
+        <AdvertisementDableDesktop>
+          dable廣告 (桌機版) 施工中......
+        </AdvertisementDableDesktop>
+      </StoryEndMobileTablet>
+    </>
+  )
+}

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -1,0 +1,121 @@
+//TODO: add component to add html head dynamically, not jus write head in every pag
+import client from '../../apollo/apollo-client'
+import errors from '@twreporter/errors'
+import { GCP_PROJECT_ID } from '../../config/index.mjs'
+
+import { fetchExternalBySlug } from '../../apollo/query/externals'
+import ExternalNormalStyle from '~/components/external/external-normal-style'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import Layout from '../../components/shared/layout'
+
+/**
+ * @typedef {import('../../apollo/fragments/external').External} External
+ */
+
+/**
+ *
+ * @param {Object} props
+ * @param {External} props.external
+ * @param {Object} props.headerData
+ * @returns {JSX.Element}
+ */
+export default function External({ external, headerData }) {
+  return (
+    <Layout
+      head={{ title: `${external?.title}` }}
+      header={{ type: 'default', data: headerData }}
+      footer={{ type: 'default' }}
+    >
+      <ExternalNormalStyle external={external} />
+    </Layout>
+  )
+}
+
+/**
+ * @type {import('next').GetServerSideProps}
+ */
+export async function getServerSideProps({ params, req }) {
+  const { slug } = params
+  const traceHeader = req.headers?.['x-cloud-trace-context']
+  let globalLogFields = {}
+  if (traceHeader && !Array.isArray(traceHeader)) {
+    const [trace] = traceHeader.split('/')
+    globalLogFields[
+      'logging.googleapis.com/trace'
+    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
+  }
+
+  const responses = await Promise.allSettled([
+    fetchHeaderDataInDefaultPageLayout(), //fetch header data
+    client.query({
+      query: fetchExternalBySlug,
+      variables: { slug },
+    }),
+  ])
+
+  const handledResponses = responses.map((response) => {
+    if (response.status === 'fulfilled') {
+      return response.value
+    } else if (response.status === 'rejected') {
+      const { graphQLErrors, clientErrors, networkError } = response.reason
+      const annotatingError = errors.helpers.wrap(
+        response.reason,
+        'UnhandledError',
+        'Error occurs while getting section page data'
+      )
+
+      console.log(
+        JSON.stringify({
+          severity: 'ERROR',
+          message: errors.helpers.printAll(
+            annotatingError,
+            {
+              withStack: true,
+              withPayload: true,
+            },
+            0,
+            0
+          ),
+          debugPayload: {
+            graphQLErrors,
+            clientErrors,
+            networkError,
+          },
+          ...globalLogFields,
+        })
+      )
+      return
+    }
+  })
+
+  const headerData =
+    'sectionsData' in handledResponses[0]
+      ? handledResponses[0]
+      : {
+          sectionsData: [],
+          topicsData: [],
+        }
+  const sectionsData = Array.isArray(headerData.sectionsData)
+    ? headerData.sectionsData
+    : []
+  const topicsData = Array.isArray(headerData.topicsData)
+    ? headerData.topicsData
+    : []
+
+  /** @type {External} */
+  const external =
+    'data' in handledResponses[1]
+      ? handledResponses[1]?.data?.externals[0] || {}
+      : {}
+
+  if (!Object.keys(external).length) {
+    return { notFound: true }
+  }
+
+  const props = {
+    external,
+    headerData: { sectionsData, topicsData },
+  }
+
+  return { props }
+}

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -4,7 +4,7 @@ import errors from '@twreporter/errors'
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
 
 import { fetchExternalBySlug } from '../../apollo/query/externals'
-import ExternalNormalStyle from '~/components/external/external-normal-style'
+import ExternalNormalStyle from '../../components/external/external-normal-style'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
 

--- a/packages/mirror-media-next/utils/external.js
+++ b/packages/mirror-media-next/utils/external.js
@@ -1,0 +1,76 @@
+/**
+ * The `brief` of the externals is string and not in the format of a draft.
+ * Here convert the string into a data format with `blocks` and `entityMap`.
+ *
+ * @param {string} id
+ * @param {string} text
+ * @returns {Object}
+ */
+
+function transformStringToDraft(id = '', text = '') {
+  return {
+    blocks: [
+      {
+        data: {},
+        depth: 0,
+        entityRanges: [],
+        inlineStyleRanges: [],
+        key: `${id}`,
+        text: `${text}`,
+        type: 'unstyled',
+      },
+    ],
+    entityMap: {},
+  }
+}
+
+/**
+ * @typedef {import('../apollo/fragments/partner').Partner} Partner
+ */
+
+/**
+ * Special requirement:
+ * When the partner's slug is 'healthnews', 'zuchi', or '5678news', the section title will be '生活'.
+ * When the partner's slug is 'ebc', the section title will be '時事'.
+ * For all other partners, the section title will be '合作媒體'.
+ *
+ * @param {Partner} partner
+ * @returns {string}
+ */
+function getExternalSectionTitle(partner = {}) {
+  let sectionTitle
+  switch (partner['slug']) {
+    case 'healthnews':
+    case 'zuchi':
+    case '5678news':
+      sectionTitle = '生活'
+      break
+    case 'ebc':
+      sectionTitle = '時事'
+      break
+    case undefined:
+      sectionTitle = ''
+      break
+    default:
+      sectionTitle = '合作媒體'
+      break
+  }
+
+  return sectionTitle
+}
+
+/**
+ * The author field in externals can be either a plain string or a string containing HTML formatting. Based on the content of the string, return the corresponding JSX.Element.
+ *
+ * @param {string} credits
+ * @returns {JSX.Element}
+ */
+function getCreditsHtml(credits = '') {
+  if (/<[a-z][\s\S]*>/i.test(credits)) {
+    return <span dangerouslySetInnerHTML={{ __html: credits }} />
+  } else {
+    return <span>{credits}</span>
+  }
+}
+
+export { transformStringToDraft, getExternalSectionTitle, getCreditsHtml }


### PR DESCRIPTION
## Notable Change

- 新增 `/external/[slug]` 頁面： 
   - 是否導向 404 取決於文章是否發布（不論 partner 是否有填寫或 partner 是否公開）。
- 新增 `external` 元件： 
   - 考量到 `externals` 的 `credit` 與 `heroImage` 資料格式與 story 頁有差異，因此新增元件獨立處理。
   - 其餘元件與 `/story/normal` 一般文章頁共用。
   - 移除「相關文章」區塊（因 externals 無相關文章欄位）
  
- 新增 `external` utils：

   - `transformStringToDraft`：將「前言」字串轉為 draft 資料格式。
   - `getExternalSectionTitle`：依據 partner slug，回傳特定 section 小分類標題。
   - `getCreditsHtml`：「作者」欄位可能是純字串 or 含有 html 格式的字串，分析資料內容並回傳相應的 JSX。

- 新增 `fetchExternalBySlug` ：透過 slug 取得 `externals` 文章資料。
