### PR TITLE
feat(mm-next): get trimmed and full content of story page, use `draft-renderer` at client-side

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -135,6 +135,7 @@ export const asideListingPost = gql`
  * @property {string} heroCaption - caption to explain hero video or image
  * @property {Draft} brief - post brief
  * @property {Draft} content - post content
+ * @property {Draft} trimmedContent - post trimmed content
  * @property {Related[] } relateds related articles selected by cms users
  * @property {Related[] | null} manualOrderOfRelateds related articles with adjusted order
  * @property {boolean} isFeatured
@@ -198,7 +199,7 @@ export const post = gql`
     }
     heroCaption
     brief
-    content
+
     relateds {
       id
       slug
@@ -214,5 +215,16 @@ export const post = gql`
         w1200
       }
     }
+  }
+`
+
+export const postTrimmedContent = gql`
+  fragment postTrimmedContent on Post {
+    trimmedContent
+  }
+`
+export const postFullContent = gql`
+  fragment postFullContent on Post {
+    content
   }
 `

--- a/packages/mirror-media-next/apollo/query/posts.js
+++ b/packages/mirror-media-next/apollo/query/posts.js
@@ -1,5 +1,11 @@
 import { gql } from '@apollo/client'
-import { listingPost, asideListingPost, post } from '../fragments/post'
+import {
+  listingPost,
+  asideListingPost,
+  post,
+  postTrimmedContent,
+  postFullContent,
+} from '../fragments/post'
 
 const fetchAsidePosts = gql`
   ${asideListingPost}
@@ -38,11 +44,29 @@ const fetchPosts = gql`
 
 const fetchPostBySlug = gql`
   ${post}
+  ${postTrimmedContent}
+  ${postFullContent}
   query fetchPostBySlug($slug: String) {
     post(where: { slug: $slug }) {
       ...post
+      ...postTrimmedContent
+      ...postFullContent
     }
   }
 `
 
-export { fetchPosts, fetchAsidePosts, fetchPostBySlug }
+const fetchPostFullContentBySlug = gql`
+  ${postFullContent}
+  query fetchPostFullContentBySlug($slug: String) {
+    post(where: { slug: $slug }) {
+      ...postFullContent
+    }
+  }
+`
+
+export {
+  fetchPosts,
+  fetchAsidePosts,
+  fetchPostBySlug,
+  fetchPostFullContentBySlug,
+}

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -67,6 +67,9 @@ import DableAd from '../../ads/dable/dable-ad'
 /**
  * @typedef {import('../../../apollo/fragments/post').Post } PostData
  */
+/**
+ * @typedef {import('../../../type/draft-js').Draft} PostContent
+ */
 
 const sectionColor = css`
   ${
@@ -344,10 +347,10 @@ const HeaderPlaceHolder = styled.header`
 
 /**
  *
- * @param {{postData: PostData}} param
+ * @param {{postData: PostData,postContent: PostContent}} param
  * @returns {JSX.Element}
  */
-export default function StoryNormalStyle({ postData }) {
+export default function StoryNormalStyle({ postData, postContent }) {
   const {
     title = '',
     slug = '',
@@ -370,7 +373,6 @@ export default function StoryNormalStyle({ postData }) {
     brief = { blocks: [], entityMap: {} },
     relateds = [],
     manualOrderOfRelateds = [],
-    content = { blocks: [], entityMap: {} },
   } = postData
 
   const [headerData, setHeaderData] = useState({
@@ -523,7 +525,7 @@ export default function StoryNormalStyle({ postData }) {
             sectionSlug={section?.slug}
             brief={brief}
           ></ArticleBrief>
-          <ArticleContent content={content} />
+          <ArticleContent content={postContent} />
           <DateUnderContent>
             <span>更新時間｜</span>
             <span className="time">{updatedTaipeiTime} 臺北時間</span>

--- a/packages/mirror-media-next/components/story/photography/index.js
+++ b/packages/mirror-media-next/components/story/photography/index.js
@@ -110,13 +110,18 @@ const ArrowButton = styled.button`
  */
 
 /**
+ * @typedef {Pick<PostData,'content'>['content']} PostContent
+ */
+
+/**
  *
  * @param {Object} param
  * @param {PostData} param.postData
+ * @param {PostContent} param.postContent
  * @returns
  */
 
-export default function StoryPhotographyStyle({ postData }) {
+export default function StoryPhotographyStyle({ postData, postContent }) {
   const {
     title = '',
     heroImage = null,
@@ -131,7 +136,7 @@ export default function StoryPhotographyStyle({ postData }) {
     extend_byline = '',
     relateds = [],
     manualOrderOfRelateds = [],
-    content = null,
+
     brief = null,
   } = postData
 
@@ -153,7 +158,7 @@ export default function StoryPhotographyStyle({ postData }) {
       : relateds
 
   // Get images array from content.entityMap
-  const photosArray = Object.values(content.entityMap).filter(
+  const photosArray = Object.values(postContent.entityMap).filter(
     (item) => item.type === 'image'
   )
 
@@ -244,7 +249,7 @@ export default function StoryPhotographyStyle({ postData }) {
         <ContentContainer>
           <section className="content">
             <DraftRenderBlock
-              rawContentBlock={content}
+              rawContentBlock={postContent}
               contentLayout="photography"
             />
           </section>

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -19,6 +19,11 @@ const { getContentBlocksH2H3 } = MirrorMedia
 /**
  * @typedef {import('../../../apollo/fragments/post').Post} PostData
  */
+
+/**
+ * @typedef {Pick<PostData,'content'>['content']} PostContent
+ */
+
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
  */
@@ -95,9 +100,10 @@ function getSectionLabelFirst(sections) {
  *
  * @param {Object} props
  * @param {PostData} props.postData
+ * @param {PostContent} props.postContent
  * @returns {JSX.Element}
  */
-export default function StoryPremiumStyle({ postData }) {
+export default function StoryPremiumStyle({ postData, postContent }) {
   const [headerData, setHeaderData] = useState({
     sectionsData: [],
   })
@@ -105,7 +111,6 @@ export default function StoryPremiumStyle({ postData }) {
   const {
     title,
     brief = { blocks: [], entityMap: {} },
-    content = { blocks: [], entityMap: {} },
     sections = [],
     manualOrderOfSections = [],
     writers = [],
@@ -126,7 +131,7 @@ export default function StoryPremiumStyle({ postData }) {
     slug = '',
     manualOrderOfRelateds = [],
   } = postData
-  const h2AndH3Block = getContentBlocksH2H3(content)
+  const h2AndH3Block = getContentBlocksH2H3(postContent)
   const sectionsWithOrdered =
     manualOrderOfSections && manualOrderOfSections.length
       ? sortArrayWithOtherArrayId(sections, manualOrderOfSections)
@@ -242,7 +247,7 @@ export default function StoryPremiumStyle({ postData }) {
             <section className="content">
               <DraftRenderBlock
                 contentLayout="premium"
-                rawContentBlock={content}
+                rawContentBlock={postContent}
               ></DraftRenderBlock>
             </section>
             <CopyrightWarning />

--- a/packages/mirror-media-next/components/story/shared/nav-subtitle-navigator.js
+++ b/packages/mirror-media-next/components/story/shared/nav-subtitle-navigator.js
@@ -238,6 +238,13 @@ export default function NavSubtitleNavigator({
       )
 
       /**
+       * Because content is currently render at client side, so we need to check element targets is existed.
+       * If not, then should not add intersection observer.
+       */
+      if (targets.some((element) => element === null)) {
+        return
+      }
+      /**
        * An Array to keep track of which subtitle is currently visible on the viewport.
        * Each object in the array has the following properties:
        *   - key: the key of the subtitle
@@ -287,6 +294,7 @@ export default function NavSubtitleNavigator({
         threshold: 0,
         rootMargin: '50% 0px -50% 0px',
       })
+
       targets.forEach((item) => observer.observe(item))
     }
     return () => {

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -22,6 +22,10 @@ import Aside from '../shared/aside'
  */
 
 /**
+ * @typedef {Pick<PostData,'content'>['content']} PostContent
+ */
+
+/**
  * @typedef {import('../../../type/theme').Theme} Theme
  */
 const Main = styled.main`
@@ -96,9 +100,10 @@ const StyledCredits = styled(Credits)`
  *
  * @param {Object} param
  * @param {PostData} param.postData
- * @returns
+ * @param {PostContent} param.postContent
+ * @returns {JSX.Element}
  */
-export default function StoryWideStyle({ postData }) {
+export default function StoryWideStyle({ postData, postContent }) {
   const {
     title = '',
     heroImage = null,
@@ -120,7 +125,6 @@ export default function StoryWideStyle({ postData }) {
     relateds = [],
     manualOrderOfRelateds = [],
     slug = '',
-    content = null,
     brief = null,
     tags = [],
   } = postData
@@ -150,7 +154,7 @@ export default function StoryWideStyle({ postData }) {
     { extend_byline: extend_byline },
   ]
 
-  const h2AndH3Block = getContentBlocksH2H3(content)
+  const h2AndH3Block = getContentBlocksH2H3(postContent)
 
   return (
     <>
@@ -193,7 +197,7 @@ export default function StoryWideStyle({ postData }) {
             <section className="content">
               <DraftRenderBlock rawContentBlock={brief} contentLayout="wide" />
               <DraftRenderBlock
-                rawContentBlock={content}
+                rawContentBlock={postContent}
                 contentLayout="wide"
               />
             </section>


### PR DESCRIPTION
## Notable Change
1. `Post` 相關的apollo fragment/query，新增field `trimmedContent`。
2. 於文章頁新增一state `postContent`，用於控管內文所顯示的內容。
3. 於client-side使用draft-renderer，避免於server-side使用將造成memory-leak的問題。
4. 由於內文將於client side才會顯示，新增一判斷邏輯於元件`subtitle-navigator`，避免錯誤。