### PR TITLE
feat(mm-next): add Dable ad

### DIFF
--- a/packages/mirror-media-next/components/ads/dable/dable-ad.js
+++ b/packages/mirror-media-next/components/ads/dable/dable-ad.js
@@ -1,0 +1,55 @@
+import useWindowDimensions from '../../../hooks/use-window-dimensions'
+import Script from 'next/script'
+import { DABLE_WIDGET_IDS } from '../../../constants/ads'
+import { mediaSize } from '../../../styles/media'
+
+/**
+ *
+ * @param {Object} props
+ * @param {boolean} props.isDesktop - programmatically set for desktop or not
+ * @returns
+ */
+export default function DableAd({ isDesktop }) {
+  const { width } = useWindowDimensions()
+  const isDesktopWidth = width >= mediaSize.xl
+
+  if (isDesktopWidth !== isDesktop) {
+    return <></>
+  }
+
+  return (
+    <>
+      <Script
+        id="dable"
+        dangerouslySetInnerHTML={{
+          __html: `
+            (function (d, a, b, l, e, _) {
+              if (d[b] && d[b].q) return
+              d[b] = function () {
+                ;(d[b].q = d[b].q || []).push(arguments)
+              }
+              e = a.createElement(l)
+              e.async = 1
+              e.charset = 'utf-8'
+              e.src = '//static.dable.io/dist/plugin.min.js'
+              _ = a.getElementsByTagName(l)[0]
+              _.parentNode.insertBefore(e, _)
+            })(window, document, 'dable', 'script')
+            dable('setService', 'mirrormedia.mg')
+            dable('sendLogOnce')
+            dable('renderWidget', 'dablewidget_${DABLE_WIDGET_IDS.MB}')
+            dable('renderWidget', 'dablewidget_${DABLE_WIDGET_IDS.PC}')
+          `,
+        }}
+      />
+      <div
+        id={`dablewidget_${
+          isDesktopWidth ? DABLE_WIDGET_IDS.PC : DABLE_WIDGET_IDS.MB
+        }`}
+        data-widget_id={
+          isDesktopWidth ? DABLE_WIDGET_IDS.PC : DABLE_WIDGET_IDS.MB
+        }
+      ></div>
+    </>
+  )
+}

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -28,6 +28,7 @@ import {
 import { fetchHeaderDataInDefaultPageLayout } from '../../../utils/api'
 import { fetchAsidePosts } from '../../../apollo/query/posts'
 import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
+import DableAd from '../../ads/dable/dable-ad'
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
  */
@@ -549,6 +550,7 @@ export default function StoryNormalStyle({ postData }) {
           />
           <AdvertisementDableMobile>
             dable廣告(手機版)施工中......
+            <DableAd isDesktop={false} />
           </AdvertisementDableMobile>
           <StoryEndDesktop>
             <StoryMoreInfo>
@@ -569,6 +571,7 @@ export default function StoryNormalStyle({ postData }) {
             <MagazineInviteBanner />
             <AdvertisementDableDesktop>
               dable廣告 (桌機版) 施工中......
+              <DableAd isDesktop={true} />
             </AdvertisementDableDesktop>
           </StoryEndDesktop>
         </Article>

--- a/packages/mirror-media-next/constants/ads.js
+++ b/packages/mirror-media-next/constants/ads.js
@@ -36,6 +36,11 @@ const MICRO_AD_UNITS = {
   },
 }
 
+const DABLE_WIDGET_IDS = {
+  MB: '6XgaOJ7N',
+  PC: 'GlYwenoy',
+}
+
 const {
   member,
   news,
@@ -1546,4 +1551,4 @@ const GPT_UNITS = {
 
 const GPT_AD_NETWORK = '40175602'
 
-export { MICRO_AD_UNITS, GPT_UNITS, GPT_AD_NETWORK }
+export { MICRO_AD_UNITS, DABLE_WIDGET_IDS, GPT_UNITS, GPT_AD_NETWORK }


### PR DESCRIPTION
# Feature
- 新增 Dable 基礎設定
- Dable 範例 (待調整)

## 基礎設定
1. 新增 [Dable widget ids](https://github.com/caesarWHLee/Adam/blob/ad-dable/packages/mirror-media-next/constants/ads.js)
2. 廣告相關的 component 放在 `~/component/ads/{對應廣告商}/` 中
3. 因 Dable 廣告的 style 是由 script 所決定，依照不同的 id 來決定 render 桌機還是手機版本，因此只會有一個 component，除了控制桌機/手機版本之外，會把 Dable 的 script 透過 `dangerouslySetInnerHTML` 的方式塞入 (主要是該段 code 用在 `useEffect` 會有 type 的問題)。
4. 在寫使用範例時，因 story 頁面目前的寫法會同時產生 mobile/pc 的 HTML，透過 css `display: none` 的設定來隱藏，而 Dable 的 script 只會針對第一個 Dable componet 來注入內容，而手機的 Dable component 位置是較前面的，實測在桌機版的狀況下桌機的 Dable 廣告會出不來，因此在 Dable component 中加入 `props.isDesktop`，只有在該 `comoponent props.isDesktop` 和 browser 實際的尺寸吻合的時候， Dable component 才會返回帶有 Dable id 的 div。

## 使用範例
參考[以下用法](https://github.com/caesarWHLee/Adam/blob/ad-dable/packages/mirror-media-next/components/story/normal/index.js)
在桌機和手機的 wrapper 中加入 DableAd，並依帶入 `isDesktop` 來定義該 DableAd 是 for 桌機還是手機

## 開發
Dable 廣告可以在 local 上直接測試。

## Follow up
- 在 2.0 中 Dable 廣告會依照 vuex 中的 state.canAdvertise 來決定是否顯示，待確認是否和其他廣告中的各種顯示邏輯合併，確認後再加入。
- 2.0 中使用了 LazyRenderer 來 lazy load Dable 廣告，觀察因為只有 Dable 有使用這個技術，待確認是否其他廣告也需要做這類的優化，因此目前沒有使用類似的技術。


## Related PR
- [Micro Ad 設定](https://github.com/mirror-media/Adam/pull/227)
- [Pop In ad 設定](https://github.com/mirror-media/Adam/pull/235)
- [Dable ad 設定](https://github.com/mirror-media/Adam/pull/239)
- [Avivid ad 設定](https://github.com/mirror-media/Adam/pull/240)
- [GPT ad 設定](https://github.com/mirror-media/Adam/pull/252)

## Reference
- [2.0 廣告大全: Dable](https://paper.dropbox.com/doc/--B5HoYJJCDi3wuLktiME_oi2YAg-UtXMJmDEubtFfxcoB3zZ9#:uid=692843401096935133306520&h2=Dable)