### PR TITLE
style(mm-next): adjust story component `credits` and related code

### DIFF
--- a/packages/mirror-media-next/components/story/premium/article-info.js
+++ b/packages/mirror-media-next/components/story/premium/article-info.js
@@ -67,9 +67,9 @@ const Wrapper = styled.div`
   flex-direction: column;
   padding-left: 44px;
   padding-right: 20px;
-
+  width: 100%;
   max-width: 684px;
-  min-width: fit-content;
+
   margin: 32px auto 20px;
   position: relative;
   &::before {

--- a/packages/mirror-media-next/components/story/shared/credits.js
+++ b/packages/mirror-media-next/components/story/shared/credits.js
@@ -5,21 +5,15 @@ import Link from 'next/link'
  * @typedef {import('../../../type/theme').Theme} Theme
  */
 
-const Wrapper = styled.section`
-  width: 100%;
-  max-width: 640px;
-  margin: 24px auto 0;
-`
-
 const CreditsWrapper = styled.section`
   font-size: 16px;
   font-weight: 400;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
 
-  text-align: center;
+  margin-top: 24px;
+
+  text-align: left;
   width: 100%;
+  max-width: 300px;
   line-height: 1.5;
 `
 
@@ -46,19 +40,16 @@ const CreditTitle = styled.figcaption`
 
 const CreditList = styled.figure`
   display: flex;
-  margin: 0 auto;
   justify-content: flex-start;
-  width: 100%;
+  width: auto;
 
   ul {
     width: 100%;
 
-    justify-content: space-between;
-
-    display: grid;
-
-    grid-template-columns: repeat(auto-fill, minmax(48px, max-content));
     gap: 0 16px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: start;
     &.no-link-list {
       display: block;
     }
@@ -128,7 +119,7 @@ export default function Credits({ credits = [], className = '' }) {
   })
 
   const creditsJsx = shouldShowCredits ? (
-    <CreditsWrapper>
+    <>
       {credits.map((credit, index) => {
         const title = Object.keys(credit)
         const titleName = CREDIT_TITLE_NAME_MAP[title]
@@ -167,8 +158,8 @@ export default function Credits({ credits = [], className = '' }) {
           </CreditList>
         )
       })}
-    </CreditsWrapper>
+    </>
   ) : null
 
-  return <Wrapper className={className}>{creditsJsx}</Wrapper>
+  return <CreditsWrapper className={className}>{creditsJsx}</CreditsWrapper>
 }

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -88,7 +88,10 @@ const SocialMedia = styled.li`
     }
   }
 `
-
+const StyledCredits = styled(Credits)`
+  margin-left: auto;
+  margin-right: auto;
+`
 /**
  *
  * @param {Object} param
@@ -181,7 +184,7 @@ export default function StoryWideStyle({ postData }) {
               </li> */}
               </SocialMediaAndDonateLink>
             </NavSubtitleNavigator>
-            <Credits credits={credits}></Credits>
+            <StyledCredits credits={credits}></StyledCredits>
             <DateWrapper>
               <StyledDate timeData={publishedDate} timeType="publishedDate" />
               <StyledDate timeData={updatedAt} timeType="updatedDate" />


### PR DESCRIPTION
## Notable Change
在review https://github.com/mirror-media/Adam/pull/223#discussion_r1205897918 時發現原本credits的css寫法，若credits任一成員名字較長，會導致破版現象。
經確認需求後，調整credits的樣式，改為使用`display: flex`排列credit成員。
此外，亦限制credits最大寬度為300px，避免成員過少時，視覺上過於偏左的情況。