### PR TITLE
feat(mm-next): add proxy server for amp routes

### DIFF
--- a/packages/mirror-media-next/Dockerfile
+++ b/packages/mirror-media-next/Dockerfile
@@ -25,4 +25,8 @@ COPY --from=build /build/public ./public
 COPY --from=build /build/.next/standalone ./
 COPY --from=build /build/.next/static ./.next/static
 
-CMD ["node", "server.js"]
+## Use tini to manage zombie processes and signal forwarding
+## https://github.com/krallin/tini
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+CMD ["/app/run.sh"]

--- a/packages/mirror-media-next/README.md
+++ b/packages/mirror-media-next/README.md
@@ -34,11 +34,22 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
 
 ## Reminder
+
 ### 使用 .mjs 副檔名的時機
+
 為了要能讓 `node` 能用 ES module 的方式來處理 import/export，可以藉由選擇以下其中一個方法來達成：
+
 1. 副檔名為 `.mjs`
 2. 在 `pacakge.json` 中，設定 `type` 為 `"module"`
 
 而我們選擇方法 1，將 `node` 使用到的 ES module 檔案的副檔名設定為 `.mjs`，在有限的範圍內控制其行為
 
 Ref: [ECMAScript Modules | Node.js](https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_enabling)
+
+## Environment Variables (環境變數)
+
+| 變數名稱            | 資料型態 | 初始值 | 變數說明                        |
+| ------------------- | -------- | ------ | ------------------------------- |
+| PROXY_AMP           | 布林     | false  | 是否為 proxy AMP 模式           |
+| PROXY_SERVER_PORT   | 字串     | '3000' | proxy server port               |
+| PROXIED_SERVER_PORT | 字串     | '3001' | 被 proxy 的 next.js server port |

--- a/packages/mirror-media-next/README.md
+++ b/packages/mirror-media-next/README.md
@@ -48,8 +48,8 @@ Ref: [ECMAScript Modules | Node.js](https://nodejs.org/docs/latest-v13.x/api/esm
 
 ## Environment Variables (環境變數)
 
-| 變數名稱            | 資料型態 | 初始值 | 變數說明                        |
-| ------------------- | -------- | ------ | ------------------------------- |
-| PROXY_AMP           | 布林     | false  | 是否為 proxy AMP 模式           |
-| PROXY_SERVER_PORT   | 字串     | '3000' | proxy server port               |
-| PROXIED_SERVER_PORT | 字串     | '3001' | 被 proxy 的 next.js server port |
+| 變數名稱            | 資料型態   | 初始值  | 變數說明                        |
+| ------------------- | ---------- | ------- | ------------------------------- |
+| PROXY_AMP           | 字串(布林) | 'false' | 是否為 proxy AMP 模式           |
+| PROXY_SERVER_PORT   | 字串(整數) | '3000'  | proxy server port               |
+| PROXIED_SERVER_PORT | 字串(整數) | '3001'  | 被 proxy 的 next.js server port |

--- a/packages/mirror-media-next/amp-proxy-server.js
+++ b/packages/mirror-media-next/amp-proxy-server.js
@@ -24,9 +24,8 @@ app.use(
       const response = responseBuffer.toString('utf8') // convert buffer to string
 
       // manipulate html to remove all amp prohibit attributes
-      const ampProhibitAttributes = ['contenteditable', 'spellcheck']
       return response.replace(
-        new RegExp(ampProhibitAttributes.join('|'), 'g'),
+        /contenteditable|spellcheck/g,
         (match) => `data-${match}`
       )
     }),

