### PR TITLE
feat(ad): add `GPT` ad in listing page

### DIFF
--- a/packages/mirror-media-next/components/ads/gpt/gpt-ad.js
+++ b/packages/mirror-media-next/components/ads/gpt/gpt-ad.js
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { getAdSlotParam, getAdWidth } from '../../../utils/gpt-ad.js'
 import styled from 'styled-components'
+import { useMembership } from '../../../context/membership'
 
 const Wrapper = styled.div`
   /**
@@ -57,6 +58,8 @@ export default function GPTAd({
   onSlotRenderEnded,
   className,
 }) {
+  const { isLoggedIn } = useMembership()
+
   const [adWidth, setAdWidth] = useState('')
   const [adDivId, setAdDivId] = useState('')
 
@@ -110,9 +113,12 @@ export default function GPTAd({
     }
   }, [adKey, pageKey, onSlotRequested, onSlotRenderEnded])
 
-  return (
+  //The login member type has not been implemented yet. For now, we will temporarily use `isLoggedIn` as the basis for deciding whether to display GPT advertisements.
+  const gptAdJsx = !isLoggedIn ? (
     <Wrapper className={`${className} gpt-ad`}>
       <Ad width={adWidth} id={adDivId} />
     </Wrapper>
-  )
+  ) : null
+
+  return <>{gptAdJsx}</>
 }

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -8,6 +8,9 @@ import AuthorArticles from '../../components/author/author-articles'
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
+import GPTAd from '../../components/ads/gpt/gpt-ad'
+import { useMembership } from '../../context/membership'
+import { Z_INDEX } from '../../constants/index'
 
 const AuthorContainer = styled.main`
   width: 320px;
@@ -40,6 +43,35 @@ const AuthorTitle = styled.h1`
   }
 `
 
