### PR TITLE
feat(ad): add `memberType` to determine whether to display GPT Ad

### DIFF
--- a/packages/mirror-media-next/components/ads/gpt/gpt-ad.js
+++ b/packages/mirror-media-next/components/ads/gpt/gpt-ad.js
@@ -58,10 +58,12 @@ export default function GPTAd({
   onSlotRenderEnded,
   className,
 }) {
-  const { isLoggedIn } = useMembership()
+  const { memberInfo, isLogInProcessFinished } = useMembership()
+  const { memberType } = memberInfo
 
   const [adWidth, setAdWidth] = useState('')
   const [adDivId, setAdDivId] = useState('')
+  const [gptAdJsx, setGptAdJsx] = useState(null)
 
   useEffect(() => {
     if (!(pageKey && adKey)) {
@@ -113,12 +115,25 @@ export default function GPTAd({
     }
   }, [adKey, pageKey, onSlotRequested, onSlotRenderEnded])
 
-  //The login member type has not been implemented yet. For now, we will temporarily use `isLoggedIn` as the basis for deciding whether to display GPT advertisements.
-  const gptAdJsx = !isLoggedIn ? (
-    <Wrapper className={`${className} gpt-ad`}>
-      <Ad width={adWidth} id={adDivId} />
-    </Wrapper>
-  ) : null
+  //When the user's member type is 'not-member', 'one-time-member', or 'basic-member', the AD should be displayed.
+
+  // Since the member type needs to be determined on the client-side, the rendering of `gptAdJsx` should be done on the client-side.
+
+  useEffect(() => {
+    const invalidMemberType = ['not-member', 'one-time-member', 'basic-member']
+
+    if (isLogInProcessFinished) {
+      if (invalidMemberType.includes(memberType)) {
+        setGptAdJsx(
+          <Wrapper className={`${className} gpt-ad`}>
+            <Ad width={adWidth} id={adDivId} />
+          </Wrapper>
+        )
+      } else {
+        return
+      }
+    }
+  }, [adDivId, adWidth, className, isLogInProcessFinished, memberType])
 
   return <>{gptAdJsx}</>
 }

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -1,5 +1,6 @@
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
+import dynamic from 'next/dynamic'
 
 import client from '../../apollo/apollo-client'
 import { fetchContact } from '../../apollo/query/contact'
@@ -8,13 +9,15 @@ import AuthorArticles from '../../components/author/author-articles'
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
-import GPTAd from '../../components/ads/gpt/gpt-ad'
 import { Z_INDEX } from '../../constants/index'
+
+const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
 
 const AuthorContainer = styled.main`
   width: 320px;
   margin: 0 auto;
-
   ${({ theme }) => theme.breakpoint.md} {
     width: 672px;
   }

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -1,5 +1,6 @@
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
+import dynamic from 'next/dynamic'
 
 import client from '../../apollo/apollo-client'
 import { fetchPosts } from '../../apollo/query/posts'
@@ -12,8 +13,11 @@ import {
   fetchHeaderDataInPremiumPageLayout,
 } from '../../utils/api'
 import Layout from '../../components/shared/layout'
-import GPTAd from '../../components/ads/gpt/gpt-ad'
 import { Z_INDEX } from '../../constants/index'
+
+const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -1,5 +1,6 @@
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
+import dynamic from 'next/dynamic'
 
 import client from '../../apollo/apollo-client'
 import ExternalArticles from '../../components/externals/partner-articles'
@@ -16,8 +17,11 @@ import {
   getExternalPartnerColor,
   getPageKeyByPartnerSlug,
 } from '../../utils/external'
-import GPTAd from '../../components/ads/gpt/gpt-ad'
 import { Z_INDEX } from '../../constants/index'
+
+const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -1,5 +1,6 @@
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
+import dynamic from 'next/dynamic'
 
 import WarmLifeArticles from '../../components/externals/warmlife-articles'
 import {
@@ -10,8 +11,11 @@ import {
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
 import axios from 'axios'
-import GPTAd from '../../components/ads/gpt/gpt-ad'
 import { Z_INDEX, SECTION_IDS } from '../../constants/index'
+
+const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
 
 const RENDER_PAGE_SIZE = 12
 const WARMLIFE_DEFAULT_TITLE = `生活暖流`

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -1,5 +1,6 @@
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
+import dynamic from 'next/dynamic'
 
 import client from '../../apollo/apollo-client'
 import { fetchPosts } from '../../apollo/query/posts'
@@ -8,9 +9,12 @@ import SectionArticles from '../../components/shared/section-articles'
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
-import GPTAd from '../../components/ads/gpt/gpt-ad'
 import { Z_INDEX } from '../../constants/index'
 import { SECTION_IDS } from '../../constants/index'
+
+const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -1,5 +1,6 @@
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
+import dynamic from 'next/dynamic'
 
 import client from '../../apollo/apollo-client'
 import { fetchPosts } from '../../apollo/query/posts'
@@ -8,8 +9,11 @@ import TagArticles from '../../components/tag/tag-articles'
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
-import GPTAd from '../../components/ads/gpt/gpt-ad'
 import { Z_INDEX } from '../../constants/index'
+
+const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
 
 const TagContainer = styled.main`
   width: 320px;

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -1,6 +1,7 @@
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
 import axios from 'axios'
+import dynamic from 'next/dynamic'
 
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import { GCP_PROJECT_ID, URL_RESTFUL_SERVER } from '../../config/index.mjs'
@@ -13,8 +14,11 @@ import YoutubeArticle from '../../components/video/youtube-article'
 import VideoList from '../../components/video/video-list'
 import YoutubePolicy from '../../components/shared/youtube-policy'
 import Layout from '../../components/shared/layout'
-import GPTAd from '../../components/ads/gpt/gpt-ad'
 import { Z_INDEX } from '../../constants/index'
+
+const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
 
 const Wrapper = styled.main`
   width: 320px;


### PR DESCRIPTION
### Notable Changes 

- 如使用者：未登入 或 memberType = `one-time-member` |  `basic-member` | `not-member`，則會顯示廣告，其餘狀態不顯示廣告。
- 由於 `memberType` 是在 client-side 端才確認，因此修改 `GPT` 廣告於 client-side 端才 render，並增加條件判定：確認當 `isLogInProcessFinished` 為 true 後（即 useContext 確認完 login 狀態後），才進一步對 member type 作類別判定，以避免廣告閃現問題。
- 各頁面也統一修改為透過 `next/dynamic` 動態載入 GPT 元件，統一於 client-side 端處理廣告元件。

### 影響頁面

   - 作者列表
   - category 列表
   - externals / 合作夥伴列表
   - externals / warmlife
   - section 列表
   - tag 列表
   - video 影音內頁

### Related PR
-  #294