### PR TITLE
feat(ad): add `MicroAd` in listing/home/story page

### DIFF
--- a/packages/mirror-media-next/components/ads/micro-ad/micro-ad-with-label.js
+++ b/packages/mirror-media-next/components/ads/micro-ad/micro-ad-with-label.js
@@ -1,27 +1,423 @@
-import styled from 'styled-components'
+import { useEffect, useState } from 'react'
+import styled, { css } from 'styled-components'
 import MicroAd from './micro-ad'
 
-const StyledMicroAd = styled(MicroAd)`
-  .popListVert-list__item > a::before,
-  figure::before {
-    content: '特企';
-    display: inline;
-    z-index: 2;
-    padding: 4px;
-    background: rgba(188, 188, 188, 1);
-    color: #ffffff;
-    font-weight: 300;
-    font-size: 12px;
-    line-height: 12px;
-    position: absolute;
-    transform: translate(0, -100%);
-    @include media-breakpoint-up(md) {
-      font-size: 14px;
+import { useMembership } from '../../../context/membership'
+
+const typeListing = css`
+  display: block;
+  position: relative;
+  width: 100%;
+  margin: 0 auto;
+  font-size: 18px;
+  background: #f3f1e9;
+
+  #compass-fit-widget-content {
+    // Image
+    .listArticleBlock__figure {
+      position: relative;
+
+      // Label ('特企')
+      .listArticleBlock__figure--colorBlock {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        padding: 8px;
+        color: white;
+        font-size: 16px;
+        font-weight: 300;
+        background-color: #bcbcbc;
+
+        ${({ theme }) => theme.breakpoint.md} {
+          font-size: 18px;
+          font-weight: 600;
+          padding: 4px 20px;
+        }
+      }
+    }
+
+    .listArticleBlock__content {
+      margin: 20px 20px 36px 20px;
+
+      ${({ theme }) => theme.breakpoint.md} {
+        margin: 20px;
+      }
+      ${({ theme }) => theme.breakpoint.xl} {
+        margin: 8px 8px 40px 8px;
+      }
+
+      // Title
+      h2 {
+        color: #054f77;
+        line-height: 25px;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+
+        ${({ theme }) => theme.breakpoint.md} {
+          height: 75px;
+        }
+        ${({ theme }) => theme.breakpoint.xl} {
+          font-size: 18px;
+        }
+      }
+
+      // Description
+      p {
+        font-size: 16px;
+        color: #979797;
+        margin-top: 20px;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+
+        ${({ theme }) => theme.breakpoint.md} {
+          margin-top: 16px;
+        }
+        ${({ theme }) => theme.breakpoint.xl} {
+          margin-top: 20px;
+          -webkit-line-clamp: 4;
+        }
+      }
+    }
+  }
+`
+const typeHome = css`
+  display: flex;
+  width: 288px;
+  margin: 0 auto;
+  padding: 15px 0;
+  border-bottom: 1px solid #b8b8b8;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    position: relative;
+    margin: 0;
+    width: 244px;
+    padding: 0;
+    bottom: unset;
+  }
+
+  // Mobile: AD Image
+  > a {
+    display: inline-block;
+    position: relative;
+    height: 134px;
+    min-width: 134px;
+  }
+
+  // Mobile: AD Detail
+  .latest-list_item_title {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding-left: 20px;
+    //Since the advertiser uses inline-style to set the background-color, it is necessary to use !important.
+    background-color: #ffffff !important;
+
+    ${({ theme }) => theme.breakpoint.md} {
+      position: absolute;
+      bottom: 0;
+      z-index: 1;
+      padding-left: 0 !important;
+    }
+
+    // Mobile: AD Label('特企')
+    .latest-list_item_label {
+      width: fit-content;
+      height: 36px;
+      padding: 8px 10px;
+      text-align: center;
+      color: white;
+      font-size: 18px;
+      line-height: 20px;
+      font-weight: 400;
+    }
+
+    // AD Title
+    > a {
+      text-align: left;
+      width: 134px;
+      font-size: 18px;
+      line-height: 1.3;
+      font-weight: 400;
+      color: rgba(0, 0, 0, 0.66);
+
+      h3 {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
+        overflow: hidden;
+      }
+
+      ${({ theme }) => theme.breakpoint.md} {
+        width: 244px;
+        font-size: 16px;
+        line-height: 27px;
+        font-weight: 300;
+        color: white;
+        background-color: rgba(5, 79, 119, 0.8);
+        padding: 10px;
+
+        h3 {
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          -webkit-line-clamp: 2;
+          overflow: hidden;
+        }
+      }
+    }
+
+    // Mobile: AD Description Brief
+    span.brief {
+      display: none;
+    }
+  }
+
+  // Desktop: AD Container
+  .latest-list_item {
+    // Desktop: AD Image
+    > a {
+      ${({ theme }) => theme.breakpoint.md} {
+        display: inline-block;
+        position: relative;
+        width: 244px;
+        height: 170px;
+        position: relative;
+
+        .latest-list_item_img {
+          object-fit: cover;
+          height: 100%;
+        }
+      }
+    }
+
+    // Desktop: AD Label('特企')
+    .latest-list_item_label {
+      ${({ theme }) => theme.breakpoint.md} {
+        width: fit-content;
+        height: 36px;
+        padding: 8px 10px;
+        text-align: center;
+        color: white;
+        font-size: 18px;
+        line-height: 20px;
+        font-weight: 300;
+        position: absolute;
+        bottom: 0;
+        left: 0;
+      }
+    }
+  }
+`
+const typeStory = css`
+  ${({ theme }) => theme.breakpoint.xl} {
+    height: 90px;
+  }
+
+  // Micro AD container
+  #compass-fit-widget-content {
+    max-width: 280px;
+    font-size: 18px;
+    line-height: 1.5;
+    color: black;
+    font-weight: 400;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
+    ${({ theme }) => theme.breakpoint.md} {
+      max-width: 640px;
+      height: 90px;
+      flex-direction: row-reverse;
+      justify-content: space-between;
+      color: #808080;
+      background-color: rgb(244, 241, 233);
+      gap: 20px;
+    }
+
+    // AD Image
+    figure {
+      height: 186.67px;
+      position: relative;
+
+      img {
+        height: 100%;
+        object-fit: cover;
+      }
+
+      ${({ theme }) => theme.breakpoint.md} {
+        width: 87px;
+        min-width: 87px;
+        max-width: 87px;
+        height: 100%;
+      }
+    }
+
+    // AD Title
+    .pop_item_title {
+      ${({ theme }) => theme.breakpoint.md} {
+        position: relative;
+        padding: 16px 0 0 25.75px;
+        &::before {
+          position: absolute;
+          content: '';
+          width: 7.72px;
+          height: 100%;
+          background-color: #808080;
+          left: 0;
+          top: 0;
+        }
+      }
+    }
+
+    // AD Label('特企')
+    .pop_item--colorBlock {
+      padding: 4px;
+      background: #bcbcbc;
+      width: 48px;
+      height: 22px;
+      color: #ffffff;
+      font-style: normal;
+      font-weight: 300;
+      font-size: 20px;
       line-height: 14px;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+
+      ${({ theme }) => theme.breakpoint.md} {
+        width: 40px;
+        font-size: 16px;
+      }
+    }
+
+    .compass-fit-clear {
+      display: none;
+    }
+
+    // Desktop: Micro AD container
+    .popListVert-list__item {
+      ${({ theme }) => theme.breakpoint.xl} {
+        width: 100%;
+        display: flex;
+        flex-direction: row-reverse;
+        justify-content: space-between;
+        position: relative;
+        height: 100%;
+      }
+
+      // AD Image
+      > a {
+        ${({ theme }) => theme.breakpoint.xl} {
+          min-width: 135px;
+          max-width: 135px;
+
+          img {
+            height: 100%;
+            object-fit: cover;
+          }
+        }
+      }
+
+      .popListVert-list__item--text {
+        ${({ theme }) => theme.breakpoint.xl} {
+          // AD Label('特企')
+          > div {
+            padding: 4px;
+            background: #bcbcbc;
+            width: 48px;
+            height: 22px;
+            color: #ffffff;
+            font-style: normal;
+            font-weight: 300;
+            font-size: 20px;
+            line-height: 14px;
+            position: absolute;
+            bottom: 0;
+            right: 87px;
+          }
+
+          // AD Title
+          h2 {
+            display: block;
+            height: 100%;
+            position: relative;
+            padding: 16px 0 0 40px;
+            font-style: normal;
+            font-weight: 400;
+            font-size: 18px;
+            line-height: 1.3;
+            color: #808080;
+
+            &::before {
+              position: absolute;
+              content: '';
+              width: 10px;
+              height: 100%;
+              background-color: #808080;
+              left: 0;
+              top: 0;
+            }
+          }
+        }
+      }
     }
   }
 `
 
-export default function MicroAdWithLabel({ unitId }) {
-  return <StyledMicroAd unitId={unitId} />
+/**
+ * @typedef {import('../../../utils/ad').MicroAdType} MicroAdType
+ */
+/**
+ * @param {Object} props
+ * @param {MicroAdType} props.type
+ */
+const StyledMicroAd = styled(MicroAd)`
+  ${({ type }) => {
+    switch (type) {
+      case 'HOME':
+        return typeHome
+      case 'LISTING':
+        return typeListing
+      case 'STORY':
+        return typeStory
+      default:
+        return typeListing
+    }
+  }}
+`
+
+/**
+ * @param {Object} props
+ * @param {string} props.unitId
+ * @param {MicroAdType} props.microAdType
+ * @returns {JSX.Element}
+ */
+export default function MicroAdWithLabel({ unitId, microAdType }) {
+  const { memberInfo, isLogInProcessFinished } = useMembership()
+  const { memberType } = memberInfo
+
+  const [microAdJsx, setMicroAdJsx] = useState(null)
+
+  //When the user's member type is 'not-member', 'one-time-member', or 'basic-member', the AD should be displayed.
+
+  // Since the member type needs to be determined on the client-side, the rendering of `microAdJsx` should be done on the client-side.
+
+  useEffect(() => {
+    const invalidMemberType = ['not-member', 'one-time-member', 'basic-member']
+
+    if (isLogInProcessFinished) {
+      if (invalidMemberType.includes(memberType)) {
+        setMicroAdJsx(<StyledMicroAd unitId={unitId} type={microAdType} />)
+      } else {
+        return
+      }
+    }
+  }, [isLogInProcessFinished, memberType, microAdType, unitId])
+
+  return <>{microAdJsx}</>
 }

--- a/packages/mirror-media-next/components/ads/micro-ad/micro-ad.js
+++ b/packages/mirror-media-next/components/ads/micro-ad/micro-ad.js
@@ -1,6 +1,9 @@
 import { useEffect } from 'react'
 
 /**
+ * @typedef {import('../../../utils/ad').MicroAdType} MicroAdType
+ */
+/**
  * This is the base component to deal with MicroAd scripts and handle lifecycle.
  * Wrap this component by levarge the styled-components function [styling any component](https://styled-components.com/docs/basics#styling-any-component)
  * to maintain MicroAd's ad as separate component.
@@ -8,6 +11,7 @@ import { useEffect } from 'react'
  * @param {Object} props
  * @param {string} props.unitId - MicroAd's unit id to connect to MicroAd's script and style
  * @param {string} [props.className] - styled-components property to set style for a React Component
+ * @param {MicroAdType} props.type
  * @returns {React.ReactElement}
  */
 export default function MicroAd({ unitId, className }) {

--- a/packages/mirror-media-next/components/externals/externals-list.js
+++ b/packages/mirror-media-next/components/externals/externals-list.js
@@ -1,5 +1,15 @@
+import { Fragment } from 'react'
 import styled from 'styled-components'
+import dynamic from 'next/dynamic'
 import ExternalListItem from './externals-list-item'
+import { needInsertMicroAdAfter, getMicroAdUnitId } from '../../utils/ad'
+
+const StyledMicroAd = dynamic(
+  () => import('../../components/ads/micro-ad/micro-ad-with-label'),
+  {
+    ssr: false,
+  }
+)
 
 const ItemContainer = styled.div`
   display: grid;
