### PR TITLE
feat(mm-next): add error handle in index page

### DIFF
--- a/packages/mirror-media-next/components/editor-choice.js
+++ b/packages/mirror-media-next/components/editor-choice.js
@@ -188,61 +188,70 @@ const EditorChoiceContainer = styled.section`
  * @param {import('../type/index').ArticleInfoCard[]} props.editorChoice
  * @returns {React.ReactElement}
  */
-export default function EditorChoice({ editorChoice }) {
+export default function EditorChoice({ editorChoice = [] }) {
+  const shouldShowEditorChoice = editorChoice.length !== 0
   return (
-    <EditorChoiceContainer>
-      <List>
-        <h2>編輯精選</h2>
-        {editorChoice.map((item) => (
-          <ListItem
-            key={item.slug}
-            href={item.href}
-            target="_blank"
-            rel="noreferrer noopenner"
-          >
-            <ListItemLabel sectionName={item.sectionName}>
-              {item.sectionTitle}
-            </ListItemLabel>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={item.imgSrcTablet || '/images/default-og-img.png'}
-              alt={item.title}
-            ></img>
-            <p className="title">{item.title}</p>
-          </ListItem>
-        ))}
-      </List>
-      <SlideShow>
-        <h2>編輯精選</h2>
-        <Swiper
-          spaceBetween={100}
-          centeredSlides={true}
-          autoplay={{
-            delay: 4000,
-            disableOnInteraction: false,
-          }}
-          pagination={{
-            clickable: true,
-          }}
-          loop={true}
-          speed={750}
-          navigation={true}
-          modules={[Autoplay, Pagination, Navigation]}
-        >
-          {editorChoice.map((item) => (
-            <SwiperSlide key={item.slug}>
-              <a href={item.href} target="_blank" rel="noreferrer noopenner">
+    <>
+      {shouldShowEditorChoice ? (
+        <EditorChoiceContainer>
+          <List>
+            <h2>編輯精選</h2>
+            {editorChoice.map((item) => (
+              <ListItem
+                key={item.slug}
+                href={item.href}
+                target="_blank"
+                rel="noreferrer noopenner"
+              >
+                <ListItemLabel sectionName={item.sectionName}>
+                  {item.sectionTitle}
+                </ListItemLabel>
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   src={item.imgSrcTablet || '/images/default-og-img.png'}
                   alt={item.title}
-                />
+                ></img>
                 <p className="title">{item.title}</p>
-              </a>
-            </SwiperSlide>
-          ))}
-        </Swiper>
-      </SlideShow>
-    </EditorChoiceContainer>
+              </ListItem>
+            ))}
+          </List>
+          <SlideShow>
+            <h2>編輯精選</h2>
+            <Swiper
+              spaceBetween={100}
+              centeredSlides={true}
+              autoplay={{
+                delay: 4000,
+                disableOnInteraction: false,
+              }}
+              pagination={{
+                clickable: true,
+              }}
+              loop={true}
+              speed={750}
+              navigation={true}
+              modules={[Autoplay, Pagination, Navigation]}
+            >
+              {editorChoice.map((item) => (
+                <SwiperSlide key={item.slug}>
+                  <a
+                    href={item.href}
+                    target="_blank"
+                    rel="noreferrer noopenner"
+                  >
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={item.imgSrcTablet || '/images/default-og-img.png'}
+                      alt={item.title}
+                    />
+                    <p className="title">{item.title}</p>
+                  </a>
+                </SwiperSlide>
+              ))}
+            </Swiper>
+          </SlideShow>
+        </EditorChoiceContainer>
+      ) : null}
+    </>
   )
 }

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -129,15 +129,23 @@ export async function getServerSideProps({ res, req }) {
   let latestNewsData = []
   let sectionsData = []
   try {
+    const postResponse = await axios({
+      method: 'get',
+      url: `${URL_STATIC_POST_EXTERNAL}032311.json`,
+      timeout: API_TIMEOUT,
+    })
+    editorChoicesData = Array.isArray(postResponse?.data?.choices)
+      ? postResponse?.data?.choices
+      : []
+
+    latestNewsData = Array.isArray(postResponse?.data?.latest)
+      ? postResponse?.data?.latest
+      : []
+
     const responses = await Promise.allSettled([
       axios({
         method: 'get',
         url: URL_STATIC_POST_FLASH_NEWS,
-        timeout: API_TIMEOUT,
-      }),
-      axios({
-        method: 'get',
-        url: `${URL_STATIC_POST_EXTERNAL}01.json`,
         timeout: API_TIMEOUT,
       }),
       fetchHeaderDataInDefaultPageLayout(),
@@ -157,21 +165,23 @@ export async function getServerSideProps({ res, req }) {
         const rejectedReason = response.reason
         const annotatingAxiosError =
           errors.helpers.annotateAxiosError(rejectedReason)
+        const errorMessage = errors.helpers.printAll(
+          annotatingAxiosError,
+          {
+            withStack: true,
+            withPayload: false,
+          },
+          0,
+          0
+        )
         console.error(
           JSON.stringify({
             severity: 'ERROR',
-            message: errors.helpers.printAll(
-              annotatingAxiosError,
-              {
-                withStack: true,
-                withPayload: true,
-              },
-              0,
-              0
-            ),
+            message: errorMessage,
             ...globalLogFields,
           })
         )
+        throw new Error(errorMessage)
       }
     })
 
@@ -179,77 +189,51 @@ export async function getServerSideProps({ res, req }) {
     const flashNewsResponse =
       responses[0].status === 'fulfilled' && responses[0]
 
-    /** @type {PromiseFulfilledResult<AxiosPostResponse>} */
-    const postResponse = responses[1].status === 'fulfilled' && responses[1]
     const headerDataResponse =
-      responses[2].status === 'fulfilled' && responses[2]
+      responses[1].status === 'fulfilled' && responses[1]
+
     flashNewsData = Array.isArray(flashNewsResponse.value?.data?.posts)
       ? flashNewsResponse.value?.data?.posts
       : []
-    editorChoicesData = Array.isArray(postResponse.value?.data?.choices)
-      ? postResponse.value?.data?.choices
-      : []
-    latestNewsData = Array.isArray(postResponse.value?.data?.latest)
-      ? postResponse.value?.data?.latest
-      : []
+
     sectionsData = Array.isArray(headerDataResponse.value?.sectionsData)
       ? headerDataResponse.value?.sectionsData
       : []
     topicsData = Array.isArray(headerDataResponse.value?.topicsData)
       ? headerDataResponse.value?.topicsData
       : []
+
+    return {
+      props: {
+        topicsData,
+        flashNewsData,
+        editorChoicesData,
+        latestNewsData,
+        sectionsData,
+      },
+    }
   } catch (err) {
     const annotatingError = errors.helpers.wrap(
       err,
       'UnhandledError',
       'Error occurs while getting index page data'
     )
-
+    const errorMessage = errors.helpers.printAll(
+      annotatingError,
+      {
+        withStack: true,
+        withPayload: false,
+      },
+      0,
+      0
+    )
     console.log(
       JSON.stringify({
         severity: 'ERROR',
-        message: errors.helpers.printAll(
-          annotatingError,
-          {
-            withStack: true,
-            withPayload: true,
-          },
-          0,
-          0
-        ),
+        message: errorMessage,
         ...globalLogFields,
       })
     )
-  }
-  try {
-    const headerData = await fetchHeaderDataInDefaultPageLayout()
-    sectionsData = headerData.sectionsData
-    topicsData = headerData.topicsData
-  } catch (error) {
-    console.error(
-      JSON.stringify({
-        severity: 'ERROR',
-        message: errors.helpers.printAll(
-          error,
-          {
-            withStack: true,
-            withPayload: true,
-          },
-          0,
-          0
-        ),
-        ...globalLogFields,
-      })
-    )
-  }
-
-  return {
-    props: {
-      topicsData,
-      flashNewsData,
-      editorChoicesData,
-      latestNewsData,
-      sectionsData,
-    },
+    throw new Error(errorMessage)
   }
 }


### PR DESCRIPTION
## Notable Change
1.  於首頁新增錯誤處理。
2. 將`post_external01.json`改為使用async/await去抓取資料，這代表如果fetch失敗的話，會直接顯示500頁。
3. 如果日後需要將`post_external01.json`的Promise改為「fetch失敗的話僅不顯示資料，而不顯示500頁」，需改為原本所使用的`Promise.allSettled`。