### PR TITLE
refactor(mm-next): remove unused code and props in index page

### DIFF
--- a/packages/mirror-media-next/components/latest-news.js
+++ b/packages/mirror-media-next/components/latest-news.js
@@ -96,7 +96,6 @@ const transformRawDataContent = function (articleRawData) {
 /**
  * @param {Object} props
  * @param {RawData[]} [props.latestNewsData = []]
- * @param {String} [props.latestNewsTimestamp = '']
  * @returns {JSX.Element}
  */
 


### PR DESCRIPTION
## Notable Change
移除首頁中不需要的程式碼，包含透過`apollo/client`抓取cms 編輯精選（改為使用json資料）、props `latestNewsTimestamp`（該props原本是用於使server side取得的json資料，若超過一定時間，需要在client side抓取一次。但現在透過設定首頁快取時間，則可以達到原本的目的）