@@ -29,8 +39,16 @@ const ItemContainer = styled.div`
 export default function ExternalList({ renderList }) {
   return (
     <ItemContainer>
-      {renderList.map((item) => (
-        <ExternalListItem key={item.id} item={item} />
+      {renderList.map((item, index) => (
+        <Fragment key={item.id}>
+          <ExternalListItem item={item} />
+          {needInsertMicroAdAfter(index) && (
+            <StyledMicroAd
+              unitId={getMicroAdUnitId(index, 'LISTING', 'RWD')}
+              microAdType="LISTING"
+            />
+          )}
+        </Fragment>
       ))}
     </ItemContainer>
   )

--- a/packages/mirror-media-next/components/latest-news.js
+++ b/packages/mirror-media-next/components/latest-news.js
@@ -1,11 +1,23 @@
+import { Fragment } from 'react'
 import styled from 'styled-components'
 import axios from 'axios'
+import dynamic from 'next/dynamic'
 import InfiniteScrollList from './infinite-scroll-list'
 import LoadingPage from '../public/images/loading_page.gif'
 import LatestNewsItem from './latest-news-item'
 import { transformRawDataToArticleInfo } from '../utils'
 import { URL_STATIC_POST_EXTERNAL } from '../config/index.mjs'
 import Image from 'next/legacy/image'
+import { needInsertMicroAdAfter, getMicroAdUnitId } from '../utils/ad'
+import useWindowDimensions from '../hooks/use-window-dimensions'
+import { mediaSize } from '../styles/media'
+
+const StyledMicroAd = dynamic(
+  () => import('../components/ads/micro-ad/micro-ad-with-label'),
+  {
+    ssr: false,
+  }
+)
 
 const Wrapper = styled.section`
   width: 100%;
