### PR TITLE
feat(was): provide roles claim in JWT

### DIFF
--- a/packages/weekly-api-server/src/middlewares/auth.js
+++ b/packages/weekly-api-server/src/middlewares/auth.js
@@ -220,8 +220,11 @@ export function signAccessTokenForInternalColleague({ jwtSecret }) {
       res.locals.auth?.decodedIdToken?.uid
     const email = res.locals.auth?.decodedIdToken?.email
 
-    // skip this middleware if email does not ends with '@mirrormedia.mg'
-    if (typeof email === 'string' && !email.endsWith('@mirrormedia.mg')) {
+    // skip this middleware if email does not ends with certain email domains
+    if (typeof email === 'string' &&
+      !email.endsWith('@mirrormedia.mg') &&
+      !email.endsWith('@mnews.tw') &&
+      !email.endsWith('@mirrorfiction.com')) {
       return next()
     }
 

--- a/packages/weekly-api-server/src/middlewares/auth.js
+++ b/packages/weekly-api-server/src/middlewares/auth.js
@@ -130,8 +130,7 @@ export function signAccessToken({ jwtSecret }) {
     } = res.locals.memberInfo || {}
     const firebaseId =
       res.locals.memberInfo?.firebaseId || res.locals.auth?.decodedIdToken?.uid
-    // @TODO: add roles claim in JWT if needed
-    // let roles = ['']
+    let roles = ['']
     let scope = ''
 
     switch (memberType) {
@@ -139,12 +138,12 @@ export function signAccessToken({ jwtSecret }) {
       case 'subscribe_group':
       case 'subscribe_yearly':
       case 'subscribe_monthly': {
-        // roles = ['premium-member']
+        roles = ['premium-member']
         scope = `read:posts read:member-posts:all read:member-info:${firebaseId} write:member-info:${firebaseId}`
         break
       }
       case 'subscribe_one_time': {
-        // roles = ['one-time-member']
+        roles = ['one-time-member']
         scope = `read:posts read:member-info:${firebaseId} write:member-info:${firebaseId}`
         if (Array.isArray(subscriptions)) {
           const postIdArr = subscriptions
@@ -156,7 +155,7 @@ export function signAccessToken({ jwtSecret }) {
       }
       case 'none':
       default: {
-        // roles = ['member']
+        roles = ['member']
         scope =
           `read:posts read:member-info:${firebaseId} write:member-info:${firebaseId}`
         break
@@ -177,7 +176,7 @@ export function signAccessToken({ jwtSecret }) {
       ],
       exp: expiresIn, // one hour later
       iat: nowTs,
-      // roles,
+      roles,
       scope,
     }
 
@@ -243,7 +242,7 @@ export function signAccessTokenForInternalColleague({ jwtSecret }) {
       ],
       exp: expiresIn, // one hour later
       iat: nowTs,
-      // roles,
+      roles: ['staff'],
       scope,
     }
 


### PR DESCRIPTION
### Notable Changes
- add `roles` claim in JWT
- member type `marketing`, `subscribe_monthly`, `subscribe_yearly` and `subscribe_group` will be `premium-member`
- member type `subscribe_one_time` will be `one-time-member`
- member type `none` will be `member`
- email ends with `@mirrormedia.mg`, `@mirrorfiction.com` and `@mnews.tw` will be `staff`