### PR TITLE
feat(mm-next): add adult-only-warning and wine-warning on amp page

### DIFF
--- a/packages/mirror-media-next/components/story/shared/adult-only-warning.js
+++ b/packages/mirror-media-next/components/story/shared/adult-only-warning.js
@@ -109,7 +109,7 @@ export default function AdultOnlyWarning({ isAdult = false }) {
   }, [shouldShowAdultWarning])
 
   const adultOnlyJsx = shouldShowAdultWarning ? (
-    <Wrapper ref={warningRef}>
+    <Wrapper ref={warningRef} id="adult-only-warning">
       <WarningContent>
         <WarningTitle>
           您即將進入之內容
@@ -127,6 +127,7 @@ export default function AdultOnlyWarning({ isAdult = false }) {
             onClick={() => {
               setIsAgreed(true)
             }}
+            on="tap:adult-only-warning.hide,amp-page.toggleClass(class='disable-scroll')"
             aria-label="是，我已年滿十八歲"
           >
             是，我已年滿十八歲

--- a/packages/mirror-media-next/components/story/shared/adult-only-warning.js
+++ b/packages/mirror-media-next/components/story/shared/adult-only-warning.js
@@ -82,10 +82,11 @@ const ButtonWrapper = styled.div`
  *
  * @param {Object} props
  * @param {boolean} props.isAdult
+ * @param {string} [props.onEvent]
  * @returns {JSX.Element}
  */
 
-export default function AdultOnlyWarning({ isAdult = false }) {
+export default function AdultOnlyWarning({ isAdult = false, onEvent = '' }) {
   const [isAgreed, setIsAgreed] = useState(false)
 
   const shouldShowAdultWarning = Boolean(isAdult && !isAgreed)
@@ -127,7 +128,7 @@ export default function AdultOnlyWarning({ isAdult = false }) {
             onClick={() => {
               setIsAgreed(true)
             }}
-            on="tap:adult-only-warning.hide,amp-page.toggleClass(class='disable-scroll')"
+            on={onEvent}
             aria-label="是，我已年滿十八歲"
           >
             是，我已年滿十八歲

--- a/packages/mirror-media-next/components/story/shared/adult-only-warning.js
+++ b/packages/mirror-media-next/components/story/shared/adult-only-warning.js
@@ -3,6 +3,7 @@ import { Z_INDEX } from '../../../constants'
 import NextLink from 'next/link'
 import { useState, useEffect, useRef } from 'react'
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock'
+import { useAmp } from 'next/amp'
 
 const Wrapper = styled.div`
   position: fixed;
@@ -82,11 +83,11 @@ const ButtonWrapper = styled.div`
  *
  * @param {Object} props
  * @param {boolean} props.isAdult
- * @param {string} [props.onEvent]
  * @returns {JSX.Element}
  */
 
-export default function AdultOnlyWarning({ isAdult = false, onEvent = '' }) {
+export default function AdultOnlyWarning({ isAdult = false }) {
+  const isAmp = useAmp()
   const [isAgreed, setIsAgreed] = useState(false)
 
   const shouldShowAdultWarning = Boolean(isAdult && !isAgreed)
@@ -109,6 +110,31 @@ export default function AdultOnlyWarning({ isAdult = false, onEvent = '' }) {
     }
   }, [shouldShowAdultWarning])
 
+  let agreeBtnJsx
+  if (isAmp) {
+    agreeBtnJsx = (
+      <button
+        className="agree-button"
+        on="tap:adult-only-warning.hide,amp-page.toggleClass(class='disable-scroll')"
+        aria-label="是，我已年滿十八歲"
+      >
+        是，我已年滿十八歲
+      </button>
+    )
+  } else {
+    agreeBtnJsx = (
+      <button
+        className="agree-button"
+        onClick={() => {
+          setIsAgreed(true)
+        }}
+        aria-label="是，我已年滿十八歲"
+      >
+        是，我已年滿十八歲
+      </button>
+    )
+  }
+
   const adultOnlyJsx = shouldShowAdultWarning ? (
     <Wrapper ref={warningRef} id="adult-only-warning">
       <WarningContent>
@@ -123,16 +149,7 @@ export default function AdultOnlyWarning({ isAdult = false, onEvent = '' }) {
         </p>
 
         <ButtonWrapper>
-          <button
-            className="agree-button"
-            onClick={() => {
-              setIsAgreed(true)
-            }}
-            on={onEvent}
-            aria-label="是，我已年滿十八歲"
-          >
-            是，我已年滿十八歲
-          </button>
+          {agreeBtnJsx}
           <NextLink href="/" aria-label="離開">
             <button>離開</button>
           </NextLink>

--- a/packages/mirror-media-next/components/story/shared/wine-warning.js
+++ b/packages/mirror-media-next/components/story/shared/wine-warning.js
@@ -2,6 +2,7 @@ import Image from 'next/image'
 
 import styled from 'styled-components'
 import { Z_INDEX } from '../../../constants'
+import { getCategoryOfWineSlug } from '../../../utils/index'
 
 const Wrapper = styled.div`
   width: 100%;
@@ -37,15 +38,7 @@ const Wrapper = styled.div`
  */
 
 export default function WineWarning({ categories = [] }) {
-  let categoryOfWineSlug //array of categories with the slug 'wine' or 'wine1'.
-
-  if (Array.isArray(categories)) {
-    categoryOfWineSlug = categories.filter(
-      (category) => category.slug === 'wine' || category.slug === 'wine1'
-    )
-  } else {
-    categoryOfWineSlug = []
-  }
+  let categoryOfWineSlug = getCategoryOfWineSlug(categories)
 
   const wineWarningJsx =
     categoryOfWineSlug.length > 0 ? (

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -10,11 +10,17 @@ import { fetchPostBySlug } from '../../../apollo/query/posts'
 // @ts-ignore
 import { GCP_PROJECT_ID } from '../../../config/index.mjs'
 import styled from 'styled-components'
+import AdultOnlyWarning from '../../../components/story/shared/adult-only-warning'
 
 export const config = { amp: true }
 
 const AmpBody = styled.body`
   background: #f5f5f5;
+  &.disable-scroll {
+    margin: 0;
+    height: 100vh !important;
+    overflow: hidden !important;
+  }
 `
 
 /**
@@ -33,7 +39,8 @@ function StoryAmpPage({ postData }) {
     title = '',
     relateds = [],
     manualOrderOfRelateds = [],
-    isMember,
+    isMember = false,
+    isAdult = false,
   } = postData
 
   const relatedsWithOrdered =
@@ -45,8 +52,9 @@ function StoryAmpPage({ postData }) {
       <Head>
         <title>{title}</title>
       </Head>
-      <AmpBody>
+      <AmpBody id="amp-page" className={isAdult && 'disable-scroll'}>
         <AmpHeader />
+        <AdultOnlyWarning isAdult={isAdult} />
         <AmpMain postData={postData} isMember={isMember} />
         <AmpRelated relateds={relatedsWithOrdered} />
         <AmpFooter />

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -54,7 +54,10 @@ function StoryAmpPage({ postData }) {
       </Head>
       <AmpBody id="amp-page" className={isAdult && 'disable-scroll'}>
         <AmpHeader />
-        <AdultOnlyWarning isAdult={isAdult} />
+        <AdultOnlyWarning
+          isAdult={isAdult}
+          onEvent="tap:adult-only-warning.hide,amp-page.toggleClass(class='disable-scroll')"
+        />
         <AmpMain postData={postData} isMember={isMember} />
         <AmpRelated relateds={relatedsWithOrdered} />
         <AmpFooter />

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -16,10 +16,10 @@ export const config = { amp: true }
 
 const AmpBody = styled.body`
   background: #f5f5f5;
-  &.disable-scroll {
+  #amp-page.disable-scroll {
     margin: 0;
-    height: 100vh !important;
-    overflow: hidden !important;
+    height: 100vh;
+    overflow: hidden;
   }
 `
 
@@ -52,15 +52,14 @@ function StoryAmpPage({ postData }) {
       <Head>
         <title>{title}</title>
       </Head>
-      <AmpBody id="amp-page" className={isAdult && 'disable-scroll'}>
-        <AmpHeader />
-        <AdultOnlyWarning
-          isAdult={isAdult}
-          onEvent="tap:adult-only-warning.hide,amp-page.toggleClass(class='disable-scroll')"
-        />
-        <AmpMain postData={postData} isMember={isMember} />
-        <AmpRelated relateds={relatedsWithOrdered} />
-        <AmpFooter />
+      <AmpBody>
+        <section id="amp-page" className={isAdult && 'disable-scroll'}>
+          <AmpHeader />
+          <AdultOnlyWarning isAdult={isAdult} />
+          <AmpMain postData={postData} isMember={isMember} />
+          <AmpRelated relateds={relatedsWithOrdered} />
+          <AmpFooter />
+        </section>
       </AmpBody>
     </div>
   )

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -10,7 +10,6 @@ import {
   getCategoryOfWineSlug,
 } from '../../../utils'
 import { fetchPostBySlug } from '../../../apollo/query/posts'
-// @ts-ignore
 import { GCP_PROJECT_ID } from '../../../config/index.mjs'
 import styled from 'styled-components'
 import AdultOnlyWarning from '../../../components/story/shared/adult-only-warning'
@@ -67,7 +66,7 @@ function StoryAmpPage({ postData }) {
       <AmpBody>
         <section
           id="amp-page"
-          className={`${categoryOfWineSlug.length && 'is-wine'} ${
+          className={`${!!categoryOfWineSlug.length && 'is-wine'} ${
             isAdult && 'disable-scroll'
           }`}
         >

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -5,21 +5,30 @@ import AmpHeader from '../../../components/amp/amp-header'
 import AmpFooter from '../../../components/amp/amp-footer'
 import AmpRelated from '../../../components/amp/amp-related'
 import AmpMain from '../../../components/amp/amp-main'
-import { sortArrayWithOtherArrayId } from '../../../utils'
+import {
+  sortArrayWithOtherArrayId,
+  getCategoryOfWineSlug,
+} from '../../../utils'
 import { fetchPostBySlug } from '../../../apollo/query/posts'
 // @ts-ignore
 import { GCP_PROJECT_ID } from '../../../config/index.mjs'
 import styled from 'styled-components'
 import AdultOnlyWarning from '../../../components/story/shared/adult-only-warning'
+import WineWarning from '../../../components/story/shared/wine-warning'
 
 export const config = { amp: true }
 
 const AmpBody = styled.body`
   background: #f5f5f5;
   #amp-page.disable-scroll {
-    margin: 0;
     height: 100vh;
     overflow: hidden;
+  }
+  #amp-page.is-wine {
+    margin-bottom: 5vh;
+    ${({ theme }) => theme.breakpoint.sm} {
+      margin-bottom: 10vh;
+    }
   }
 `
 
@@ -35,12 +44,14 @@ const AmpBody = styled.body`
  */
 
 function StoryAmpPage({ postData }) {
+  const isWine = getCategoryOfWineSlug()
   const {
     title = '',
     relateds = [],
     manualOrderOfRelateds = [],
     isMember = false,
     isAdult = false,
+    categories = [],
   } = postData
 
   const relatedsWithOrdered =
@@ -53,13 +64,19 @@ function StoryAmpPage({ postData }) {
         <title>{title}</title>
       </Head>
       <AmpBody>
-        <section id="amp-page" className={isAdult && 'disable-scroll'}>
+        <section
+          id="amp-page"
+          className={`${getCategoryOfWineSlug?.length > 0 && 'is-wine'} ${
+            isAdult && 'disable-scroll'
+          }`}
+        >
           <AmpHeader />
-          <AdultOnlyWarning isAdult={isAdult} />
           <AmpMain postData={postData} isMember={isMember} />
           <AmpRelated relateds={relatedsWithOrdered} />
           <AmpFooter />
         </section>
+        <AdultOnlyWarning isAdult={isAdult} />
+        <WineWarning categories={categories} />
       </AmpBody>
     </div>
   )

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -44,7 +44,6 @@ const AmpBody = styled.body`
  */
 
 function StoryAmpPage({ postData }) {
-  const isWine = getCategoryOfWineSlug()
   const {
     title = '',
     relateds = [],
@@ -53,6 +52,8 @@ function StoryAmpPage({ postData }) {
     isAdult = false,
     categories = [],
   } = postData
+
+  const categoryOfWineSlug = getCategoryOfWineSlug(categories)
 
   const relatedsWithOrdered =
     manualOrderOfRelateds && manualOrderOfRelateds.length
@@ -66,7 +67,7 @@ function StoryAmpPage({ postData }) {
       <AmpBody>
         <section
           id="amp-page"
-          className={`${getCategoryOfWineSlug?.length > 0 && 'is-wine'} ${
+          className={`${categoryOfWineSlug.length && 'is-wine'} ${
             isAdult && 'disable-scroll'
           }`}
         >

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -245,6 +245,20 @@ const getMagazineHrefFromSlug = (slug) => {
   return href
 }
 
+/**
+array of categories with the slug 'wine' or 'wine1'.
+@param {Object[]} categories
+@returns {Object[]} 
+*/
+const getCategoryOfWineSlug = (categories) => {
+  if (Array.isArray(categories)) {
+    return categories.filter(
+      (category) => category.slug === 'wine' || category.slug === 'wine1'
+    )
+  }
+  return []
+}
+
 export {
   transformRawDataToArticleInfo,
   transformTimeDataIntoDotFormat,
@@ -254,4 +268,5 @@ export {
   getArticleHref,
   sortArrayWithOtherArrayId,
   getMagazineHrefFromSlug,
+  getCategoryOfWineSlug,
 }

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -246,10 +246,14 @@ const getMagazineHrefFromSlug = (slug) => {
 }
 
 /**
-array of categories with the slug 'wine' or 'wine1'.
-@param {Object[]} categories
-@returns {Object[]} 
-*/
+ * @typedef {import('../apollo/fragments/category').Category} Category - category information
+ */
+
+/**
+ * array of categories with the slug 'wine' or 'wine1'.
+ * @param {Pick<Category, 'id' | 'name' | 'slug'>[]} categories - certain category information
+ * @returns {Pick<Category, 'id' | 'name' | 'slug'>[] | []}
+ */
 const getCategoryOfWineSlug = (categories) => {
   if (Array.isArray(categories)) {
     return categories.filter(


### PR DESCRIPTION
## Notable Changed
在 amp 頁面中放入 18 禁提示，和 `~/components/story/shared/adult-only-warning.js` 共用。
- amp 無法使用 onClick，也不能存 useState 的內容，因此直接使用它有提供的 action 達成相同效果。
- `adult-only-warning.hide` 會隱藏整個 modal。
- `amp-page.toggleClass(class='disable-scroll')` 拿掉 `disable-class`，讓頁面可以滾動。（與此同時如果是 `isAdult` amp body 本來有該 class 和相關 style， 可以阻止滾動）。