+const StyledGPTAd = styled(GPTAd)`
+  width: 100%;
+  max-width: 336px;
+  margin: auto;
+  height: 280px;
+  margin-top: 20px;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 970px;
+    height: 250px;
+  }
+`
+
+const StickyGPTAd = styled(GPTAd)`
+  position: fixed;
+  width: 100%;
+  max-width: 320px;
+  margin: 60px auto 0px;
+  height: 50px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: ${Z_INDEX.top};
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
+  }
+`
+
 const RENDER_PAGE_SIZE = 12
 
 /**
@@ -56,6 +88,8 @@ const RENDER_PAGE_SIZE = 12
  * @returns {React.ReactElement}
  */
 export default function Author({ postsCount, posts, author, headerData }) {
+  const { isLoggedIn } = useMembership()
+
   return (
     <Layout
       head={{ title: `${author?.name}相關報導` }}
@@ -63,6 +97,7 @@ export default function Author({ postsCount, posts, author, headerData }) {
       footer={{ type: 'default' }}
     >
       <AuthorContainer>
+        {!isLoggedIn && <StyledGPTAd pageKey="other" adKey="HD" />}
         <AuthorTitle>{author?.name}</AuthorTitle>
         <AuthorArticles
           postsCount={postsCount}
@@ -70,6 +105,8 @@ export default function Author({ postsCount, posts, author, headerData }) {
           author={author}
           renderPageSize={RENDER_PAGE_SIZE}
         />
+        {!isLoggedIn && <StyledGPTAd pageKey="other" adKey="FT" />}
+        {!isLoggedIn && <StickyGPTAd pageKey="other" adKey="ST" />}
       </AuthorContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -9,7 +9,6 @@ import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
 import GPTAd from '../../components/ads/gpt/gpt-ad'
-import { useMembership } from '../../context/membership'
 import { Z_INDEX } from '../../constants/index'
 
 const AuthorContainer = styled.main`
@@ -88,8 +87,6 @@ const RENDER_PAGE_SIZE = 12
  * @returns {React.ReactElement}
  */
 export default function Author({ postsCount, posts, author, headerData }) {
-  const { isLoggedIn } = useMembership()
-
   return (
     <Layout
       head={{ title: `${author?.name}相關報導` }}
@@ -97,7 +94,7 @@ export default function Author({ postsCount, posts, author, headerData }) {
       footer={{ type: 'default' }}
     >
       <AuthorContainer>
-        {!isLoggedIn && <StyledGPTAd pageKey="other" adKey="HD" />}
+        <StyledGPTAd pageKey="other" adKey="HD" />
         <AuthorTitle>{author?.name}</AuthorTitle>
         <AuthorArticles
           postsCount={postsCount}
@@ -105,8 +102,8 @@ export default function Author({ postsCount, posts, author, headerData }) {
           author={author}
           renderPageSize={RENDER_PAGE_SIZE}
         />
-        {!isLoggedIn && <StyledGPTAd pageKey="other" adKey="FT" />}
-        {!isLoggedIn && <StickyGPTAd pageKey="other" adKey="ST" />}
+        <StyledGPTAd pageKey="other" adKey="FT" />
+        <StickyGPTAd pageKey="other" adKey="ST" />
       </AuthorContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -12,6 +12,8 @@ import {
   fetchHeaderDataInPremiumPageLayout,
 } from '../../utils/api'
 import Layout from '../../components/shared/layout'
+import GPTAd from '../../components/ads/gpt/gpt-ad'
+import { Z_INDEX } from '../../constants/index'
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -132,6 +134,35 @@ const PremiumCategoryTitle = styled.h1`
   }
 `
 
+const StyledGPTAd = styled(GPTAd)`
+  width: 100%;
+  max-width: 336px;
+  margin: auto;
+  height: 280px;
+  margin-top: 20px;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 970px;
+    height: 250px;
+  }
+`
+
+const StickyGPTAd = styled(GPTAd)`
+  position: fixed;
+  width: 100%;
+  max-width: 320px;
+  margin: 60px auto 0px;
+  height: 50px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: ${Z_INDEX.top};
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
+  }
+`
+
 const RENDER_PAGE_SIZE = 12
 
 /**
@@ -162,6 +193,7 @@ export default function Category({
       footer={{ type: 'default' }}
     >
       <CategoryContainer isPremium={isPremium}>
+        <StyledGPTAd pageKey="other" adKey="HD" />
         {isPremium ? (
           <PremiumCategoryTitle sectionName={category?.sections?.[0].slug}>
             {category?.name}
@@ -178,6 +210,8 @@ export default function Category({
           renderPageSize={RENDER_PAGE_SIZE}
           isPremium={isPremium}
         />
+        <StyledGPTAd pageKey="other" adKey="FT" />
+        <StickyGPTAd pageKey="other" adKey="ST" />
       </CategoryContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -13,6 +13,9 @@ import {
 } from '../../apollo/query/externals'
 import { fetchPartnerBySlug } from '../../apollo/query/partner'
 import { getExternalPartnerColor } from '../../utils/external'
+import GPTAd from '../../components/ads/gpt/gpt-ad'
+import { useMembership } from '../../context/membership'
+import { Z_INDEX, SECTION_IDS } from '../../constants/index'
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -56,7 +59,37 @@ const PartnerTitle = styled.h1`
   }
 `
 
+const StyledGPTAd = styled(GPTAd)`
+  width: 100%;
+  max-width: 336px;
+  margin: auto;
+  height: 280px;
+  margin-top: 20px;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 970px;
+    height: 250px;
+  }
+`
+
+const StickyGPTAd = styled(GPTAd)`
+  position: fixed;
+  width: 100%;
+  max-width: 320px;
+  margin: 60px auto 0px;
+  height: 50px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: ${Z_INDEX.top};
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
+  }
+`
+
 const RENDER_PAGE_SIZE = 12
+const EXTERNALS_GPT_SECTION_IDS = SECTION_IDS.news // The default section of the `[partnerSlug]` page is `時事`
 
 /**
  * @typedef {import('../../apollo/fragments/external').ListingExternal} ListingExternal
@@ -78,6 +111,8 @@ export default function ExternalPartner({
   partner,
   headerData,
 }) {
+  const { isLoggedIn } = useMembership()
+
   return (
     <Layout
       head={{ title: `${partner?.name}相關報導` }}
@@ -85,6 +120,9 @@ export default function ExternalPartner({
       footer={{ type: 'default' }}
     >
       <PartnerContainer>
+        {!isLoggedIn && (
+          <StyledGPTAd pageKey={EXTERNALS_GPT_SECTION_IDS} adKey="HD" />
+        )}
         <PartnerTitle partnerColor={getExternalPartnerColor(partner)}>
           {partner?.name}
         </PartnerTitle>
@@ -94,6 +132,12 @@ export default function ExternalPartner({
           partner={partner}
           renderPageSize={RENDER_PAGE_SIZE}
         />
+        {!isLoggedIn && (
+          <StyledGPTAd pageKey={EXTERNALS_GPT_SECTION_IDS} adKey="FT" />
+        )}
+        {!isLoggedIn && (
+          <StickyGPTAd pageKey={EXTERNALS_GPT_SECTION_IDS} adKey="ST" />
+        )}
       </PartnerContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -12,10 +12,12 @@ import {
   fetchExternalCounts,
 } from '../../apollo/query/externals'
 import { fetchPartnerBySlug } from '../../apollo/query/partner'
-import { getExternalPartnerColor } from '../../utils/external'
+import {
+  getExternalPartnerColor,
+  getPageKeyByPartnerSlug,
+} from '../../utils/external'
 import GPTAd from '../../components/ads/gpt/gpt-ad'
-import { useMembership } from '../../context/membership'
-import { Z_INDEX, SECTION_IDS } from '../../constants/index'
+import { Z_INDEX } from '../../constants/index'
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -89,7 +91,6 @@ const StickyGPTAd = styled(GPTAd)`
 `
 
 const RENDER_PAGE_SIZE = 12
-const EXTERNALS_GPT_SECTION_IDS = SECTION_IDS.news // The default section of the `[partnerSlug]` page is `時事`
 
 /**
  * @typedef {import('../../apollo/fragments/external').ListingExternal} ListingExternal
@@ -111,8 +112,6 @@ export default function ExternalPartner({
   partner,
   headerData,
 }) {
-  const { isLoggedIn } = useMembership()
-
   return (
     <Layout
       head={{ title: `${partner?.name}相關報導` }}
@@ -120,9 +119,10 @@ export default function ExternalPartner({
       footer={{ type: 'default' }}
     >
       <PartnerContainer>
-        {!isLoggedIn && (
-          <StyledGPTAd pageKey={EXTERNALS_GPT_SECTION_IDS} adKey="HD" />
-        )}
+        <StyledGPTAd
+          pageKey={getPageKeyByPartnerSlug(partner.slug)}
+          adKey="HD"
+        />
         <PartnerTitle partnerColor={getExternalPartnerColor(partner)}>
           {partner?.name}
         </PartnerTitle>
@@ -132,12 +132,14 @@ export default function ExternalPartner({
           partner={partner}
           renderPageSize={RENDER_PAGE_SIZE}
         />
-        {!isLoggedIn && (
-          <StyledGPTAd pageKey={EXTERNALS_GPT_SECTION_IDS} adKey="FT" />
-        )}
-        {!isLoggedIn && (
-          <StickyGPTAd pageKey={EXTERNALS_GPT_SECTION_IDS} adKey="ST" />
-        )}
+        <StyledGPTAd
+          pageKey={getPageKeyByPartnerSlug(partner.slug)}
+          adKey="FT"
+        />
+        <StickyGPTAd
+          pageKey={getPageKeyByPartnerSlug(partner.slug)}
+          adKey="ST"
+        />
       </PartnerContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -11,13 +11,12 @@ import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
 import axios from 'axios'
 import GPTAd from '../../components/ads/gpt/gpt-ad'
-import { useMembership } from '../../context/membership'
 import { Z_INDEX, SECTION_IDS } from '../../constants/index'
 
 const RENDER_PAGE_SIZE = 12
-const WARM_LIFE_DEFAULT_TITLE = `生活暖流`
-const WARM_LIFE_DEFAULT_COLOR = 'lightBlue'
-const EXTERNALS_GPT_SECTION_IDS = SECTION_IDS.news // The default section of the `warmlife` page is `時事`
+const WARMLIFE_DEFAULT_TITLE = `生活暖流`
+const WARMLIFE_DEFAULT_COLOR = 'lightBlue'
+const WARMLIFE_GPT_SECTION_IDS = SECTION_IDS.news // The default section of `warmlife` page is `時事`
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -41,7 +40,7 @@ const WarmLifeTitle = styled.h1`
   line-height: 1.15;
   font-weight: 500;
 
