### PR TITLE
feat(was): proxy gcs and youtube API requests to original servers

### DIFF
--- a/packages/weekly-api-server/src/app.js
+++ b/packages/weekly-api-server/src/app.js
@@ -6,6 +6,7 @@ import express from 'express'
 import middlewareCreator from './middlewares'
 import { createGcsProxy } from './gcs-proxy-mini-app'
 import { createGraphQLProxy } from './gql-proxy-mini-app'
+import { createYoutubeProxy } from './youtube-proxy-mini-app'
 
 const statusCodes = consts.statusCodes
 
@@ -27,6 +28,7 @@ const statusCodes = consts.statusCodes
  *  @param {string} opts.weeklyProxyOrigin
  *  @param {string} opts.israfelProxyOrigin
  *  @param {string} opts.gcsProxyOrigin
+ *  @param {string} opts.youtubeProxyOrigin
  *  @param {string[]|'*'} [opts.corsAllowOrigin=[]]
  *  @return {express.Application}
  */
@@ -38,6 +40,7 @@ export function createApp({
   israfelProxyOrigin,
   gcsProxyOrigin,
   corsAllowOrigin = [],
+  youtubeProxyOrigin,
 }) {
   // create express app
   const app = express()
@@ -156,6 +159,13 @@ export function createApp({
   app.use(
     createGcsProxy({
       proxyOrigin: gcsProxyOrigin,
+    })
+  )
+
+  // mini app: youtube proxy
+  app.use(
+    createYoutubeProxy({
+      proxyOrigin: youtubeProxyOrigin,
     })
   )
 

--- a/packages/weekly-api-server/src/app.js
+++ b/packages/weekly-api-server/src/app.js
@@ -4,6 +4,7 @@ import cors from 'cors'
 import errors from '@twreporter/errors'
 import express from 'express'
 import middlewareCreator from './middlewares'
+import { createGcsProxy } from './gcs-proxy-mini-app'
 import { createGraphQLProxy } from './gql-proxy-mini-app'
 
 const statusCodes = consts.statusCodes
@@ -25,6 +26,7 @@ const statusCodes = consts.statusCodes
  *  @param {string} opts.jwtSecret
  *  @param {string} opts.weeklyProxyOrigin
  *  @param {string} opts.israfelProxyOrigin
+ *  @param {string} opts.gcsProxyOrigin
  *  @param {string[]|'*'} [opts.corsAllowOrigin=[]]
  *  @return {express.Application}
  */
@@ -34,6 +36,7 @@ export function createApp({
   jwtSecret,
   weeklyProxyOrigin,
   israfelProxyOrigin,
+  gcsProxyOrigin,
   corsAllowOrigin = [],
 }) {
   // create express app
@@ -134,7 +137,6 @@ export function createApp({
   // mini app: weekly GraphQL API
   app.use(
     createGraphQLProxy({
-      gcpProjectId,
       jwtSecret,
       proxyOrigin: weeklyProxyOrigin,
       proxyPath: '/content/graphql',
@@ -144,10 +146,16 @@ export function createApp({
   // mini app: isafel GraphQL API
   app.use(
     createGraphQLProxy({
-      gcpProjectId,
       jwtSecret,
       proxyOrigin: israfelProxyOrigin,
       proxyPath: '/member/graphql',
+    })
+  )
+
+  // mini app: GCS proxy
+  app.use(
+    createGcsProxy({
+      proxyOrigin: gcsProxyOrigin,
     })
   )
 

--- a/packages/weekly-api-server/src/environment-variables.js
+++ b/packages/weekly-api-server/src/environment-variables.js
@@ -5,6 +5,7 @@ const {
   ISRAFEL_GQL_ORIGIN,
   WEEKLY_GQL_ORIGIN,
   CORS_ALLOW_ORIGINS,
+  GCS_ORIGIN,
 } = process.env
 
 /**
@@ -41,6 +42,9 @@ const envVar = {
   },
   cors: {
     allowOrigins: getAllowOrigins(CORS_ALLOW_ORIGINS),
+  },
+  gcs: {
+    origin: GCS_ORIGIN || 'https://v3-statics.mirrormedia.mg'
   },
 }
 

--- a/packages/weekly-api-server/src/environment-variables.js
+++ b/packages/weekly-api-server/src/environment-variables.js
@@ -6,6 +6,7 @@ const {
   WEEKLY_GQL_ORIGIN,
   CORS_ALLOW_ORIGINS,
   GCS_ORIGIN,
+  YOUTUBE_ORIGIN,
 } = process.env
 
 /**
@@ -45,6 +46,9 @@ const envVar = {
   },
   gcs: {
     origin: GCS_ORIGIN || 'https://v3-statics.mirrormedia.mg'
+  },
+  youtube: {
+    origin: YOUTUBE_ORIGIN || 'https://api.mirrormedia.mg'
   },
 }
 

--- a/packages/weekly-api-server/src/gcs-proxy-mini-app.js
+++ b/packages/weekly-api-server/src/gcs-proxy-mini-app.js
@@ -1,0 +1,32 @@
+import express from 'express'
+import { createProxyMiddleware } from 'http-proxy-middleware'
+
+/**
+ *  This function creates a mini app.
+ *  This mini app aims to proxy requests to Google Cloud Storage.
+ *
+ *  @param {Object} opts
+ *  @param {string} opts.proxyOrigin
+ *  @return {express.Router}
+ */
+export function createGcsProxy({
+  proxyOrigin,
+}) {
+  // create express mini app
+  const router = express.Router()
+
+  router.use(
+    '/gcs',
+    // proxy request to API GraphQL endpoint
+    createProxyMiddleware({
+      target: proxyOrigin,
+      changeOrigin: true,
+      pathRewrite: (path) => path.replace(/^\/gcs/, ''),
+      onProxyReq: (proxyReq, req, res) => {
+        proxyReq.setHeader('X-PROXIED-BY', 'Weekly API Server')
+      },
+    })
+  )
+
+  return router
+}

--- a/packages/weekly-api-server/src/gql-proxy-mini-app.js
+++ b/packages/weekly-api-server/src/gql-proxy-mini-app.js
@@ -1,5 +1,4 @@
 import consts from './constants'
-import cors from 'cors'
 // @ts-ignore `@twreporter/errors` does not have tyepscript definition file yet
 import errors from '@twreporter/errors'
 import express from 'express'
@@ -14,32 +13,22 @@ const statusCodes = consts.statusCodes
  *  proxies requests to backed GraphQL API origin server.
  *
  *  @param {Object} opts
- *  @param {string} opts.gcpProjectId
  *  @param {string} opts.jwtSecret
  *  @param {string} opts.proxyOrigin
  *  @param {'/content/graphql'|'/member/graphql'} opts.proxyPath
- *  @param {string[]} [opts.corsAllowOrigin=[]]
  *  @return {express.Router}
  */
 export function createGraphQLProxy({
-  gcpProjectId,
   jwtSecret,
   proxyOrigin,
   proxyPath,
-  corsAllowOrigin = [],
 }) {
   // create express mini app
   const router = express.Router()
 
-  const corsOpts = {
-    origin: corsAllowOrigin,
-  }
-
-  // enable cors pre-flight request
+  // enable pre-flight request
   router.options(
     proxyPath,
-    middlewareCreator.createLoggerMw(gcpProjectId),
-    cors(corsOpts)
   )
 
   const verifyAccessToken = middlewareCreator.verifyAccessToken({
@@ -48,11 +37,6 @@ export function createGraphQLProxy({
 
   router.post(
     proxyPath,
-    // log request
-    middlewareCreator.createLoggerMw(gcpProjectId),
-
-    // handle cors request
-    cors(corsOpts),
 
     // verify access token if needed
     /** @type {express.RequestHandler} */

--- a/packages/weekly-api-server/src/server.js
+++ b/packages/weekly-api-server/src/server.js
@@ -13,6 +13,7 @@ async function start() {
       jwtSecret: envVar.jwt.secret,
       israfelProxyOrigin: envVar.apis.israfel.origin,
       weeklyProxyOrigin: envVar.apis.weekly.origin,
+      gcsProxyOrigin: envVar.gcs.origin,
       corsAllowOrigin: envVar.cors.allowOrigins,
     })
     server = http.createServer(app).listen(port, () => {

--- a/packages/weekly-api-server/src/server.js
+++ b/packages/weekly-api-server/src/server.js
@@ -15,6 +15,7 @@ async function start() {
       weeklyProxyOrigin: envVar.apis.weekly.origin,
       gcsProxyOrigin: envVar.gcs.origin,
       corsAllowOrigin: envVar.cors.allowOrigins,
+      youtubeProxyOrigin: envVar.youtube.origin,
     })
     server = http.createServer(app).listen(port, () => {
       console.log(

--- a/packages/weekly-api-server/src/youtube-proxy-mini-app.js
+++ b/packages/weekly-api-server/src/youtube-proxy-mini-app.js
@@ -1,0 +1,33 @@
+import express from 'express'
+import { createProxyMiddleware } from 'http-proxy-middleware'
+
+
+/**
+ *  This function creates a mini app.
+ *  This mini app aims to proxy requests to Google Cloud Storage.
+ *
+ *  @param {Object} opts
+ *  @param {string} opts.proxyOrigin
+ *  @return {express.Router}
+ */
+export function createYoutubeProxy({
+  proxyOrigin,
+}) {
+  // create express mini app
+  const router = express.Router()
+
+  console.log('proxyOrigin:', proxyOrigin)
+  router.use(
+    '/youtube',
+    // proxy request to API GraphQL endpoint
+    createProxyMiddleware({
+      target: proxyOrigin,
+      changeOrigin: true,
+      onProxyReq: (proxyReq, req, res) => {
+        proxyReq.setHeader('X-PROXIED-BY', 'Weekly API Server')
+      },
+    })
+  )
+
+  return router
+}


### PR DESCRIPTION
### Notable Change
- add `/gcs` route to proxy requests to gcs original server
- add `/youtube` route to proxy youtube API requests to 2.0 api server

### Examples
- request `https://adam-weekly-api-server-dev-ufaummkd5q-de.a.run.app/gcs/json/post_external01.json` will be proxied to `https://v3-statics-dev.mirrormedia.mg/json/post_external01.json` 
- request `https://adam-weekly-api-server-dev-ufaummkd5q-de.a.run.app/youtube/search? maxResults=7&order=date&part=snippet&channelId=UCYkldEK001GxR884OZMFnRw` will be proxied to `http://104.199.190.189:8080/youtube/search?maxResults=7&order=date&part=snippet&channelId=UCYkldEK001GxR884OZMFnRw`