### PR TITLE
feat(mm-mext/premium): conditionally render either `SupportMirrorMediaBanner` or `SupportSingleArticleBanner` based on memberType

### DIFF
--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -14,7 +14,7 @@ import AsideArticleList from '../../../components/story/normal/aside-article-lis
 import FbPagePlugin from '../../../components/story/normal/fb-page-plugin'
 import SocialNetworkService from '../../../components/story/normal/social-network-service'
 import SubscribeInviteBanner from '../../../components/story/normal/subscribe-invite-banner'
-import DonateBanner from '../../../components/story/shared/donate-banner'
+import SupportMirrorMediaBanner from '../../../components/story/shared/support-mirrormedia-banner'
 import MagazineInviteBanner from '../../../components/story/shared/magazine-invite-banner'
 import RelatedArticleList from '../../../components/story/normal/related-article-list'
 import ArticleContent from './article-content'
@@ -533,7 +533,7 @@ export default function StoryNormalStyle({ postData, postContent }) {
             <span>更新時間｜</span>
             <span className="time">{updatedTaipeiTime} 臺北時間</span>
           </DateUnderContent>
-          <DonateBanner />
+          <SupportMirrorMediaBanner />
           <SocialNetworkServiceSmall />
           <SubscribeInviteBanner />
           <RelatedArticleList relateds={relatedsWithOrdered} />

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -14,7 +14,7 @@ import AsideArticleList from '../../../components/story/normal/aside-article-lis
 import FbPagePlugin from '../../../components/story/normal/fb-page-plugin'
 import SocialNetworkService from '../../../components/story/normal/social-network-service'
 import SubscribeInviteBanner from '../../../components/story/normal/subscribe-invite-banner'
-import SupportMirrorMediaBanner from '../../../components/story/shared/support-mirrormedia-banner'
+import SupportMirrorMediaBanner from '../shared/support-mirrormedia-banner'
 import MagazineInviteBanner from '../../../components/story/shared/magazine-invite-banner'
 import RelatedArticleList from '../../../components/story/normal/related-article-list'
 import ArticleContent from './article-content'

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -7,7 +7,8 @@ import { sortArrayWithOtherArrayId } from '../../../utils'
 import errors from '@twreporter/errors'
 import TitleAndInfoAndHero from './title-and-info-and-hero'
 import CopyrightWarning from '../shared/copyright-warning'
-import DonateBanner from '../shared/donate-banner'
+import SupportMirrorMediaBanner from '../shared/support-mirrormedia-banner'
+import SupportSingleArticleBanner from '../shared/support-single-article-banner'
 import Aside from '../shared/aside'
 import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
 import NavSubtitleNavigator from '../shared/nav-subtitle-navigator'
@@ -274,7 +275,11 @@ export default function StoryPremiumStyle({ postData, postContent }) {
             </section>
             <CopyrightWarning />
             {shouldShowArticleMask && <ArticleMask postId={id} />}
-            <DonateBanner />
+            {memberType === 'one-time-member' ? (
+              <SupportMirrorMediaBanner />
+            ) : (
+              <SupportSingleArticleBanner />
+            )}
           </ContentWrapper>
         </article>
       </Main>

--- a/packages/mirror-media-next/components/story/shared/support-mirrormedia-banner.js
+++ b/packages/mirror-media-next/components/story/shared/support-mirrormedia-banner.js
@@ -1,0 +1,99 @@
+import styled from 'styled-components'
+import DonateLink from './donate-link'
+import SubscribeLink from './subscribe-link'
+
+const Container = styled.div`
+  margin: 32px 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 20px;
+  background: linear-gradient(90deg, #61b8c6 0%, #054f77 100%);
+  box-shadow: 0px 4px 28px rgba(0, 0, 0, 0.06), 0px 2px 12px rgba(0, 0, 0, 0.08);
+  border-radius: 24px;
+
+  .title {
+    color: white;
+    font-family: 'PingFang TC';
+    font-weight: 600;
+    font-size: 24px;
+    line-height: 200%;
+    margin-bottom: 8px;
+  }
+`
+
+const InnerWrapper = styled.div`
+  display: grid;
+  grid-template-rows: auto;
+  gap: 12px;
+  grid-gap: 12px;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    grid-template-columns: 1fr 1fr;
+  }
+`
+
+const InnerBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  background: #ffffff;
+  border-radius: 8px;
+
+  .desc {
+    font-family: 'PingFang TC';
+    font-weight: 400;
+    font-size: 18px;
+    line-height: 150%;
+    text-align: center;
+    color: rgba(0, 0, 0, 0.87);
+    margin-bottom: 16px;
+  }
+
+  .banner-button {
+    width: 100%;
+    height: 70px;
+    padding: 20px;
+    font-family: 'PingFang TC';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 20px;
+    text-align: center;
+    color: white;
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    border-radius: 24px;
+    flex: none;
+    flex-grow: 0;
+    img {
+      width: 20px;
+      height: 20px;
+    }
+  }
+`
+
+/**
+ *
+ * @param {Object} props
+ * @param {string} [props.className]
+ * @returns {JSX.Element}
+ */
+export default function SupportMirrorMediaBanner({ className }) {
+  return (
+    <Container className={className}>
+      <p className="title">支持鏡週刊</p>
+      <InnerWrapper>
+        <InnerBox>
+          <p className="desc">小心意大意義，小額贊助鏡週刊！</p>
+          <DonateLink className="banner-button" />
+        </InnerBox>
+        <InnerBox>
+          <p className="desc">每月 $49 元全站看到飽，暢享無廣告閱讀體驗</p>
+          <SubscribeLink className="banner-button" />
+        </InnerBox>
+      </InnerWrapper>
+    </Container>
+  )
+}

--- a/packages/mirror-media-next/components/story/shared/support-single-article-banner.js
+++ b/packages/mirror-media-next/components/story/shared/support-single-article-banner.js
@@ -1,0 +1,72 @@
+import styled from 'styled-components'
+import DonateLink from './donate-link'
+
+const Container = styled.div`
+  margin: 32px 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 24px 60px;
+  background: #ffffff;
+  box-shadow: 0px 4px 28px rgba(0, 0, 0, 0.06), 0px 2px 12px rgba(0, 0, 0, 0.08);
+  border-radius: 24px;
+
+  .title {
+    color: white;
+    font-family: 'PingFang TC';
+    margin-bottom: 12px;
+    font-weight: 500;
+    font-size: 18px;
+    line-height: 150%;
+    color: rgba(0, 0, 0, 0.87);
+    text-align: center;
+  }
+
+  .desc {
+    font-family: 'PingFang TC';
+    margin-bottom: 12px;
+    font-style: normal;
+    font-weight: 500;
+    font-size: 14px;
+    line-height: 200%;
+    color: rgba(0, 0, 0, 0.5);
+    text-align: center;
+  }
+
+  .banner-button {
+    width: 100%;
+    height: 70px;
+    padding: 20px;
+    font-family: 'PingFang TC';
+    font-style: normal;
+    font-weight: 500;
+    font-size: 20px;
+    text-align: center;
+    color: white;
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    border-radius: 24px;
+    flex: none;
+    flex-grow: 0;
+    img {
+      width: 20px;
+      height: 20px;
+    }
+  }
+`
+
+/**
+ *
+ * @param {Object} props
+ * @param {string} [props.className]
+ * @returns {JSX.Element}
+ */
+export default function SupportMirrorMediaBanner({ className }) {
+  return (
+    <Container className={className}>
+      <p className="title">小心意大意義，小額贊助鏡週刊！</p>
+      {/* <p className="desc">目前已有 123,456 人贊助本文</p> */}
+      <DonateLink className="banner-button" />
+    </Container>
+  )
+}

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -11,7 +11,7 @@ import DonateLink from '../shared/donate-link'
 import SubscribeLink from '../shared/subscribe-link'
 import HeroImageAndVideo from '../shared/hero-image-and-video'
 import Credits from '../shared/credits'
-import DonateBanner from '../shared/donate-banner'
+import SupportMirrorMediaBanner from '../shared/support-mirrormedia-banner'
 import NavSubtitleNavigator from '../shared/nav-subtitle-navigator'
 import MoreInfoAndTag from '../shared/more-info-and-tag'
 import Date from '../shared/date'
@@ -69,11 +69,6 @@ const ContentWrapper = styled.section`
       margin: 40px auto 0;
     }
   }
-`
-const StyledDonateBanner = styled(DonateBanner)`
-  margin-left: auto;
-  margin-right: auto;
-  width: 100%;
 `
 
 const SocialMediaAndDonateLink = styled.ul`
@@ -217,7 +212,7 @@ export default function StoryWideStyle({ postData, postContent }) {
               />
             </section>
             <MoreInfoAndTag tags={tags} />
-            <StyledDonateBanner />
+            <SupportMirrorMediaBanner />
           </ContentWrapper>
           <Aside
             relateds={relatedsWithOrdered}


### PR DESCRIPTION
- 於一般文章頁新增`SupportMirrorMediaBanner` 
- 於wide文章頁新增`SupportMirrorMediaBanner` 
- premium 文章頁未截斷內文，若memberType = 'one-time-member' 新增 `SupportMirrorMediaBanner`，其餘新增 `SupportSingleArticleBanner`
