### PR TITLE
fix(mm-next/photography): solve the awkward scrolling issue in Safari

### DIFF
--- a/packages/mirror-media-next/components/story/photography/index.js
+++ b/packages/mirror-media-next/components/story/photography/index.js
@@ -12,6 +12,15 @@ import RelatedPosts from './related-posts'
 import { ArrowDown } from './icons'
 import Footer from '../../shared/footer'
 
+/**
+ * Determines if the current browser is Safari.
+ *
+ * @return {boolean} Returns true if the browser is Safari, false otherwise.
+ */
+const isSafari = () => {
+  return /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+}
+
 const Main = styled.main`
   margin: auto;
   padding-bottom: 40px;
@@ -37,7 +46,10 @@ const Main = styled.main`
 
   // Snap scrolling effect
   height: 100vh;
-  scroll-snap-type: y mandatory;
+  scroll-snap-type: ${({
+    // @ts-ignore
+    isSafari,
+  }) => (isSafari ? 'y proximity' : 'y mandatory ')};
   overflow: auto;
 
   // Hide the scroll bar
@@ -215,8 +227,17 @@ export default function StoryPhotographyStyle({ postData, postContent }) {
     setIsTransparent((prevState) => !prevState)
   }
 
+  const [isSafariDevice, setIsSafariDevice] = useState(false)
+
+  useEffect(() => {
+    setIsSafariDevice(isSafari())
+  }, [])
+
   return (
-    <Main>
+    <Main
+      // @ts-ignore
+      isSafari={isSafariDevice}
+    >
       <Header />
       <Page>
         <HeroSection


### PR DESCRIPTION
- `isSafari` function: Determines if the current browser is Safari by checking the user agent string.
- Sets the `scroll-snap-type` CSS property based on the value of the isSafari prop.
  - If isSafari is true, sets scroll-snap-type to `y proximity` 
  - If isSafari is false, sets scroll-snap-type to `y mandatory`