### PR TITLE
feat(mm-next): add Avivid ad

### DIFF
--- a/packages/mirror-media-next/components/ads/avivid/avivid-script.js
+++ b/packages/mirror-media-next/components/ads/avivid/avivid-script.js
@@ -1,0 +1,12 @@
+import Script from 'next/script'
+
+export default function AvividScript() {
+  return (
+    <Script
+      id="likrNotification"
+      dangerouslySetInnerHTML={{
+        __html: `window.AviviD = window.AviviD || {settings:{},status:{}}; AviviD.web_id = "mirrormedia"; AviviD.category_id = "20180905000003"; AviviD.tracking_platform = 'likr'; (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl+'&timestamp='+new Date().getTime();f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-W9F4QDN'); (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl+'&timestamp='+new Date().getTime();f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-MKB8VFG');`,
+      }}
+    />
+  )
+}

--- a/packages/mirror-media-next/components/whole-site-script.js
+++ b/packages/mirror-media-next/components/whole-site-script.js
@@ -1,9 +1,11 @@
 import GPTScript from './ads/gpt/gpt-script'
+import AvividScript from './ads/avivid/avivid-script'
 
 export default function WholeSiteScript() {
   return (
     <>
       <GPTScript />
+      <AvividScript />
     </>
   )
 }

--- a/packages/mirror-media-next/pages/_app.js
+++ b/packages/mirror-media-next/pages/_app.js
@@ -11,6 +11,7 @@ import WholeSiteScript from '../components/whole-site-script'
 import { auth } from '../firebase'
 import axios from 'axios'
 import { WEEKLY_API_SERVER_ORIGIN } from '../config/index.mjs'
+
 /**
  *
  * @param {Object} props


### PR DESCRIPTION
# Feature
- 新增 Avivid 廣告

## 設定
1. 廣告相關的 component 放在 ~/component/ads/{對應廣告商}/ 中
2. 因 Avivid 廣告為桌機版全站插入 `position: fixed` 的廣告，只需要跑 Avivid 提供的程式碼即可，所以新增了 AvividAd component 來添加 inline 的 script。
3. 將所有需要全站插入的 script 統一放在 _app.js 中 `<Component {...pageProps} />` 之上，共同包裹在 provider 之中，因 Avivid 廣告將會依照訂閱會員與否來決定是否呈現，所以會需要用到 useContext 來取得權限。

## 開發
Avivid 廣告可以在 local 上直接測試。

## Follow up
- 2.0 中 Avivid 會依照會員與否 `isPremiumMember ` 來決定是否呈現，待確認是否和其他廣告的顯示邏輯共同整合。


## Related PR
- [Micro Ad 設定](https://github.com/mirror-media/Adam/pull/227)
- [Pop In ad 設定](https://github.com/mirror-media/Adam/pull/235)
- [Dable ad 設定](https://github.com/mirror-media/Adam/pull/239)
- [Avivid ad 設定](https://github.com/mirror-media/Adam/pull/240)
- [GPT ad 設定](https://github.com/mirror-media/Adam/pull/252)

## Reference
- [2.0 廣告大全: MicroAd](https://paper.dropbox.com/doc/--B5HoYJJCDi3wuLktiME_oi2YAg-UtXMJmDEubtFfxcoB3zZ9#:uid=021432474303969025349393&h2=AviviD)