### PR TITLE
fix(story): change redirect function to utils

### DIFF
--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -12,6 +12,7 @@ import { fetchPostBySlug } from '../../apollo/query/posts'
 import StoryNormalStyle from '../../components/story/normal'
 import Layout from '../../components/shared/layout'
 import { convertDraftToText, getResizedUrl } from '../../utils/index'
+import { handleStoryPageRedirect } from '../../utils/story'
 const StoryWideStyle = dynamic(() => import('../../components/story/wide'))
 const StoryPhotographyStyle = dynamic(() =>
   import('../../components/story/photography')
@@ -191,35 +192,7 @@ export async function getServerSideProps({ params, req }) {
 
     //redirect to specific slug or external url
     const redirect = postData?.redirect
-
-    if (redirect && redirect.trim()) {
-      const redirectHref = redirect.trim()
-      if (
-        redirectHref.startsWith('https://') ||
-        redirectHref.startsWith('http://')
-      ) {
-        return {
-          redirect: {
-            destination: `${redirectHref} `,
-            permanent: false,
-          },
-        }
-      } else if (redirectHref.startsWith('www.')) {
-        return {
-          redirect: {
-            destination: `https://${redirectHref}`,
-            permanent: false,
-          },
-        }
-      } else {
-        return {
-          redirect: {
-            destination: `/story/${redirectHref} `,
-            permanent: false,
-          },
-        }
-      }
-    }
+    handleStoryPageRedirect(redirect)
 
     return {
       props: {

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -9,6 +9,7 @@ import {
   sortArrayWithOtherArrayId,
   getCategoryOfWineSlug,
 } from '../../../utils'
+import { handleStoryPageRedirect } from '../../../utils/story'
 import { fetchPostBySlug } from '../../../apollo/query/posts'
 import { GCP_PROJECT_ID } from '../../../config/index.mjs'
 import styled from 'styled-components'
@@ -110,37 +111,8 @@ export async function getServerSideProps({ params, req }) {
     }
 
     //redirect to specific slug or external url
-    // TODO: 抽成一個 utils function
     const redirect = postData?.redirect
-
-    if (redirect && redirect.trim()) {
-      const redirectHref = redirect.trim()
-      if (
-        redirectHref.startsWith('https://') ||
-        redirectHref.startsWith('http://')
-      ) {
-        return {
-          redirect: {
-            destination: `${redirectHref} `,
-            permanent: false,
-          },
-        }
-      } else if (redirectHref.startsWith('www.')) {
-        return {
-          redirect: {
-            destination: `https://${redirectHref}`,
-            permanent: false,
-          },
-        }
-      } else {
-        return {
-          redirect: {
-            destination: `/story/${redirectHref} `,
-            permanent: false,
-          },
-        }
-      }
-    }
+    handleStoryPageRedirect(redirect)
 
     return {
       props: {

--- a/packages/mirror-media-next/utils/story.js
+++ b/packages/mirror-media-next/utils/story.js
@@ -4,6 +4,7 @@
  */
 /**
  *
+ * Decide whether to redirect, or should redirect to external URL, or `story/[slug]` page.
  * @param {string} redirect - post's redirect URL
  * @returns {Redirect}
  */

--- a/packages/mirror-media-next/utils/story.js
+++ b/packages/mirror-media-next/utils/story.js
@@ -1,0 +1,42 @@
+/**
+ * @typedef {Object} Redirect
+ * @property {{ destination: string,permanent: boolean }} redirect
+ */
+/**
+ *
+ * @param {string} redirect - post's redirect URL
+ * @returns {Redirect}
+ */
+
+const handleStoryPageRedirect = (redirect) => {
+  if (redirect && redirect.trim()) {
+    const redirectHref = redirect.trim()
+    if (
+      redirectHref.startsWith('https://') ||
+      redirectHref.startsWith('http://')
+    ) {
+      return {
+        redirect: {
+          destination: `${redirectHref} `,
+          permanent: false,
+        },
+      }
+    } else if (redirectHref.startsWith('www.')) {
+      return {
+        redirect: {
+          destination: `https://${redirectHref}`,
+          permanent: false,
+        },
+      }
+    } else {
+      return {
+        redirect: {
+          destination: `/story/${redirectHref} `,
+          permanent: false,
+        },
+      }
+    }
+  }
+}
+
+export { handleStoryPageRedirect }

--- a/packages/mirror-media-next/utils/story.js
+++ b/packages/mirror-media-next/utils/story.js
@@ -1,6 +1,6 @@
 /**
  * @typedef {Object} Redirect
- * @property {{ destination: string,permanent: boolean }} redirect
+ * @property {{ destination: string, permanent: boolean }} redirect
  */
 /**
  *


### PR DESCRIPTION
### Notable Change 
- 因 `story` 中的一般頁面與 `amp` 頁面會共同使用到 redirect function，因此將該函式轉為 utils 處理。且因該函式只有 `story` 頁面會使用到，因此另建一個 `story.js` 存放。
- 新增 utils `handleStoryPageRedirect` ：使用者傳入 `redirect` 網址字串資料，即可回傳相應的 redirect URL。