### PR TITLE
feat(mm-next/header): show external partner, add link to `/papermag`,  open another tab on link of promotions

### DIFF
--- a/packages/mirror-media-next/components/header.js
+++ b/packages/mirror-media-next/components/header.js
@@ -8,6 +8,8 @@ import {
   SOCIAL_MEDIA_LINKS,
 } from '../constants'
 
+const DISPLAY_PARTNERS = [{ name: '生活暖流', href: '/externals/warmlife' }]
+
 import SubBrandList from './sub-brand-list'
 import SearchBarDesktop from './search-bar-desktop'
 import PromotionLinks from './promotion-links'
@@ -278,6 +280,7 @@ export default function Header({
           <MobileSidebar
             topics={topics}
             sections={sections}
+            displayedPartners={DISPLAY_PARTNERS}
             subBrands={SUB_BRAND_LINKS}
             promotions={PROMOTION_LINKS}
             socialMedia={SOCIAL_MEDIA_LINKS}
@@ -307,7 +310,7 @@ export default function Header({
             }
           />
         </SearchInputWrapper>
-        <NavSections sections={sections} />
+        <NavSections sections={sections} displayedPartners={DISPLAY_PARTNERS} />
         <TopicsAndFlashNews>
           {children}
           <TopicsAndSubscribe>

--- a/packages/mirror-media-next/components/mobile-sidebar.js
+++ b/packages/mirror-media-next/components/mobile-sidebar.js
@@ -190,14 +190,12 @@ const SubBrandList = styled.ul`
   }
 `
 const PromotionList = styled.ul`
-  display: flex;
   color: #bcbcbc;
-  justify-content: start;
+  justify-content: center;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
   flex-wrap: wrap;
   row-gap: 9px;
-  li {
-    min-width: 33.33%;
-  }
 `
 // The way to display social-media link is copied from mirror-media-nuxt,
 // should be refactor if has separate image of each social media.
@@ -330,7 +328,9 @@ export default function MobileSidebar({
           <PromotionList>
             {promotions.map((promotion) => (
               <li key={promotion.name}>
-                <a href={promotion.href}>{promotion.title}</a>
+                <Link href={promotion.href} target="_blank">
+                  {promotion.title}
+                </Link>
               </li>
             ))}
           </PromotionList>

--- a/packages/mirror-media-next/components/mobile-sidebar.js
+++ b/packages/mirror-media-next/components/mobile-sidebar.js
@@ -243,14 +243,16 @@ const SocialMediaList = styled.div`
  * @param {import('../type').SubBrand[]} props.subBrands
  * @param {import('../type').Promotion[]} props.promotions
  * @param {import('../type').SocialMedia[]} props.socialMedia
+ * @param {{name: string, href:string}[]} props.displayedPartners
  * @returns {React.ReactElement}
  */
 export default function MobileSidebar({
   topics,
-  sections,
+  sections = [],
   subBrands,
   promotions,
   socialMedia,
+  displayedPartners = [],
 }) {
   const [openSidebar, setOpenSidebar] = useState(false)
   const [openSection, setOpenSection] = useState('')
@@ -298,6 +300,13 @@ export default function MobileSidebar({
                 ))}
               </Categories>
             </Fragment>
+          ))}
+          {displayedPartners.map(({ name, href }) => (
+            <Section key={name}>
+              <Link style={{ width: '50%' }} href={href}>
+                <h3>{name}</h3>
+              </Link>
+            </Section>
           ))}
         </SideBarTop>
         <SideBarBottom>

--- a/packages/mirror-media-next/components/nav-sections.js
+++ b/packages/mirror-media-next/components/nav-sections.js
@@ -101,9 +101,9 @@ const Section = styled.li`
     ${
       /**
        * @param {Object} param
-       * @param {string} param.sectionSlug
+       * @param {string} [param.sectionSlug]
        */
-      ({ sectionSlug }) => (sectionSlug ? colorCss : 'color: #fff;')
+      ({ sectionSlug }) => (sectionSlug ? colorCss : 'color: #000;')
     }
   }
 `
@@ -168,9 +168,10 @@ const CategoryLink = styled.a`
 /**
  * @param {Object} props
  * @param {SectionWithHrefTemp[]} props.sections
+ * @param {{name: string, href:string}[]} props.displayedPartners
  * @returns {React.ReactElement}
  */
-export default function NavSections({ sections = [] }) {
+export default function NavSections({ sections = [], displayedPartners = [] }) {
   return (
     <SectionsWrapper>
       <SectionLogo>
@@ -198,6 +199,15 @@ export default function NavSections({ sections = [] }) {
             </SectionDropDown>
           </Section>
         ))}
+        <>
+          {displayedPartners.map((partner) => (
+            <Section key={partner.name}>
+              <SectionLink href={partner.href}>
+                <h2>{partner.name}</h2>
+              </SectionLink>
+            </Section>
+          ))}
+        </>
       </Sections>
     </SectionsWrapper>
   )

--- a/packages/mirror-media-next/components/subscribe-magazine.js
+++ b/packages/mirror-media-next/components/subscribe-magazine.js
@@ -1,9 +1,9 @@
 import styled from 'styled-components'
-import { minWidth } from '../styles/media'
 
+import Link from 'next/link'
 const SubscribeMagazineButton = styled.button`
   display: none;
-  @media ${minWidth.xl} {
+  ${({ theme }) => theme.breakpoint.xl} {
     display: block;
     width: 141px;
     background-color: rgba(0, 0, 0, 1);
@@ -13,5 +13,9 @@ const SubscribeMagazineButton = styled.button`
 `
 
 export default function SubscribeMagazine() {
-  return <SubscribeMagazineButton>鏡週刊雜誌訂閱</SubscribeMagazineButton>
+  return (
+    <SubscribeMagazineButton>
+      <Link href="/papermag">鏡週刊雜誌訂閱</Link>
+    </SubscribeMagazineButton>
+  )
 }


### PR DESCRIPTION
## Notable Change
1. 於header中顯示合作媒體，點擊後會導向特定externals列表頁。目前是將欲顯示的合作媒體，直接寫死在header中。
2. 於header中新增前往頁面/papermag的連結。
3. 在手機版header側欄中，點擊promotion list時，會另開分頁。