### PR TITLE
fix(mm-next): modify `topic`、`story` og desc/image

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/topic.js
+++ b/packages/mirror-media-next/apollo/fragments/topic.js
@@ -17,6 +17,8 @@ import { tag } from './tag'
  * @property {number} postsCount
  * @property {import('./post').Post[]} posts
  * @property {import('./tag').Tag[]} tags
+ * @property {string} og_description
+ * @property {import('./photo').Photo} og_image
  */
 
 export const simpleTopic = gql`
@@ -56,6 +58,10 @@ export const topic = gql`
     }
     tags {
       ...tag
+    }
+    og_description
+    og_image {
+      ...heroImage
     }
   }
 `

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -80,7 +80,7 @@ export default function ExternalPartner({
 }) {
   return (
     <Layout
-      head={{ title: `${partner?.name}分類報導` }}
+      head={{ title: `${partner?.name}相關報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -64,7 +64,7 @@ const WarmLifeTitle = styled.h1`
 export default function WarmLife({ warmLifeData, headerData }) {
   return (
     <Layout
-      head={{ title: `${WARM_LIFE_DEFAULT_TITLE}分類報導` }}
+      head={{ title: `${WARM_LIFE_DEFAULT_TITLE}相關報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >

--- a/packages/mirror-media-next/pages/section/topic.js
+++ b/packages/mirror-media-next/pages/section/topic.js
@@ -63,7 +63,7 @@ const RENDER_PAGE_SIZE = 12
 export default function Topics({ topics, topicsCount, headerData }) {
   return (
     <Layout
-      head={{ title: `精選專區分類報導` }}
+      head={{ title: `精選專區` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -11,6 +11,7 @@ import AdultOnlyWarning from '../../components/story/shared/adult-only-warning'
 import { fetchPostBySlug } from '../../apollo/query/posts'
 import StoryNormalStyle from '../../components/story/normal'
 import Layout from '../../components/shared/layout'
+import { convertDraftToText, getResizedUrl } from '../../utils/index'
 const StoryWideStyle = dynamic(() => import('../../components/story/wide'))
 const StoryPhotographyStyle = dynamic(() =>
   import('../../components/story/photography')
@@ -133,15 +134,12 @@ export default function Story({ postData }) {
     <Layout
       head={{
         title: `${title}`,
-        // fallback to undefined if both text is empty string or falsy value
         description:
-          postData.brief?.blocks[0]?.text ||
-          postData.content?.blocks[0]?.text ||
-          undefined,
+          convertDraftToText(postData.brief) ||
+          convertDraftToText(postData.content),
         imageUrl:
-          postData.heroImage?.resized?.original ||
-          postData.og_image?.resized?.original ||
-          undefined,
+          getResizedUrl(postData.og_image?.resized) ||
+          getResizedUrl(postData.heroImage?.resized),
       }}
       header={{ type: 'empty' }}
       footer={{ type: 'empty' }}

--- a/packages/mirror-media-next/pages/topic/[id].js
+++ b/packages/mirror-media-next/pages/topic/[id].js
@@ -10,6 +10,7 @@ import TopicGroup from '../../components/topic/group/topic-group'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
 import { parseUrl } from '../../utils/topic'
+import { convertDraftToText, getResizedUrl } from '../../utils/index'
 
 const RENDER_PAGE_SIZE = 12
 
@@ -53,8 +54,12 @@ export default function Topic({ topic, slideshowData, headerData }) {
       head={{
         title: `${topic?.name}`,
         // fallback to undefined if text is empty string or falsy value
-        description: topic?.brief?.blocks[0]?.text || undefined,
-        imageUrl: parseUrl(topic?.style),
+        description:
+          topic?.og_description ||
+          convertDraftToText(topic?.brief) ||
+          undefined,
+        imageUrl:
+          getResizedUrl(topic?.og_image?.resized) || parseUrl(topic?.style),
       }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -263,6 +263,51 @@ const getCategoryOfWineSlug = (categories) => {
   return []
 }
 
+/**
+ * Convert the `text` content in `rawContentBlock` data (h2, h3, unstyled)
+ * and combine the first 160 characters as a plain text description for `og-description`.
+ * @param {import('../type/draft-js').Draft} rawContentBlock
+ * @returns {string | undefined}
+ */
+const convertDraftToText = (rawContentBlock) => {
+  if (
+    rawContentBlock &&
+    rawContentBlock?.blocks &&
+    rawContentBlock.blocks.length > 0
+  ) {
+    const text = rawContentBlock.blocks.map((block) => block.text).join('')
+
+    const ogDescription =
+      text && text.length > 160
+        ? text.trim().slice(0, 160) + '...'
+        : text.trim()
+
+    return ogDescription
+  } else {
+    return undefined
+  }
+}
+
+/**
+ * To get the URL link for `og-image`, sorted in ascending order based on file size.
+ * @param {import('../apollo/fragments/photo').Resized | undefined | null} resized
+ * @returns {string | undefined}
+ */
+const getResizedUrl = (resized) => {
+  if (resized) {
+    return (
+      resized?.w480 ||
+      resized?.w800 ||
+      resized?.w1200 ||
+      resized?.w1600 ||
+      resized?.w2400 ||
+      resized?.original
+    )
+  } else {
+    return undefined
+  }
+}
+
 export {
   transformRawDataToArticleInfo,
   transformTimeDataIntoDotFormat,
@@ -273,4 +318,6 @@ export {
   sortArrayWithOtherArrayId,
   getMagazineHrefFromSlug,
   getCategoryOfWineSlug,
+  convertDraftToText,
+  getResizedUrl,
 }


### PR DESCRIPTION
### Notable Change 
- `Topic` type & query 新增 property `og_description`、`og_image`，以取得 topic 頁 OG 資訊。
- 新增 utils `convertDraftToText`：取得前言/內文的文字資訊，提供 og-description 使用。
- 新增 utils `getResizedUrl`：取得 og_image 和 heroImage 圖片（取用優先順序由 width 小至大），提供 og-image 使用。