### PR TITLE
refactor(mm-next): add amp as contentLayout type

### DIFF
--- a/packages/mirror-media-next/components/amp/amp-info.js
+++ b/packages/mirror-media-next/components/amp/amp-info.js
@@ -1,8 +1,5 @@
 import styled from 'styled-components'
-import {
-  transformTimeDataIntoDotFormat,
-  sortArrayWithOtherArrayId,
-} from '../../utils'
+import { transformTimeDataIntoDotFormat } from '../../utils'
 import { color } from '../../styles/theme/color'
 
 const Section = styled.div`

--- a/packages/mirror-media-next/components/amp/amp-main.js
+++ b/packages/mirror-media-next/components/amp/amp-main.js
@@ -191,10 +191,14 @@ export default function AmpMain({ postData }) {
         })}
       </TagsWrapper>
       <AmpBriefContainer>
-        <ArticleBrief sectionSlug={section?.slug} brief={brief}></ArticleBrief>
+        <ArticleBrief
+          sectionSlug={section?.slug}
+          brief={brief}
+          contentLayout="amp"
+        ></ArticleBrief>
       </AmpBriefContainer>
       <AmpContentContainer>
-        <DraftRenderBlock rawContentBlock={content} contentLayout="normal" />
+        <DraftRenderBlock rawContentBlock={content} contentLayout="amp" />
       </AmpContentContainer>
     </MainWrapper>
   )

--- a/packages/mirror-media-next/components/story/shared/brief.js
+++ b/packages/mirror-media-next/components/story/shared/brief.js
@@ -43,7 +43,7 @@ const BriefContainer = styled.div`
  * @param {Object} props
  * @param {Brief} props.brief
  * @param {String} [props.sectionSlug]
- * @param { 'normal' | 'wide' | 'photography' | 'premium' } [props.contentLayout]
+ * @param { 'normal' | 'wide' | 'photography' | 'premium' | 'amp' } [props.contentLayout]
  * @returns {JSX.Element}
  */
 export default function ArticleBrief({

--- a/packages/mirror-media-next/components/story/shared/draft-renderer-block.js
+++ b/packages/mirror-media-next/components/story/shared/draft-renderer-block.js
@@ -13,7 +13,7 @@ const { DraftRenderer, hasContentInRawContentBlock, removeEmptyContentBlock } =
  * We use package `@mirrormedia/draft-renderer` to render the block of draft.js
  * @param {Object} props
  * @param {import('../../../type/draft-js').Draft} props.rawContentBlock - The blocks of draft.js we want to render.
- * @param { 'normal' | 'wide' | 'photography' | 'premium' } [props.contentLayout]
+ * @param { 'normal' | 'wide' | 'photography' | 'premium' | 'amp' } [props.contentLayout]
  * - Which layout we want to render.
  * - Different layout will affect the style of blocks.
  * - Optional, default value is `normal`


### PR DESCRIPTION
### 描述
新增 'amp' 作為一種 contentLayout type，讓 amp 頁面可以 render 客製化內容。