@@ -135,6 +147,9 @@ export default function LatestNews(props) {
     return latestNews
   }
 
+  const { width } = useWindowDimensions()
+  const device = width >= mediaSize.md ? 'PC' : 'MB'
+
   return (
     <Wrapper>
       <h2>最新文章</h2>
@@ -151,8 +166,16 @@ export default function LatestNews(props) {
       >
         {(renderList) => (
           <ItemContainer>
-            {renderList.map((item) => (
-              <LatestNewsItem key={item.slug} itemData={item}></LatestNewsItem>
+            {renderList.map((item, index) => (
+              <Fragment key={item.slug}>
+                <LatestNewsItem itemData={item} />
+                {needInsertMicroAdAfter(index) && (
+                  <StyledMicroAd
+                    unitId={getMicroAdUnitId(index, 'HOME', device)}
+                    microAdType="HOME"
+                  />
+                )}
+              </Fragment>
             ))}
           </ItemContainer>
         )}

--- a/packages/mirror-media-next/components/shared/article-list.js
+++ b/packages/mirror-media-next/components/shared/article-list.js
@@ -1,5 +1,15 @@
+import { Fragment } from 'react'
 import styled from 'styled-components'
+import dynamic from 'next/dynamic'
 import ArticleListItem from './article-list-item'
+import { needInsertMicroAdAfter, getMicroAdUnitId } from '../../utils/ad'
+
+const StyledMicroAd = dynamic(
+  () => import('../../components/ads/micro-ad/micro-ad-with-label'),
+  {
+    ssr: false,
+  }
+)
 
 const ItemContainer = styled.div`
   display: grid;
@@ -31,8 +41,16 @@ const ItemContainer = styled.div`
 export default function ArticleList({ renderList, section }) {
   return (
     <ItemContainer>
-      {renderList.map((item) => (
-        <ArticleListItem key={item.id} item={item} section={section} />
+      {renderList.map((item, index) => (
+        <Fragment key={item.id}>
+          <ArticleListItem item={item} section={section} />
+          {needInsertMicroAdAfter(index) && (
+            <StyledMicroAd
+              unitId={getMicroAdUnitId(index, 'LISTING', 'RWD')}
+              microAdType="LISTING"
+            />
+          )}
+        </Fragment>
       ))}
     </ItemContainer>
   )

--- a/packages/mirror-media-next/components/story/normal/related-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/related-article-list.js
@@ -3,10 +3,17 @@
 import styled from 'styled-components'
 import Image from '@readr-media/react-image'
 import Link from 'next/link'
-import MicroAdWithLabel from '../../ads/micro-ad/micro-ad-with-label'
+import dynamic from 'next/dynamic'
 import useWindowDimensions from '../../../hooks/use-window-dimensions'
 import { mediaSize } from '../../../styles/media'
 import { MICRO_AD_UNITS } from '../../../constants/ads'
+
+const StyledMicroAd = dynamic(
+  () => import('../../../components/ads/micro-ad/micro-ad-with-label'),
+  {
+    ssr: false,
+  }
+)
 
 /**
  * @typedef {import('../../../apollo/fragments/post').HeroImage &
@@ -132,8 +139,7 @@ const AdvertisementWrapper = styled.div`
  */
 export default function RelatedArticleList({ relateds }) {
   const { width } = useWindowDimensions()
-  const isDesktopWidth = width >= mediaSize.xl
-  const device = isDesktopWidth ? 'PC' : 'MB'
+  const device = width >= mediaSize.xl ? 'PC' : 'MB'
 
   const relatedsArticleJsx = relateds.length ? (
     <ArticleWrapper>
@@ -169,17 +175,17 @@ export default function RelatedArticleList({ relateds }) {
     </ArticleWrapper>
   ) : null
 
+  const microAdJsx = MICRO_AD_UNITS.STORY[device].map((unit) => (
+    <StyledMicroAd key={unit.name} unitId={unit.id} microAdType="STORY" />
+  ))
+
   return (
     <Wrapper>
       <h2>延伸閱讀</h2>
       {relatedsArticleJsx}
       <AdvertisementWrapper>
-        特企區塊施工中......
-        {/* just a example, should be refactored as a separate componet including the device variable logic */}
-        {MICRO_AD_UNITS.STORY[device].map((unit) => (
-          <MicroAdWithLabel key={unit.name} unitId={unit.id} />
-        ))}
         {/* micro ad */}
+        {microAdJsx}
         {/* popin */}
       </AdvertisementWrapper>
     </Wrapper>

--- a/packages/mirror-media-next/utils/ad.js
+++ b/packages/mirror-media-next/utils/ad.js
@@ -1,0 +1,54 @@
+import { MICRO_AD_UNITS } from '../constants/ads'
+
+/**
+ * Determining whether to insert a `Micro` advertisement after a specific post index.
+ *
+ * @param {number} index
+ * @returns {boolean}
+ */
+const needInsertMicroAdAfter = (index = 0) => {
+  if (typeof index !== 'number') {
+    return false
+  }
+
+  return index === 1 || index === 3 || index === 5
+}
+
+/**
+ * @typedef {'HOME' | 'LISTING' | 'STORY' } MicroAdType
+ */
+/**
+ * @typedef {'PC' | 'MB' | 'RWD' } Device
+ */
+
+/**
+ * Determining which Micro advertisement ID to take based on the `index`.
+ *
+ * @param {number} index
+ * @param {MicroAdType} microAdType
+ * @param {Device} device
+ * @returns {string | null}
+ */
+const getMicroAdUnitId = (
+  index = 0,
+  microAdType = 'LISTING',
+  device = 'RWD'
+) => {
+  let unitId = null
+
+  if (typeof index !== 'number') {
+    return null
+  }
+
+  if (microAdType === 'LISTING') {
+    const unitIndex = Math.floor((index - 1) / 2)
+    unitId = MICRO_AD_UNITS.LISTING[device][unitIndex]?.id || null
+  } else if (microAdType === 'HOME') {
+    const unitIndex = Math.floor((index - 1) / 2)
+    unitId = MICRO_AD_UNITS.HOME[device][unitIndex]?.id || null
+  }
+
+  return unitId
+}
+
+export { needInsertMicroAdAfter, getMicroAdUnitId }


### PR DESCRIPTION
## Notable Change
- 傳入指定參數進 `StyledMicroAd`，以 render 不同頁面的 MicroAD 廣告樣式：
   - 傳入 `microAdType`，來顯示相對應的 `HOME`、`STORY`、`LISTING` 頁面廣告 css 樣式。
   - MicroAD 廣告樣式，統一在 `micro-ad-with-label.js` 管理 / 設定。

- 新增 utils `needInsertMicroAdAfter` ，安插廣告至指定位置（僅 `HOME`、`LISTING` 會使用到）
   - 傳入 map 的 index 數值，判斷是否需要安插 MicroAD 廣告。
   - 目前 `HOME`、`LISTING` 需求上固定為第 3、6、9 篇要安插一則廣告，`STORY` 則無此需求。
-  新增 utils `getMicroAdUnitId`，傳入指定參數以取得 unit ID：

    - 針對不同 `microAdType`（'HOME'、'STORY'、'LISTING'）和 `device` 大小（'RWD'、'PC'、'MB'），取得相對應的 `MICRO_AD_UNITS` 的 ID 資料。

- 判斷是否顯示 Micro AD 廣告：
   - 如使用者：未登入 或 memberType = `one-time-member` | `basic-member` | `not-member`，則會顯示廣告，其餘狀態不顯示廣告。
   - 由於 memberType 是在 client-side 端才確認，因此修改 Micro 廣告於 client-side 端才 render，並增加條件判定：確認當 `isLogInProcessFinished` 為 true 後（即 useContext 確認完 login 狀態後），才進一步對 member type 作類別判定，以避免廣告閃現問題。
   - 各頁面也統一修改為透過 `next/dynamic` 動態載入 Micro 元件，統一於 client-side 端處理廣告元件。

## 影響頁面
- `HOME`：首頁 `/index`
- `STORY`：一般文章頁 `/story/[slug]` - normal
- `LISTING`：各列表頁

   - 作者列表 `/author/[id]`
   - category 列表 `/category/[slug]`
   - 生活暖流列表 `/externals/warmlife`
   - 合作夥伴列表 `/externals/[partnerSlug]`
   - tag列表 `/tag/[slug]`
   - section列表 `/section/[slug]`
   
## 開發
- MicroAd 廣告可以在 local 上直接測試。
- 實作測試會員登入，需要這樣做（感謝典洋補充）：

   - 先在本地端起2.0 (mirror-media-nuxt)，並在2.0登入
   - 登入完畢後，關掉2.0 server。
   - 改起3.0 server。
   - 如果步驟一跟步驟三，server都是在localhost:3000的話，起3.0 server時，firebase會記住你在2.0時的登入狀況，並取得firebase id token。

## Related PR
- https://github.com/mirror-media/Adam/pull/294
- [Micro Ad 設定](https://github.com/mirror-media/Adam/pull/227)
- [週刊 2.0 MicroAD nuxt](https://github.com/mirror-media/mirror-media-nuxt/blob/dev/components/UiArticleList.vue#L22-L41)

## Reference
- [2.0 廣告大全: MicroAd](https://paper.dropbox.com/doc/--B5HoYJJCDi3wuLktiME_oi2YAg-UtXMJmDEubtFfxcoB3zZ9#:uid=071423843947501619480333&h2=Micro-Ad-%EF%BC%88%E5%BE%AE%E5%91%8A%EF%BC%89)
- [週刊3.0 廣告顯示整理](https://paper.dropbox.com/doc/3.0--B53VMW_QOKXDKGMyEKqAjXvsAg-CEkZYSHEzyntVmsMLzUk5)