### PR TITLE
fix(mm-next/premium): modify support banner showing logic

### DIFF
--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -206,6 +206,15 @@ export default function StoryPremiumStyle({ postData, postContent }) {
   const { memberInfo } = useMembership()
   const { memberType } = memberInfo
 
+  let supportBanner
+  if (postContent.type === 'fullContent') {
+    if (memberType === 'one-time-member') {
+      supportBanner = <SupportMirrorMediaBanner />
+    } else {
+      supportBanner = <SupportSingleArticleBanner />
+    }
+  }
+
   return (
     <>
       {isHeaderDataLoaded ? (
@@ -275,17 +284,7 @@ export default function StoryPremiumStyle({ postData, postContent }) {
             </section>
             <CopyrightWarning />
             {shouldShowArticleMask && <ArticleMask postId={id} />}
-            {!(
-              memberType === 'not-member' || memberType === 'basic-member'
-            ) && (
-              <div>
-                {memberType === 'one-time-member' ? (
-                  <SupportMirrorMediaBanner />
-                ) : (
-                  <SupportSingleArticleBanner />
-                )}
-              </div>
-            )}
+            {supportBanner}
           </ContentWrapper>
         </article>
       </Main>


### PR DESCRIPTION
改成用  `postContent.type` 來判斷是否顯示 support banner，能夠看到全文的使用者，才能看到這個 banner。其中，若使用者為 `one-time-member` 顯示「支持鏡週刊」banner，若非` one-time-member`，則顯示「贊助單篇文章」banner。