-  color: ${({ theme }) => theme.color.brandColor[WARM_LIFE_DEFAULT_COLOR]};
+  color: ${({ theme }) => theme.color.brandColor[WARMLIFE_DEFAULT_COLOR]};
 
   ${({ theme }) => theme.breakpoint.md} {
     margin: 20px 0 24px;
@@ -95,29 +94,21 @@ const StickyGPTAd = styled(GPTAd)`
  * @returns {React.ReactElement}
  */
 export default function WarmLife({ warmLifeData, headerData }) {
-  const { isLoggedIn } = useMembership()
-
   return (
     <Layout
-      head={{ title: `${WARM_LIFE_DEFAULT_TITLE}相關報導` }}
+      head={{ title: `${WARMLIFE_DEFAULT_TITLE}相關報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
       <WarmLifeContainer>
-        {!isLoggedIn && (
-          <StyledGPTAd pageKey={EXTERNALS_GPT_SECTION_IDS} adKey="HD" />
-        )}
-        <WarmLifeTitle>{WARM_LIFE_DEFAULT_TITLE}</WarmLifeTitle>
+        <StyledGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} adKey="HD" />
+        <WarmLifeTitle>{WARMLIFE_DEFAULT_TITLE}</WarmLifeTitle>
         <WarmLifeArticles
           warmLifeExternals={warmLifeData}
           renderPageSize={RENDER_PAGE_SIZE}
         />
