### PR TITLE
feat(mm-next/photography): move isIOS navigator.userAgent into useEffect

### DIFF
--- a/packages/mirror-media-next/components/story/photography/hero-section.js
+++ b/packages/mirror-media-next/components/story/photography/hero-section.js
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 /**
@@ -23,8 +24,15 @@ const HeroImage = styled.div`
   flex-direction: column;
   justify-content: center;
 
-  background-attachment: ${() => (!isIOS() ? 'fixed' : 'initial')};
+  background-attachment: ${({
+    // @ts-ignore
+    isIOS,
+  }) => (isIOS ? 'initial' : 'fixed')};
 `
+const isIOS = () => {
+  // @ts-ignore
+  return /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
+}
 
 const TitleBox = styled.div`
   width: 80%;
@@ -105,11 +113,6 @@ const BriefWrapper = styled.div`
   }
 `
 
-const isIOS = () => {
-  // @ts-ignore
-  return /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
-}
-
 /**
  * @typedef {import('../../../apollo/fragments/post').HeroImage } HeroImage
  */
@@ -129,6 +132,12 @@ export default function HeroSection({
   brief = [],
   heroImage = null,
 }) {
+  const [isIOSDevice, setIsIOSDevice] = useState(false)
+
+  useEffect(() => {
+    setIsIOSDevice(isIOS())
+  }, [])
+
   return (
     <HeroImage
       imageUrl={
@@ -140,6 +149,8 @@ export default function HeroSection({
         heroImage?.resized?.w480 ||
         '/images/default-og-img.png'
       }
+      // @ts-ignore
+      isIOS={isIOSDevice}
     >
       <TitleBox>
         <div className="title-wrapper">

--- a/packages/mirror-media-next/components/story/photography/related-posts.js
+++ b/packages/mirror-media-next/components/story/photography/related-posts.js
@@ -54,7 +54,7 @@ const PostsList = styled.ul`
     justify-content: space-between;
   }
 `
-const PostCard = styled.li`
+const PostCard = styled.div`
   color: white;
   width: 280px;
   margin-bottom: 24px;


### PR DESCRIPTION
求助：我把判斷是否 isIOS 的 function 移到 useEffect 裡面執行，解決了找不到 navigator.userAgent 的錯誤，但出現了 `Hydration Error`，把整個 isIOS 整個移除， Hydration Error 還是存在，似乎是改從 sever side render 圖輯造成的問題？

更新：我處理了 li 包 li 的問題之後，`Hydration Error`就消失了，神秘，就不打擾大家了～～