### PR TITLE
refactor(mm-next): add error handling for listing page

### DIFF
--- a/packages/mirror-media-next/components/section/topic/section-topics.js
+++ b/packages/mirror-media-next/components/section/topic/section-topics.js
@@ -1,11 +1,10 @@
 import styled from 'styled-components'
-import client from '../../../apollo/apollo-client'
 
 import InfiniteScrollList from '../../infinite-scroll-list'
 import Image from 'next/legacy/image'
 import LoadingPage from '../../../public/images/loading_page.gif'
 import TopicList from './topic-list'
-import { fetchTopics } from '../../../apollo/query/topics'
+import { fetchTopicList } from '../../../utils/api/section-topic'
 
 const Loading = styled.div`
   margin: 20px auto 0;
@@ -31,20 +30,16 @@ const Loading = styled.div`
  * @returns {React.ReactElement}
  */
 export default function SectionTopics({ topics, topicsCount, renderPageSize }) {
+  const fetchPageSize = renderPageSize * 2
   async function fetchTopicsFromPage(page) {
     try {
-      const response = await client.query({
-        query: fetchTopics,
-        variables: {
-          take: renderPageSize * 2,
-          skip: (page - 1) * renderPageSize * 2,
-          orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
-          filter: { state: { equals: 'published' } },
-        },
-      })
+      const take = fetchPageSize
+      const skip = (page - 1) * take
+      const response = await fetchTopicList(take, skip)
       return response.data.topics
     } catch (error) {
-      console.error('fetchTopicsFromPage error', error)
+      // [to-do]: use beacon api to log error on gcs
+      console.error(error)
     }
     return
   }
@@ -59,7 +54,7 @@ export default function SectionTopics({ topics, topicsCount, renderPageSize }) {
     <InfiniteScrollList
       initialList={topics}
       renderAmount={renderPageSize}
-      fetchCount={Math.ceil(topicsCount / renderPageSize)}
+      fetchCount={Math.ceil(topicsCount / fetchPageSize)}
       fetchListInPage={fetchTopicsFromPage}
       loader={loader}
     >

--- a/packages/mirror-media-next/components/shared/section-articles.js
+++ b/packages/mirror-media-next/components/shared/section-articles.js
@@ -1,13 +1,12 @@
-import client from '../../apollo/apollo-client'
 import styled from 'styled-components'
 import Image from 'next/legacy/image'
 
 import InfiniteScrollList from '../infinite-scroll-list'
 import ArticleList from './article-list'
-import { fetchPosts } from '../../apollo/query/posts'
 import PremiumArticleList from './premium-article-list'
 import { fetchPostsBySectionSlug } from '../../utils/api/section'
 import LoadingPage from '../../public/images/loading_page.gif'
+import { fetchPremiumPostsBySectionSlug } from '../../utils/api/premiumsection'
 
 const Loading = styled.div`
   margin: 20px auto 0;
@@ -65,21 +64,13 @@ export default function SectionArticles({
       return
     }
     try {
-      const response = await client.query({
-        query: fetchPosts,
-        variables: {
-          take: fetchPageSize,
-          skip: (page - 1) * renderPageSize * 2,
-          orderBy: { publishedDate: 'desc' },
-          filter: {
-            state: { equals: 'published' },
-            AND: [
-              { sections: { some: { slug: { equals: section.slug } } } },
-              { sections: { some: { slug: { equals: 'member' } } } },
-            ],
-          },
-        },
-      })
+      const take = fetchPageSize
+      const skip = (page - 1) * take
+      const response = await fetchPremiumPostsBySectionSlug(
+        section.slug,
+        take,
+        skip
+      )
       return response.data.posts
     } catch (error) {
       // [to-do]: use beacon api to log error on gcs

--- a/packages/mirror-media-next/components/shared/section-articles.js
+++ b/packages/mirror-media-next/components/shared/section-articles.js
@@ -1,12 +1,13 @@
-import styled from 'styled-components'
 import client from '../../apollo/apollo-client'
+import styled from 'styled-components'
+import Image from 'next/legacy/image'
 
 import InfiniteScrollList from '../infinite-scroll-list'
-import Image from 'next/legacy/image'
-import LoadingPage from '../../public/images/loading_page.gif'
 import ArticleList from './article-list'
 import { fetchPosts } from '../../apollo/query/posts'
 import PremiumArticleList from './premium-article-list'
+import { fetchPostsBySectionSlug } from '../../utils/api/section'
+import LoadingPage from '../../public/images/loading_page.gif'
 
 const Loading = styled.div`
   margin: 20px auto 0;
@@ -41,33 +42,33 @@ export default function SectionArticles({
   renderPageSize,
   isPremium = false,
 }) {
+  const fetchPageSize = renderPageSize * 2
+
   async function fetchPostsFromPage(page) {
+    if (!section?.slug) {
+      return
+    }
     try {
-      const response = await client.query({
-        query: fetchPosts,
-        variables: {
-          take: renderPageSize * 2,
-          skip: (page - 1) * renderPageSize * 2,
-          orderBy: { publishedDate: 'desc' },
-          filter: {
-            state: { equals: 'published' },
-            sections: { some: { slug: { equals: section.slug } } },
-          },
-        },
-      })
+      const take = fetchPageSize
+      const skip = (page - 1) * take
+      const response = await fetchPostsBySectionSlug(section.slug, take, skip)
       return response.data.posts
     } catch (error) {
+      // [to-do]: use beacon api to log error on gcs
       console.error(error)
     }
     return
   }
 
   async function fetchPremiumPostsFromPage(page) {
+    if (!section?.slug) {
+      return
+    }
     try {
       const response = await client.query({
         query: fetchPosts,
         variables: {
-          take: renderPageSize * 2,
+          take: fetchPageSize,
           skip: (page - 1) * renderPageSize * 2,
           orderBy: { publishedDate: 'desc' },
           filter: {
@@ -81,6 +82,7 @@ export default function SectionArticles({
       })
       return response.data.posts
     } catch (error) {
+      // [to-do]: use beacon api to log error on gcs
       console.error(error)
     }
     return
@@ -96,7 +98,7 @@ export default function SectionArticles({
     <InfiniteScrollList
       initialList={posts}
       renderAmount={renderPageSize}
-      fetchCount={Math.ceil(postsCount / renderPageSize)}
+      fetchCount={Math.ceil(postsCount / fetchPageSize)}
       fetchListInPage={
         isPremium ? fetchPremiumPostsFromPage : fetchPostsFromPage
       }

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -1,15 +1,16 @@
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
 
-import client from '../../apollo/apollo-client'
-import { fetchContact } from '../../apollo/query/contact'
-import { fetchPosts } from '../../apollo/query/posts'
 import AuthorArticles from '../../components/author/author-articles'
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
 import GPTAd from '../../components/ads/gpt/gpt-ad'
 import { Z_INDEX } from '../../constants/index'
+import {
+  fetchAuthorByAuthorId,
+  fetchPostsByAuthorId,
+} from '../../utils/api/author'
 
 const AuthorContainer = styled.main`
   width: 320px;
@@ -87,19 +88,20 @@ const RENDER_PAGE_SIZE = 12
  * @returns {React.ReactElement}
  */
 export default function Author({ postsCount, posts, author, headerData }) {
+  const authorName = author.name || ''
   return (
     <Layout
-      head={{ title: `${author?.name}相關報導` }}
+      head={{ title: `${authorName}相關報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
       <AuthorContainer>
         <StyledGPTAd pageKey="other" adKey="HD" />
-        <AuthorTitle>{author?.name}</AuthorTitle>
+        {authorName && <AuthorTitle>{authorName}</AuthorTitle>}
         <AuthorArticles
           postsCount={postsCount}
           posts={posts}
-          author={author}
+          authorId={author.id}
           renderPageSize={RENDER_PAGE_SIZE}
         />
         <StyledGPTAd pageKey="other" adKey="FT" />
@@ -113,7 +115,9 @@ export default function Author({ postsCount, posts, author, headerData }) {
  * @type {import('next').GetServerSideProps}
  */
 export async function getServerSideProps({ query, req }) {
-  const authorId = query.id
+  const authorId = Array.isArray(query.id) ? query.id[0] : query.id
+  const mockError = query.error === '500'
+
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}
   if (traceHeader && !Array.isArray(traceHeader)) {
@@ -125,31 +129,16 @@ export async function getServerSideProps({ query, req }) {
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
-    client.query({
-      query: fetchPosts,
-      variables: {
-        take: RENDER_PAGE_SIZE * 2,
-        skip: 0,
-        orderBy: { publishedDate: 'desc' },
-        filter: {
-          state: { equals: 'published' },
-          OR: [
-            { writers: { some: { id: { equals: authorId } } } },
-            { photographers: { some: { id: { equals: authorId } } } },
-          ],
-        },
-      },
-    }),
-    client.query({
-      query: fetchContact,
-      variables: {
-        where: { id: authorId },
-      },
-    }),
+    fetchPostsByAuthorId(authorId, RENDER_PAGE_SIZE * 2, mockError ? NaN : 0),
+    fetchAuthorByAuthorId(authorId),
   ])
 
-  const handledResponses = responses.map((response) => {
+  const handledResponses = responses.map((response, index) => {
     if (response.status === 'fulfilled') {
+      if ('data' in response.value) {
+        // handle gql requests
+        return response.value.data
+      }
       return response.value
     } else if (response.status === 'rejected') {
       const { graphQLErrors, clientErrors, networkError } = response.reason
@@ -179,12 +168,17 @@ export async function getServerSideProps({ query, req }) {
           ...globalLogFields,
         })
       )
+      if (index === 1) {
+        // fetch key data (posts) failed, redirect to 500
+        throw new Error('fetch author posts failed')
+      }
       return
     }
   })
 
+  //handle header data
   const headerData =
-    'sectionsData' in handledResponses[0]
+    handledResponses[0] && 'sectionsData' in handledResponses[0]
       ? handledResponses[0]
       : { sectionsData: [], topicsData: [] }
   const sectionsData = Array.isArray(headerData.sectionsData)
@@ -193,19 +187,27 @@ export async function getServerSideProps({ query, req }) {
   const topicsData = Array.isArray(headerData.topicsData)
     ? headerData.topicsData
     : []
+
+  // handle fetch post data
+  if (handledResponses[1]?.posts?.length === 0) {
+    // fetchPost return empty array -> wrong authorId -> 404
+    console.log(
+      JSON.stringify({
+        severity: 'WARNING',
+        message: `fetch post of authroId ${authorId} return empty posts, redirect to 404`,
+        globalLogFields,
+      })
+    )
+    return { notFound: true }
+  }
   /** @type {number} postsCount */
-  const postsCount =
-    'data' in handledResponses[1]
-      ? handledResponses[1]?.data?.postsCount || 0
-      : 0
+  const postsCount = handledResponses[1]?.postsCount || 0
   /** @type {Article[]} */
-  const posts =
-    'data' in handledResponses[1] ? handledResponses[1]?.data?.posts || [] : []
+  const posts = handledResponses[1]?.posts || []
+
+  // handle fetch author data
   /** @type {Author} */
-  const author =
-    'data' in handledResponses[2]
-      ? handledResponses[2]?.data?.contact || {}
-      : {}
+  const author = handledResponses[2]?.contact || { id: authorId }
 
   const props = {
     postsCount,

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -1,12 +1,8 @@
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
 
-import client from '../../apollo/apollo-client'
-import { fetchPosts } from '../../apollo/query/posts'
-import { fetchCategorySections } from '../../apollo/query/categroies'
 import CategoryArticles from '../../components/category/category-articles'
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
-
 import {
   fetchHeaderDataInDefaultPageLayout,
   fetchHeaderDataInPremiumPageLayout,
@@ -14,6 +10,10 @@ import {
 import Layout from '../../components/shared/layout'
 import GPTAd from '../../components/ads/gpt/gpt-ad'
 import { Z_INDEX } from '../../constants/index'
+import {
+  fetchCategoryByCategorySlug,
+  fetchPostsByCategorySlug,
+} from '../../utils/api/category'
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -186,9 +186,10 @@ export default function Category({
   isPremium,
   headerData,
 }) {
+  const categroyName = category.name || ''
   return (
     <Layout
-      head={{ title: `${category?.name}分類報導` }}
+      head={{ title: `${categroyName}分類報導` }}
       header={{ type: isPremium ? 'premium' : 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
@@ -196,11 +197,11 @@ export default function Category({
         <StyledGPTAd pageKey="other" adKey="HD" />
         {isPremium ? (
           <PremiumCategoryTitle sectionName={category?.sections?.[0].slug}>
-            {category?.name}
+            {categroyName}
           </PremiumCategoryTitle>
         ) : (
           <CategoryTitle sectionName={category?.sections?.[0].slug}>
-            {category?.name}
+            {categroyName}
           </CategoryTitle>
         )}
         <CategoryArticles
@@ -210,6 +211,7 @@ export default function Category({
           renderPageSize={RENDER_PAGE_SIZE}
           isPremium={isPremium}
         />
+
         <StyledGPTAd pageKey="other" adKey="FT" />
         <StickyGPTAd pageKey="other" adKey="ST" />
       </CategoryContainer>
@@ -221,7 +223,9 @@ export default function Category({
  * @type {import('next').GetServerSideProps}
  */
 export async function getServerSideProps({ query, req }) {
-  const categorySlug = query.slug
+  const categorySlug = Array.isArray(query.slug) ? query.slug[0] : query.slug
+  const mockError = query.error === '500'
+
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}
   if (traceHeader && !Array.isArray(traceHeader)) {
@@ -232,29 +236,18 @@ export async function getServerSideProps({ query, req }) {
   }
 
   const responses = await Promise.allSettled([
-    client.query({
-      query: fetchPosts,
-      variables: {
-        take: RENDER_PAGE_SIZE * 2,
-        skip: 0,
-        orderBy: { publishedDate: 'desc' },
-        filter: {
-          state: { equals: 'published' },
-          categories: { some: { slug: { equals: categorySlug } } },
-        },
-      },
-    }),
-    client.query({
-      query: fetchCategorySections,
-      variables: {
-        categorySlug,
-      },
-    }),
+    fetchPostsByCategorySlug(
+      categorySlug,
+      RENDER_PAGE_SIZE * 2,
+      mockError ? NaN : 0
+    ),
+    fetchCategoryByCategorySlug(categorySlug),
   ])
 
-  const handledResponses = responses.map((response) => {
+  const handledResponses = responses.map((response, index) => {
     if (response.status === 'fulfilled') {
-      return response.value
+      // since only gql requests
+      return response.value.data
     } else if (response.status === 'rejected') {
       const { graphQLErrors, clientErrors, networkError } = response.reason
       const annotatingError = errors.helpers.wrap(
@@ -283,16 +276,38 @@ export async function getServerSideProps({ query, req }) {
           ...globalLogFields,
         })
       )
+
+      if (index === 0) {
+        // fetch key data (posts) failed, redirect to 500
+        throw new Error('fetch category posts failed')
+      }
       return
     }
   })
 
+  // handle fetch post data
+  if (handledResponses[0]?.posts?.length === 0) {
+    // fetchPost return empty array -> wrong authorId -> 404
+    console.log(
+      JSON.stringify({
+        severity: 'WARNING',
+        message: `fetch post of categorySlug ${categorySlug} return empty posts, redirect to 404`,
+        globalLogFields,
+      })
+    )
+    return { notFound: true }
+  }
   /** @type {number} postsCount */
-  const postsCount = handledResponses[0]?.data?.postsCount || 0
+  const postsCount = handledResponses[0]?.postsCount || 0
   /** @type {Article[]} */
-  const posts = handledResponses[0]?.data?.posts || []
+  const posts = handledResponses[0]?.posts || []
   /** @type {Category} */
-  const category = handledResponses[1]?.data?.category || {}
+
+  // handle detch category data, if request failed fallback to isMemberOnly = false
+  const category = handledResponses[1]?.category || {
+    slug: categorySlug,
+    isMemberOnly: false,
+  }
   const isPremium = category.isMemberOnly
   let sectionsData = []
   let topicsData = []

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -1,9 +1,6 @@
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
 
-import client from '../../apollo/apollo-client'
-import { fetchPosts } from '../../apollo/query/posts'
-import { fetchSection } from '../../apollo/query/sections'
 import SectionArticles from '../../components/shared/section-articles'
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
@@ -11,6 +8,10 @@ import Layout from '../../components/shared/layout'
 import GPTAd from '../../components/ads/gpt/gpt-ad'
 import { Z_INDEX } from '../../constants/index'
 import { SECTION_IDS } from '../../constants/index'
+import {
+  fetchPostsBySectionSlug,
+  fetchSectionBySectionSlug,
+} from '../../utils/api/section'
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -100,21 +101,24 @@ const RENDER_PAGE_SIZE = 12
  * @returns {React.ReactElement}
  */
 export default function Section({ postsCount, posts, section, headerData }) {
+  const sectionName = section.name || ''
   //When the section is `論壇`, use the `culture` AD unit.
   const GPT_PAGE_KEY =
-    section?.slug === 'mirrorcolumn'
+    section.slug === 'mirrorcolumn'
       ? SECTION_IDS['culture']
       : SECTION_IDS[section.slug]
 
   return (
     <Layout
-      head={{ title: `${section?.name}分類報導` }}
+      head={{ title: `${sectionName}分類報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
       <SectionContainer>
         <StyledGPTAd pageKey={GPT_PAGE_KEY} adKey="HD" />
-        <SectionTitle sectionName={section?.slug}>{section?.name}</SectionTitle>
+        {sectionName && (
+          <SectionTitle sectionName={section.slug}>{sectionName}</SectionTitle>
+        )}
         <SectionArticles
           postsCount={postsCount}
           posts={posts}
@@ -132,7 +136,9 @@ export default function Section({ postsCount, posts, section, headerData }) {
  * @type {import('next').GetServerSideProps}
  */
 export async function getServerSideProps({ query, req }) {
-  const sectionSlug = query.slug
+  const sectionSlug = Array.isArray(query.slug) ? query.slug[0] : query.slug
+  const mockError = query.error === '500'
+
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}
   if (traceHeader && !Array.isArray(traceHeader)) {
@@ -144,28 +150,20 @@ export async function getServerSideProps({ query, req }) {
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
-    client.query({
-      query: fetchPosts,
-      variables: {
-        take: RENDER_PAGE_SIZE * 2,
-        skip: 0,
-        orderBy: { publishedDate: 'desc' },
-        filter: {
-          state: { equals: 'published' },
-          sections: { some: { slug: { equals: sectionSlug } } },
-        },
-      },
-    }),
-    client.query({
-      query: fetchSection,
-      variables: {
-        where: { slug: sectionSlug },
-      },
-    }),
+    fetchPostsBySectionSlug(
+      sectionSlug,
+      RENDER_PAGE_SIZE * 2,
+      mockError ? NaN : 0
+    ),
+    fetchSectionBySectionSlug(sectionSlug),
   ])
 
-  const handledResponses = responses.map((response) => {
+  const handledResponses = responses.map((response, index) => {
     if (response.status === 'fulfilled') {
+      if ('data' in response.value) {
+        // handle gql requests
+        return response.value.data
+      }
       return response.value
     } else if (response.status === 'rejected') {
       const { graphQLErrors, clientErrors, networkError } = response.reason
@@ -195,12 +193,17 @@ export async function getServerSideProps({ query, req }) {
           ...globalLogFields,
         })
       )
+      if (index === 1) {
+        // fetch key data (posts) failed, redirect to 500
+        throw new Error('fetch section posts failed')
+      }
       return
     }
   })
 
+  // handle header data
   const headerData =
-    'sectionsData' in handledResponses[0]
+    handledResponses[0] && 'sectionsData' in handledResponses[0]
       ? handledResponses[0]
       : {
           sectionsData: [],
@@ -212,19 +215,27 @@ export async function getServerSideProps({ query, req }) {
   const topicsData = Array.isArray(headerData.topicsData)
     ? headerData.topicsData
     : []
+
+  // handle fetch post data
+  if (handledResponses[1]?.posts?.length === 0) {
+    // fetchPost return empty array -> wrong authorId -> 404
+    console.log(
+      JSON.stringify({
+        severity: 'WARNING',
+        message: `fetch post of sectionSlug ${sectionSlug} return empty posts, redirect to 404`,
+        globalLogFields,
+      })
+    )
+    return { notFound: true }
+  }
   /** @type {number} postsCount */
-  const postsCount =
-    'data' in handledResponses[1]
-      ? handledResponses[1]?.data?.postsCount || 0
-      : 0
+  const postsCount = handledResponses[1]?.postsCount || 0
   /** @type {Article[]} */
-  const posts =
-    'data' in handledResponses[1] ? handledResponses[1]?.data?.posts || [] : []
+  const posts = handledResponses[1]?.posts || []
+
+  // handle fetch section data
   /** @type {Section} */
-  const section =
-    'data' in handledResponses[2]
-      ? handledResponses[2]?.data?.section || {}
-      : {}
+  const section = handledResponses[2]?.section || { slug: sectionSlug }
 
   const props = {
     postsCount,

--- a/packages/mirror-media-next/utils/api/author.js
+++ b/packages/mirror-media-next/utils/api/author.js
@@ -1,0 +1,35 @@
+import client from '../../apollo/apollo-client'
+import { fetchContact } from '../../apollo/query/contact'
+import { fetchPosts } from '../../apollo/query/posts'
+
+/**
+ * @param {string} authorId
+ * @param {number} take
+ * @param {number} skip
+ */
+export function fetchPostsByAuthorId(authorId, take, skip) {
+  return client.query({
+    query: fetchPosts,
+    variables: {
+      take: take,
+      skip: skip,
+      orderBy: { publishedDate: 'desc' },
+      filter: {
+        state: { equals: 'published' },
+        OR: [
+          { writers: { some: { id: { equals: authorId } } } },
+          { photographers: { some: { id: { equals: authorId } } } },
+        ],
+      },
+    },
+  })
+}
+
+export function fetchAuthorByAuthorId(authorId) {
+  return client.query({
+    query: fetchContact,
+    variables: {
+      where: { id: authorId },
+    },
+  })
+}

--- a/packages/mirror-media-next/utils/api/category.js
+++ b/packages/mirror-media-next/utils/api/category.js
@@ -1,0 +1,27 @@
+import client from '../../apollo/apollo-client'
+import { fetchCategorySections } from '../../apollo/query/categroies'
+import { fetchPosts } from '../../apollo/query/posts'
+
+export function fetchPostsByCategorySlug(categorySlug, take, skip) {
+  return client.query({
+    query: fetchPosts,
+    variables: {
+      take,
+      skip,
+      orderBy: { publishedDate: 'desc' },
+      filter: {
+        state: { equals: 'published' },
+        categories: { some: { slug: { equals: categorySlug } } },
+      },
+    },
+  })
+}
+
+export function fetchCategoryByCategorySlug(categorySlug) {
+  return client.query({
+    query: fetchCategorySections,
+    variables: {
+      categorySlug,
+    },
+  })
+}

--- a/packages/mirror-media-next/utils/api/premiumsection.js
+++ b/packages/mirror-media-next/utils/api/premiumsection.js
@@ -1,0 +1,39 @@
+import client from '../../apollo/apollo-client'
+import { fetchPosts } from '../../apollo/query/posts'
+import { fetchSection } from '../../apollo/query/sections'
+
+/**
+ * @param {string} sectionSlug
+ * @param {number} take
+ * @param {number} skip
+ * @returns
+ */
+export function fetchPremiumPostsBySectionSlug(sectionSlug, take, skip) {
+  return client.query({
+    query: fetchPosts,
+    variables: {
+      take,
+      skip,
+      orderBy: { publishedDate: 'desc' },
+      filter: {
+        state: { equals: 'published' },
+        AND: [
+          { sections: { some: { slug: { equals: sectionSlug } } } },
+          { sections: { some: { slug: { equals: 'member' } } } },
+        ],
+      },
+    },
+  })
+}
+
+/**
+ * @param {string} sectionSlug
+ */
+export function fetchSectionBySectionSlug(sectionSlug) {
+  return client.query({
+    query: fetchSection,
+    variables: {
+      where: { slug: sectionSlug },
+    },
+  })
+}

--- a/packages/mirror-media-next/utils/api/section-topic.js
+++ b/packages/mirror-media-next/utils/api/section-topic.js
@@ -1,0 +1,18 @@
+import client from '../../apollo/apollo-client'
+import { fetchTopics } from '../../apollo/query/topics'
+
+/**
+ * @param {number} take
+ * @param {number} skip
+ */
+export function fetchTopicList(take, skip) {
+  return client.query({
+    query: fetchTopics,
+    variables: {
+      take,
+      skip,
+      orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+      filter: { state: { equals: 'published' } },
+    },
+  })
+}

--- a/packages/mirror-media-next/utils/api/section.js
+++ b/packages/mirror-media-next/utils/api/section.js
@@ -1,0 +1,35 @@
+import client from '../../apollo/apollo-client'
+import { fetchPosts } from '../../apollo/query/posts'
+import { fetchSection } from '../../apollo/query/sections'
+
+/**
+ * @param {string} sectionSlug
+ * @param {number} take
+ * @param {number} skip
+ */
+export function fetchPostsBySectionSlug(sectionSlug, take, skip) {
+  return client.query({
+    query: fetchPosts,
+    variables: {
+      take,
+      skip,
+      orderBy: { publishedDate: 'desc' },
+      filter: {
+        state: { equals: 'published' },
+        sections: { some: { slug: { equals: sectionSlug } } },
+      },
+    },
+  })
+}
+
+/**
+ * @param {string} sectionSlug
+ */
+export function fetchSectionBySectionSlug(sectionSlug) {
+  return client.query({
+    query: fetchSection,
+    variables: {
+      where: { slug: sectionSlug },
+    },
+  })
+}

--- a/packages/mirror-media-next/utils/api/tag.js
+++ b/packages/mirror-media-next/utils/api/tag.js
@@ -1,0 +1,35 @@
+import client from '../../apollo/apollo-client'
+import { fetchPosts } from '../../apollo/query/posts'
+import { fetchTag } from '../../apollo/query/tags'
+
+/**
+ * @param {string} tagSlug
+ * @param {number} take
+ * @param {number} skip
+ */
+export function fetchPostsByTagSlug(tagSlug, take, skip) {
+  return client.query({
+    query: fetchPosts,
+    variables: {
+      take,
+      skip,
+      orderBy: { publishedDate: 'desc' },
+      filter: {
+        state: { equals: 'published' },
+        tags: { some: { slug: { equals: tagSlug } } },
+      },
+    },
+  })
+}
+
+/**
+ * @param {string} tagSlug
+ */
+export function fetchTagByTagSlug(tagSlug) {
+  return client.query({
+    query: fetchTag,
+    variables: {
+      where: { slug: tagSlug },
+    },
+  })
+}


### PR DESCRIPTION
# Change
Add error handling for listing page when key data (posts) are not available.

## Impact pages
- author
- tag
- section
- category
- premiumsection
- section-topic
- externals-warmlife

## 404
(Server Side) If the key data request has response but empty array was provided, show 404 UI.

## 500
(Server Side) If the key data request failed, throw error and next.js server will show 500 UI.

## Other improvement
- fix fetch count not align to fetch size when using InfiniteScrollList
- reuse function to fetch data

## Todo 
- [ ] add error bundary for all page for client side fallback error.
- [ ] send log using beacon api to log client side error.