-        {!isLoggedIn && (
-          <StyledGPTAd pageKey={EXTERNALS_GPT_SECTION_IDS} adKey="FT" />
-        )}
-        {!isLoggedIn && (
-          <StickyGPTAd pageKey={EXTERNALS_GPT_SECTION_IDS} adKey="ST" />
-        )}
+        <StyledGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} adKey="FT" />
+        <StickyGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} adKey="ST" />
       </WarmLifeContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -17,7 +17,7 @@ import { Z_INDEX, SECTION_IDS } from '../../constants/index'
 const RENDER_PAGE_SIZE = 12
 const WARM_LIFE_DEFAULT_TITLE = `生活暖流`
 const WARM_LIFE_DEFAULT_COLOR = 'lightBlue'
-const DEFAULT_GPT_SECTION_IDS = SECTION_IDS.news
+const EXTERNALS_GPT_SECTION_IDS = SECTION_IDS.news // The default section of the `warmlife` page is `時事`
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -105,7 +105,7 @@ export default function WarmLife({ warmLifeData, headerData }) {
     >
       <WarmLifeContainer>
         {!isLoggedIn && (
-          <StyledGPTAd pageKey={DEFAULT_GPT_SECTION_IDS} adKey="HD" />
+          <StyledGPTAd pageKey={EXTERNALS_GPT_SECTION_IDS} adKey="HD" />
         )}
         <WarmLifeTitle>{WARM_LIFE_DEFAULT_TITLE}</WarmLifeTitle>
         <WarmLifeArticles
@@ -113,10 +113,10 @@ export default function WarmLife({ warmLifeData, headerData }) {
           renderPageSize={RENDER_PAGE_SIZE}
         />
         {!isLoggedIn && (
-          <StyledGPTAd pageKey={DEFAULT_GPT_SECTION_IDS} adKey="FT" />
+          <StyledGPTAd pageKey={EXTERNALS_GPT_SECTION_IDS} adKey="FT" />
         )}
         {!isLoggedIn && (
-          <StickyGPTAd pageKey={DEFAULT_GPT_SECTION_IDS} adKey="ST" />
+          <StickyGPTAd pageKey={EXTERNALS_GPT_SECTION_IDS} adKey="ST" />
         )}
       </WarmLifeContainer>
     </Layout>

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -10,10 +10,14 @@ import {
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
 import axios from 'axios'
+import GPTAd from '../../components/ads/gpt/gpt-ad'
+import { useMembership } from '../../context/membership'
+import { Z_INDEX, SECTION_IDS } from '../../constants/index'
 
 const RENDER_PAGE_SIZE = 12
 const WARM_LIFE_DEFAULT_TITLE = `生活暖流`
 const WARM_LIFE_DEFAULT_COLOR = 'lightBlue'
+const DEFAULT_GPT_SECTION_IDS = SECTION_IDS.news
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -51,6 +55,35 @@ const WarmLifeTitle = styled.h1`
   }
 `
 
+const StyledGPTAd = styled(GPTAd)`
+  width: 100%;
+  max-width: 336px;
+  margin: auto;
+  height: 280px;
+  margin-top: 20px;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 970px;
+    height: 250px;
+  }
+`
+
+const StickyGPTAd = styled(GPTAd)`
+  position: fixed;
+  width: 100%;
+  max-width: 320px;
+  margin: 60px auto 0px;
+  height: 50px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: ${Z_INDEX.top};
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
+  }
+`
+
 /**
  * @typedef {import('../../apollo/fragments/external').ListingExternal} ListingExternal
  */
@@ -62,6 +95,8 @@ const WarmLifeTitle = styled.h1`
  * @returns {React.ReactElement}
  */
 export default function WarmLife({ warmLifeData, headerData }) {
+  const { isLoggedIn } = useMembership()
+
   return (
     <Layout
       head={{ title: `${WARM_LIFE_DEFAULT_TITLE}相關報導` }}
@@ -69,11 +104,20 @@ export default function WarmLife({ warmLifeData, headerData }) {
       footer={{ type: 'default' }}
     >
       <WarmLifeContainer>
+        {!isLoggedIn && (
+          <StyledGPTAd pageKey={DEFAULT_GPT_SECTION_IDS} adKey="HD" />
+        )}
         <WarmLifeTitle>{WARM_LIFE_DEFAULT_TITLE}</WarmLifeTitle>
         <WarmLifeArticles
           warmLifeExternals={warmLifeData}
           renderPageSize={RENDER_PAGE_SIZE}
         />
+        {!isLoggedIn && (
+          <StyledGPTAd pageKey={DEFAULT_GPT_SECTION_IDS} adKey="FT" />
+        )}
+        {!isLoggedIn && (
+          <StickyGPTAd pageKey={DEFAULT_GPT_SECTION_IDS} adKey="ST" />
+        )}
       </WarmLifeContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -9,6 +9,8 @@ import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
 import GPTAd from '../../components/ads/gpt/gpt-ad'
+import { Z_INDEX } from '../../constants/index'
+import { SECTION_IDS } from '../../constants/index'
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -54,10 +56,31 @@ const SectionTitle = styled.h1`
 `
 
 const StyledGPTAd = styled(GPTAd)`
+  width: 100%;
+  max-width: 336px;
+  margin: auto;
   height: 280px;
   margin-top: 20px;
+
   ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 970px;
     height: 250px;
+  }
+`
+
+const StickyGPTAd = styled(GPTAd)`
+  position: fixed;
+  width: 100%;
+  max-width: 320px;
+  margin: 60px auto 0px;
+  height: 50px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: ${Z_INDEX.top};
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
   }
 `
 
@@ -77,6 +100,12 @@ const RENDER_PAGE_SIZE = 12
  * @returns {React.ReactElement}
  */
 export default function Section({ postsCount, posts, section, headerData }) {
+  //When the section is `論壇`, use the `culture` AD unit.
+  const GPT_PAGE_KEY =
+    section?.slug === 'mirrorcolumn'
+      ? SECTION_IDS['culture']
+      : SECTION_IDS[section.slug]
+
   return (
     <Layout
       head={{ title: `${section?.name}分類報導` }}
@@ -84,7 +113,7 @@ export default function Section({ postsCount, posts, section, headerData }) {
       footer={{ type: 'default' }}
     >
       <SectionContainer>
-        <StyledGPTAd pageKey="57e1e0e5ee85930e00cad4e9" adKey="HD" />
+        <StyledGPTAd pageKey={GPT_PAGE_KEY} adKey="HD" />
         <SectionTitle sectionName={section?.slug}>{section?.name}</SectionTitle>
         <SectionArticles
           postsCount={postsCount}
@@ -92,6 +121,8 @@ export default function Section({ postsCount, posts, section, headerData }) {
           section={section}
           renderPageSize={RENDER_PAGE_SIZE}
         />
+        <StyledGPTAd pageKey={GPT_PAGE_KEY} adKey="FT" />
+        <StickyGPTAd pageKey={GPT_PAGE_KEY} adKey="ST" />
       </SectionContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -10,6 +10,7 @@ import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
 import GPTAd from '../../components/ads/gpt/gpt-ad'
 import { useMembership } from '../../context/membership'
+import { Z_INDEX } from '../../constants/index'
 
 const TagContainer = styled.main`
   width: 320px;
@@ -84,7 +85,7 @@ const StickyGPTAd = styled(GPTAd)`
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 419;
+  z-index: ${Z_INDEX.top};
 
   ${({ theme }) => theme.breakpoint.xl} {
     display: none;

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -9,7 +9,6 @@ import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
 import GPTAd from '../../components/ads/gpt/gpt-ad'
-import { useMembership } from '../../context/membership'
 import { Z_INDEX } from '../../constants/index'
 
 const TagContainer = styled.main`
@@ -108,8 +107,6 @@ const RENDER_PAGE_SIZE = 12
  * @returns {React.ReactElement}
  */
 export default function Tag({ postsCount, posts, tag, headerData }) {
-  const { isLoggedIn } = useMembership()
-
   return (
     <Layout
       head={{ title: `${tag?.name}相關報導` }}
@@ -117,7 +114,7 @@ export default function Tag({ postsCount, posts, tag, headerData }) {
       footer={{ type: 'default' }}
     >
       <TagContainer>
-        {!isLoggedIn && <StyledGPTAd pageKey="other" adKey="HD" />}
+        <StyledGPTAd pageKey="other" adKey="HD" />
         <TagTitleWrapper>
           <TagTitle>{tag?.name}</TagTitle>
         </TagTitleWrapper>
@@ -127,8 +124,8 @@ export default function Tag({ postsCount, posts, tag, headerData }) {
           tag={tag}
           renderPageSize={RENDER_PAGE_SIZE}
         />
-        {!isLoggedIn && <StyledGPTAd pageKey="other" adKey="FT" />}
-        {!isLoggedIn && <StickyGPTAd pageKey="other" adKey="ST" />}
+        <StyledGPTAd pageKey="other" adKey="FT" />
+        <StickyGPTAd pageKey="other" adKey="ST" />
       </TagContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/utils/external.js
+++ b/packages/mirror-media-next/utils/external.js
@@ -1,3 +1,5 @@
+import { SECTION_IDS } from '../constants/index'
+
 /**
  * The `brief` of the externals is string and not in the format of a draft.
  * Here convert the string into a data format with `blocks` and `entityMap`.
@@ -105,9 +107,22 @@ function getCreditsHtml(credits = '') {
   }
 }
 
+/**
+ * Returns the GPT pageKey associated with partner's slug.
+ *
+ * @param {string} partnerSlug - The slug of the partner.
+ * @return {string} - The GPT pageKey associated with the partner slug.
+ * Returns 'other' if partnerSlug is invalid, otherwise returns 'SECTION_IDS.news'.
+ */
+function getPageKeyByPartnerSlug(partnerSlug = '') {
+  const invalidSlugs = ['ebc', 'healthnews', 'zuchi', '5678news']
+  return invalidSlugs.includes(partnerSlug) ? 'other' : SECTION_IDS.news
+}
+
 export {
   transformStringToDraft,
   getExternalSectionTitle,
   getCreditsHtml,
   getExternalPartnerColor,
+  getPageKeyByPartnerSlug,
 }

--- a/packages/mirror-media-next/utils/external.js
+++ b/packages/mirror-media-next/utils/external.js
@@ -112,11 +112,11 @@ function getCreditsHtml(credits = '') {
  *
  * @param {string} partnerSlug - The slug of the partner.
  * @return {string} - The GPT pageKey associated with the partner slug.
- * Returns 'other' if partnerSlug is invalid, otherwise returns 'SECTION_IDS.news'.
+ * Returns 'SECTION_IDS.news' if partnerSlug is valid, otherwise returns 'other'.
  */
 function getPageKeyByPartnerSlug(partnerSlug = '') {
-  const invalidSlugs = ['ebc', 'healthnews', 'zuchi', '5678news']
-  return invalidSlugs.includes(partnerSlug) ? 'other' : SECTION_IDS.news
+  const validSlugs = ['ebc', 'healthnews', 'zuchi', '5678news']
+  return validSlugs.includes(partnerSlug) ? SECTION_IDS.news : 'other'
 }
 
 export {


### PR DESCRIPTION
## Notable Change
- 使用 `Z_INDEX` constants，統一設定列表頁尾 `StickyGPTAd` 的 z-index 數值。
- 統一在 `gpt-ad.js` 內透過 `isLoggedIn`，判斷是否顯示 GPT 廣告。
- 影響頁面：
 
   - 作者列表 `/author/[id]`
   - 生活暖流列表 `/externals/warmlife` - 廣告內容統一使用「時事」類別。
   - 合作夥伴列表 `/externals/[partnerSlug]` 
 
       - partner 為**東森、慈濟、健康醫療網、好醫師**者，廣告為「時事」(news) 類別。
       - 其餘 partner，廣告為「其他」(other) 類別。
   - tag 列表 `/tag/[slug]`
   - category 列表 `/category/[slug]`
   - section 列表 `/section/[slug]`


## 開發
- GPT 廣告只能在 dev 上測試，因為 Google Ad Manager 沒辦法新增 http://localhost:300 網址。

## TODO
- [x] 目前只有透過 `const { isLoggedIn } = useMembership()` 判斷：如果使用者有登入，則不顯示廣告。但廣告需求為 `membertype = none, subscribe_one_time` 時，也需要顯示廣告，這部分的條件判定尚未處理。（**討論結果：先 pending，上線前需統一處理，此次 PR 先以是否有登入為判斷依據。**）

## Reference
- [週刊3.0 廣告顯示整理](https://paper.dropbox.com/doc/3.0--B53VMW_QOKXDKGMyEKqAjXvsAg-CEkZYSHEzyntVmsMLzUk5)
- https://github.com/mirror-media/Adam/pull/252