--- a/packages/mirror-media-next/amp-proxy-server.js
+++ b/packages/mirror-media-next/amp-proxy-server.js
@@ -1,0 +1,45 @@
+const express = require('express')
+const {
+  createProxyMiddleware,
+  responseInterceptor,
+} = require('http-proxy-middleware')
+
+// Create Express Server
+const app = express()
+
+// Configuration
+const PORXY_SERVER_PORT = Number(process.env.PROXY_SERVER_PORT) || 3000
+const PROXIED_SERVER_PORT = Number(process.env.PROXIED_SERVER_PORT) || 3001
+const HOST = 'localhost'
+const API_SERVICE_URL = `http://localhost:${PROXIED_SERVER_PORT}`
+
+// handle amp route
+app.use(
+  '/story/amp',
+  createProxyMiddleware({
+    target: API_SERVICE_URL,
+    changeOrigin: true,
+    selfHandleResponse: true,
+    onProxyRes: responseInterceptor(async (responseBuffer) => {
+      const response = responseBuffer.toString('utf8') // convert buffer to string
+
+      // manipulate html to remove all amp prohibit attributes
+      const ampProhibitAttributes = ['contenteditable', 'spellcheck']
+      return response.replace(
+        new RegExp(ampProhibitAttributes.join('|'), 'g'),
+        (match) => `data-${match}`
+      )
+    }),
+  })
+)
+
+// proxy all other routes in case any other request misleading to this proxy
+app.use(
+  '*',
+  createProxyMiddleware({ target: API_SERVICE_URL, changeOrigin: true })
+)
+
+// Start Proxy
+app.listen(PORXY_SERVER_PORT, HOST, () => {
+  console.log(`Starting Proxy at ${HOST}:${PORXY_SERVER_PORT}`)
+})

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -6,7 +6,8 @@
     "dev": "concurrently \"node mocks/server\" \"next dev\"",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "start-amp-proxy-server": "node amp-proxy-server"
   },
   "engines": {
     "node": ">=14.0.0 <17.0.0"

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -23,8 +23,10 @@
     "body-scroll-lock": "3.1.5",
     "cors": "^2.8.5",
     "dayjs": "^1.11.7",
+    "express": "^4.18.2",
     "firebase": "^9.22.0",
     "graphql": "^16.6.0",
+    "http-proxy-middleware": "^2.0.6",
     "next": "^13.0.7",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -37,7 +39,6 @@
     "@types/facebook-js-sdk": "^3.3.6",
     "@types/google-publisher-tag": "^1.20230410.0",
     "concurrently": "^7.4.0",
-    "eslint-config-next": "12.2.5",
-    "express": "^4.18.1"
+    "eslint-config-next": "12.2.5"
   }
 }

--- a/packages/mirror-media-next/run.sh
+++ b/packages/mirror-media-next/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# set -eo pipefail
+
+if [ "$PROXY_AMP" = "true" ]
+then
+  # run next.js together with proxy server
+  PORT=$PROXIED_SERVER_PORT yarn start &
+  yarn run start-amp-proxy-server &
+else
+  yarn start &
+fi
+
+# Exit immediately when one of the background processes terminate.
+wait -n

--- a/yarn.lock
+++ b/yarn.lock
@@ -3547,7 +3547,7 @@ execa@^6.1.0:
     signal-exit "^3.0.7"
     strip-final-newline "^3.0.0"
 
-express@^4.18.1, express@^4.18.2:
+express@^4.18.2:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
   integrity sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==


### PR DESCRIPTION
# Issue
因為 AMP 頁面遇到 draft-js 產生的不合法 attribute 在回傳的 HTML 上 (問題在 PR [401](https://github.com/mirror-media/Lilith/pull/401))，會影響 google validate AMP 的機制 ，因此新增 proxy server 特別處理 AMP 相關的 routes。

# Feature
新增 proxy 模式，由環境變數 `PROXY_AMP` 控制，負責處理 /story/amp 的頁面請求 (需配套 load balance 設定)，proxy server 會將 amp 路徑回傳的 HTML 處理成 AMP valid 的版本 (改掉 AMP 禁止的 attributes)。

# Implementation detail
- 修改 Dockerfile 從原本的 `CMD ["node", "server.js"] ` 改成跑 run.sh，藉由環境變數 `PROXY_AMP`  來決定是否同時起兩個 server (proxy server 和 next.js server)。
- proxy 模式下，next.js server 將會被改成 `PROXIED_SERVER_PORT` (預設 3001)，proxy server 採用 `PROXY_SERVER_PORT` (預設 3000)，以便 load balancer 不用特別改打不同的 port 來拿頁面。
- proxy server 會處理兩種 route，一個是 `/story/amp`，為本 PR 主要處理的問題，另一個是把其他的 route 單純 proxy 到 next.js server 並回傳，主要是確保 load balancer 導流異常的狀況下頁面都可正常的被處理。

# Reference
參考 lilith-editools [dockerfile](https://github.com/mirror-media/Lilith/blob/main/packages/editools/Dockerfile#L56) 、 [run.sh](https://github.com/mirror-media/Lilith/blob/cd40ce7067c7d4b9270a2a653b94b85fd64cb0d3/packages/editools/run.sh)。