### PR TITLE
feat(mm-next): handle error on header/premium-header

### DIFF
--- a/packages/mirror-media-next/components/header.js
+++ b/packages/mirror-media-next/components/header.js
@@ -10,6 +10,186 @@ import {
 
 const DISPLAY_PARTNERS = [{ name: '生活暖流', href: '/externals/warmlife' }]
 
+const DEFAULT_NORMAL_SECTIONS_DATA = [
+  {
+    id: '42',
+    slug: 'member',
+    name: '會員專區',
+    categories: [
+      { id: '11', slug: 'food', name: '美食焦點', isMemberOnly: true },
+      { id: '12', slug: 'traveltaiwan', name: '旅行台灣', isMemberOnly: true },
+      { id: '17', slug: 'seetheworld', name: '看見世界', isMemberOnly: true },
+      { id: '18', slug: 'kitchenplay', name: '廚房密技', isMemberOnly: true },
+      { id: '29', slug: 'money', name: '理財', isMemberOnly: true },
+      { id: '35', slug: 'celebrity', name: '鏡大咖', isMemberOnly: true },
+      { id: '37', slug: 'column', name: '影劇專欄', isMemberOnly: true },
+      { id: '45', slug: 'wine', name: '好酒情報', isMemberOnly: true },
+      { id: '59', slug: 'somebody', name: '一鏡到底', isMemberOnly: true },
+      { id: '60', slug: 'world', name: '鏡相人間', isMemberOnly: true },
+      { id: '61', slug: 'truth', name: '心內話', isMemberOnly: true },
+      { id: '62', slug: 'mogul', name: '財經人物', isMemberOnly: true },
+      { id: '104', slug: 'timesquare', name: '時代現場', isMemberOnly: true },
+      { id: '122', slug: 'mg', name: '完整全文', isMemberOnly: false },
+      { id: '123', slug: 'dig', name: '新聞深探', isMemberOnly: true },
+    ],
+  },
+  {
+    id: '32',
+    slug: 'news',
+    name: '時事',
+    categories: [
+      { id: '19', slug: 'shopping', name: '消費', isMemberOnly: false },
+      { id: '27', slug: 'news', name: '焦點', isMemberOnly: false },
+      { id: '55', slug: 'political', name: '政治', isMemberOnly: false },
+      { id: '56', slug: 'life', name: '生活', isMemberOnly: false },
+      { id: '57', slug: 'city-news', name: '社會', isMemberOnly: false },
+      { id: '108', slug: 'boom', name: '鏡爆', isMemberOnly: false },
+      { id: '109', slug: 'global', name: '國際要聞', isMemberOnly: false },
+      { id: '118', slug: 'wine1', name: '微醺酩品', isMemberOnly: false },
+    ],
+  },
+  {
+    id: '37',
+    slug: 'businessmoney',
+    name: '財經理財',
+    categories: [
+      { id: '28', slug: 'business', name: '財經', isMemberOnly: false },
+      { id: '29', slug: 'money', name: '理財', isMemberOnly: true },
+    ],
+  },
+  {
+    id: '33',
+    slug: 'entertainment',
+    name: '娛樂',
+    categories: [
+      { id: '34', slug: 'latestnews', name: '娛樂頭條', isMemberOnly: false },
+      { id: '35', slug: 'celebrity', name: '鏡大咖', isMemberOnly: true },
+      { id: '37', slug: 'column', name: '影劇專欄', isMemberOnly: true },
+      { id: '46', slug: 'insight', name: '娛樂透視', isMemberOnly: false },
+      { id: '58', slug: 'comic', name: '動漫遊戲', isMemberOnly: false },
+      { id: '71', slug: 'rookie', name: '試鏡間', isMemberOnly: false },
+      { id: '72', slug: 'fashion', name: '穿衣鏡', isMemberOnly: false },
+      { id: '73', slug: 'madam', name: '蘭蘭夫人', isMemberOnly: false },
+      {
+        id: '74',
+        slug: 'superstar',
+        name: '我眼中的大明星',
+        isMemberOnly: false,
+      },
+    ],
+  },
+  {
+    id: '39',
+    slug: 'videohub',
+    name: '影音',
+    categories: [
+      {
+        id: '75',
+        slug: 'video_coverstory',
+        name: '鏡封面',
+        isMemberOnly: false,
+      },
+      {
+        id: '76',
+        slug: 'video_entertainment',
+        name: '鏡娛樂',
+        isMemberOnly: false,
+      },
+      { id: '77', slug: 'video_society', name: '鏡社會', isMemberOnly: false },
+      {
+        id: '78',
+        slug: 'video_investigation',
+        name: '鏡調查',
+        isMemberOnly: false,
+      },
+      {
+        id: '79',
+        slug: 'video_finance',
+        name: '財經理財',
+        isMemberOnly: false,
+      },
+      { id: '80', slug: 'video_people', name: '鏡人物', isMemberOnly: false },
+      {
+        id: '81',
+        slug: 'video_foodtravel',
+        name: '鏡食旅',
+        isMemberOnly: false,
+      },
+      {
+        id: '82',
+        slug: 'video_ent_perspective',
+        name: '娛樂透視',
+        isMemberOnly: false,
+      },
+      {
+        id: '83',
+        slug: 'video_carandwatch',
+        name: '汽車鐘錶',
+        isMemberOnly: false,
+      },
+    ],
+  },
+  {
+    id: '44',
+    slug: 'mirrorcolumn',
+    name: '論壇',
+    categories: [
+      {
+        id: '116',
+        slug: 'mirrorcolumn',
+        name: '名家專欄',
+        isMemberOnly: false,
+      },
+    ],
+  },
+  { id: '38', slug: 'mafalda', name: '瑪法達', categories: [] },
+  {
+    id: '36',
+    slug: 'culture',
+    name: '文化',
+    categories: [
+      {
+        id: '84',
+        slug: 'knowledgeprogram',
+        name: '知識好好玩',
+        isMemberOnly: false,
+      },
+      { id: '85', slug: 'bookreview', name: '書評', isMemberOnly: false },
+      { id: '86', slug: 'culture-column', name: '專欄', isMemberOnly: false },
+      { id: '87', slug: 'poem', name: '詩', isMemberOnly: false },
+      { id: '105', slug: 'booksummary', name: '鏡書摘', isMemberOnly: false },
+      { id: '120', slug: 'voice', name: '好聽人物', isMemberOnly: false },
+    ],
+  },
+  {
+    id: '30',
+    slug: 'carandwatch',
+    name: '汽車鐘錶',
+    categories: [
+      { id: '21', slug: 'watchfocus', name: '錶壇焦點', isMemberOnly: false },
+      { id: '22', slug: 'watchfeature', name: '鐘錶專題', isMemberOnly: false },
+      { id: '25', slug: 'blog', name: '編輯幕後', isMemberOnly: false },
+      { id: '66', slug: 'car_focus', name: '車壇焦點', isMemberOnly: false },
+      { id: '67', slug: 'car_features', name: '鏡車專題', isMemberOnly: false },
+      { id: '68', slug: 'test_drives', name: '靚俥試駕', isMemberOnly: false },
+      { id: '69', slug: 'pit_zone', name: '鏡車經', isMemberOnly: false },
+      {
+        id: '117',
+        slug: 'newwatches2021',
+        name: '新錶2021',
+        isMemberOnly: false,
+      },
+      { id: '121', slug: 'luxury', name: '奢華誌', isMemberOnly: false },
+      {
+        id: '124',
+        slug: 'newwatches2022',
+        name: '新錶2022',
+        isMemberOnly: false,
+      },
+    ],
+  },
+]
+
 import SubBrandList from './sub-brand-list'
 import SearchBarDesktop from './search-bar-desktop'
 import PromotionLinks from './promotion-links'
@@ -154,7 +334,7 @@ function filterOutIsMemberOnlyCategoriesInNormalSection(section) {
 }
 
 /**
- * Remove item from array `categories` if which is member only category.
+ *
  * @param {import('../apollo/fragments/section').Section} section
  * @return {SectionWithHrefTemp}
  */
@@ -194,6 +374,40 @@ function getSectionAndCategoryHref(section) {
   return newSection
 }
 
+const insertMagazineIntoSections = (section) => {
+  if (section.slug === 'member') {
+    return {
+      ...section,
+      categories: [
+        {
+          id: '7a7482edb739242537f11e24760d2c79', //hash for ensure it is unique from other category, no other usage.
+          slug: 'magazine',
+          name: '動態雜誌',
+          isMemberOnly: false,
+        },
+        ...section.categories,
+      ],
+    }
+  }
+  return { ...section }
+}
+/**
+ *
+ * @param {Sections} sectionsData
+ * @returns {SectionWithHrefTemp[]}
+ */
+const formatSections = (sectionsData) => {
+  const _sectionsData =
+    sectionsData && sectionsData.length
+      ? sectionsData
+      : DEFAULT_NORMAL_SECTIONS_DATA
+  return (
+    _sectionsData
+      .map(insertMagazineIntoSections)
+      .map(filterOutIsMemberOnlyCategoriesInNormalSection)
+      .map(getSectionAndCategoryHref) ?? []
+  )
+}
 /**
  * TODO: use typedef in `../apollo/fragments/section` and  `../apollo/fragments/topic`
  * Should be done after fetch header data from new json file
@@ -208,6 +422,8 @@ export default function Header({
   topicsData = [],
   children = null,
 }) {
+  const sections = formatSections(sectionsData)
+  const topics = topicsData && topicsData.length ? topicsData.slice(0, 9) : []
   const [showSearchField, setShowSearchField] = useState(false)
   const [searchTerms, setSearchTerms] = useState('')
   const mobileSearchButtonRef = useRef(null)
@@ -249,12 +465,6 @@ export default function Header({
     if (trimedSearchTerms === '') return setSearchTerms('')
     location.assign(`${SEARCH_URL}/search/v3/${trimedSearchTerms}`)
   }
-
-  const sections =
-    sectionsData
-      .map(filterOutIsMemberOnlyCategoriesInNormalSection)
-      .map(getSectionAndCategoryHref) ?? []
-  const topics = topicsData.slice(0, 9)
 
   return (
     <HeaderWrapper>

--- a/packages/mirror-media-next/components/header.js
+++ b/packages/mirror-media-next/components/header.js
@@ -207,6 +207,7 @@ import { SEARCH_URL } from '../config/index.mjs'
  *
  *  @typedef {import('../apollo/fragments/section').Section[]} Sections
  */
+
 /**
  * @typedef {import('./nav-sections').SectionWithHrefTemp} SectionWithHrefTemp
  */

--- a/packages/mirror-media-next/components/premium-header.js
+++ b/packages/mirror-media-next/components/premium-header.js
@@ -204,19 +204,10 @@ const MobilePremiumMemberLoginButton = styled(PremiumMemberLoginButton)`
 
 /**
  *
- * @typedef PremiumHeaderCategory
- * @property {string} id
- * @property {string} name
- * @property {string} slug
- *
- * @typedef PremiumHeaderSection
- * @property {string} id
- * @property {string} name
- * @property {string} slug
- * @property {PremiumHeaderCategory[]} categories
+ * @typedef {import('../apollo/fragments/section').Section[]} PremiumHeaderSections
  *
  * @typedef PremiumHeaderData
- * @property {PremiumHeaderSection[]} sections
+ * @property {PremiumHeaderSections} sections
  */
 
 /**

--- a/packages/mirror-media-next/components/premium-header.js
+++ b/packages/mirror-media-next/components/premium-header.js
@@ -10,6 +10,56 @@ import PremiumNavSections from './premium-nav-sections'
 import PremiumMemberLoginButton from './premium-member-login-button'
 import { SEARCH_URL } from '../config/index.mjs'
 
+const DEFAULT_PREMIUM_SECTIONS_DATA = [
+  {
+    id: '37',
+    name: '財經理財',
+    slug: 'businessmoney',
+    categories: [{ id: '29', name: '理財', slug: 'money' }],
+  },
+  {
+    id: '29',
+    name: '美食旅遊',
+    slug: 'foodtravel',
+    categories: [
+      { id: '11', name: '美食焦點', slug: 'food' },
+      { id: '12', name: '旅行台灣', slug: 'traveltaiwan' },
+      { id: '17', name: '看見世界', slug: 'seetheworld' },
+      { id: '18', name: '廚房密技', slug: 'kitchenplay' },
+      { id: '45', name: '好酒情報', slug: 'wine' },
+    ],
+  },
+  {
+    id: '35',
+    name: '人物',
+    slug: 'people',
+    categories: [
+      { id: '59', name: '一鏡到底', slug: 'somebody' },
+      { id: '60', name: '鏡相人間', slug: 'world' },
+      { id: '61', name: '心內話', slug: 'truth' },
+      { id: '62', name: '財經人物', slug: 'mogul' },
+    ],
+  },
+  {
+    id: '33',
+    name: '娛樂',
+    slug: 'entertainment',
+    categories: [
+      { id: '35', name: '鏡大咖', slug: 'celebrity' },
+      { id: '37', name: '影劇專欄', slug: 'column' },
+    ],
+  },
+  {
+    id: '43',
+    name: '新聞深探',
+    slug: 'timesquare',
+    categories: [
+      { id: '104', name: '時代現場', slug: 'timesquare' },
+      { id: '123', name: '新聞深探', slug: 'dig' },
+    ],
+  },
+]
+
 /**
  * @typedef {import('./premium-mobile-sidebar').H2AndH3Block} H2AndH3Block
  */
@@ -185,7 +235,17 @@ export default function PremiumHeader({
   const [searchTerms, setSearchTerms] = useState('')
   const mobileSearchButtonRef = useRef(null)
   const mobileSearchWrapperRef = useRef(null)
-
+  const getSections = () => {
+    if (
+      premiumHeaderData &&
+      premiumHeaderData.sections &&
+      premiumHeaderData.sections.length
+    ) {
+      return premiumHeaderData.sections
+    } else {
+      return DEFAULT_PREMIUM_SECTIONS_DATA
+    }
+  }
   // If user click search button, will show/hide search field search input field.
   // If user click outside of search input field, or outside of search button, will hide  search field if needed.
   useEffect(() => {
@@ -223,7 +283,7 @@ export default function PremiumHeader({
     location.assign(`${SEARCH_URL}/search/v3/${trimedSearchTerms}`)
   }
 
-  const sections = premiumHeaderData.sections
+  const sections = getSections()
 
   return (
     <HeaderWrapper shouldSticky={shouldShowSubtitleNavigator}>

--- a/packages/mirror-media-next/components/shared/share-header.js
+++ b/packages/mirror-media-next/components/shared/share-header.js
@@ -3,25 +3,50 @@
 import Header from '../header'
 import PremiumHeader from '../premium-header'
 import FlashNews from '../flash-news'
+
+/**
+ * @typedef {import('../header').Sections} NormalSectionsData
+ * @typedef {import('../header').Topics} TopicsData
+ * @typedef {import('../flash-news').FlashNews[]} FlashNewsData
+ * @typedef {import('../premium-header').PremiumHeaderSections} PremiumSectionsData
+ * @typedef {import('../premium-header').H2AndH3Block[]}  H2AndH3Blocks
+ */
+
 /**
  * @typedef {Object} DefaultHeaderData
- * @property {import('../header').Sections} normalSectionsData
- * @property {import('../header').Topics} topicsData
+ * @property {NormalSectionsData} [sectionsData]
+ * @property {TopicsData} [topicsData]
+ *
+ *
+ * @typedef {Object} DefaultHeaderWithFlashNewsData
+ * @property {Object} [sectionsData]
+ * @property {TopicsData} [topicsData]
+ * @property {FlashNewsData} [flashNewsData]
+ *
  *
  * @typedef {Object} PremiumHeaderData
- * @property {import('../premium-header').PremiumHeaderSection[]} premiumSectionsData
+ * @property {PremiumSectionsData} [sectionsData]
+ *
+ * @typedef {Object} PremiumHeaderWithSubtitleNavigatorData
+ * @property {PremiumSectionsData} [sectionsData]
+ * @property {H2AndH3Blocks} [h2AndH3Block]
  *
  */
 
 /**
  * @typedef {Object} HeaderData
- * @property {DefaultHeaderData['normalSectionsData'] | PremiumHeaderData['premiumSectionsData']} [sectionsData]
+ * @property {DefaultHeaderData['sectionsData'] | PremiumHeaderData['sectionsData']} sectionsData
  * @property {DefaultHeaderData['topicsData']} [topicsData]
- * @property {import('../flash-news').FlashNews[]} [flashNewsData]
+ * @property {DefaultHeaderWithFlashNewsData['flashNewsData']} [flashNewsData]
+ * @property {PremiumHeaderWithSubtitleNavigatorData['h2AndH3Block']} [h2AndH3Block]
  *
- * @typedef {'default' | 'default-with-flash-news' | 'premium' | 'empty'} HeaderType
+ *
+ * @typedef {'default' | 'default-with-flash-news' | 'premium' | 'premium-with-subtitle-navigator' | 'empty' } HeaderType
  */
 
+/**
+ * @param {DefaultHeaderData} headerData
+ */
 const getDefaultHeader = (headerData) => {
   const { sectionsData, topicsData } = headerData
   if (!sectionsData || !sectionsData.length) {
@@ -32,6 +57,9 @@ const getDefaultHeader = (headerData) => {
 
   return <Header sectionsData={sectionsData} topicsData={topicsData} />
 }
+/**
+ * @param {DefaultHeaderWithFlashNewsData} headerData
+ */
 const getDefaultHeaderWithFlashNews = (headerData) => {
   const { sectionsData, topicsData, flashNewsData } = headerData
   if (!sectionsData || !sectionsData.length) {
@@ -50,6 +78,9 @@ const getDefaultHeaderWithFlashNews = (headerData) => {
     </Header>
   )
 }
+/**
+ * @param {PremiumHeaderData} headerData
+ */
 const getPremiumHeader = (headerData) => {
   const { sectionsData } = headerData
   if (!sectionsData || !sectionsData.length) {
@@ -57,6 +88,23 @@ const getPremiumHeader = (headerData) => {
   }
 
   return <PremiumHeader premiumHeaderData={{ sections: sectionsData }} />
+}
+/**
+ * @param {PremiumHeaderWithSubtitleNavigatorData} headerData
+ */
+const getPremiumHeaderWithSubtitleNavigator = (headerData) => {
+  const { sectionsData, h2AndH3Block } = headerData
+  if (!sectionsData || !sectionsData.length) {
+    console.warn('There is no sections data for header of premium page layout')
+  }
+
+  return (
+    <PremiumHeader
+      premiumHeaderData={{ sections: sectionsData }}
+      h2AndH3Block={h2AndH3Block}
+      shouldShowSubtitleNavigator={true}
+    />
+  )
 }
 
 /**
@@ -69,32 +117,36 @@ const getPremiumHeader = (headerData) => {
  */
 export default function ShareHeader({
   pageLayoutType = 'default',
-  headerData = {},
+  headerData = { sectionsData: [] },
 }) {
-  const getheaderJsx = (pageLayoutType) => {
+  const getHeaderJsx = () => {
     switch (pageLayoutType) {
       case 'default': {
-        const defaultHeader = getDefaultHeader(headerData)
-        return defaultHeader
+        const header = getDefaultHeader(headerData)
+        return header
       }
       case 'default-with-flash-news': {
-        const defaultHeaderWithFlashNews =
-          getDefaultHeaderWithFlashNews(headerData)
-        return defaultHeaderWithFlashNews
+        const header = getDefaultHeaderWithFlashNews(headerData)
+        return header
       }
       case 'premium': {
-        const premiumHeader = getPremiumHeader(headerData)
-        return premiumHeader
+        const header = getPremiumHeader(headerData)
+        return header
+      }
+      case 'premium-with-subtitle-navigator': {
+        const header = getPremiumHeaderWithSubtitleNavigator(headerData)
+        return header
       }
       case 'empty':
         return <></>
       default: {
-        const defaultHeader = getDefaultHeader(headerData)
-        return defaultHeader
+        const header = getDefaultHeader(headerData)
+        return header
       }
     }
   }
-  const headerJsx = getheaderJsx(pageLayoutType)
+
+  const headerJsx = getHeaderJsx()
 
   return headerJsx
 }

--- a/packages/mirror-media-next/components/shared/share-header.js
+++ b/packages/mirror-media-next/components/shared/share-header.js
@@ -3,11 +3,20 @@
 import Header from '../header'
 import PremiumHeader from '../premium-header'
 import FlashNews from '../flash-news'
+/**
+ * @typedef {Object} DefaultHeaderData
+ * @property {import('../header').Sections} normalSectionsData
+ * @property {import('../header').Topics} topicsData
+ *
+ * @typedef {Object} PremiumHeaderData
+ * @property {import('../premium-header').PremiumHeaderSection[]} premiumSectionsData
+ *
+ */
 
 /**
  * @typedef {Object} HeaderData
- * @property {Array} [sectionsData]
- * @property {Array} [topicsData]
+ * @property {DefaultHeaderData['normalSectionsData'] | PremiumHeaderData['premiumSectionsData']} [sectionsData]
+ * @property {DefaultHeaderData['topicsData']} [topicsData]
  * @property {import('../flash-news').FlashNews[]} [flashNewsData]
  *
  * @typedef {'default' | 'default-with-flash-news' | 'premium' | 'empty'} HeaderType
@@ -53,7 +62,7 @@ const getPremiumHeader = (headerData) => {
 /**
  *
  * @param {Object} props
- * @param {HeaderType } props.pageLayoutType
+ * @param {HeaderType} props.pageLayoutType
  * @param {HeaderData} [props.headerData]
  * @param {JSX.Element | null} [props.children]
  * @returns {JSX.Element}

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -1,12 +1,11 @@
 //TODO: adjust margin and padding of all margin and padding after implement advertisement.
 //TODO: refactor jsx structure, make it more readable.
 
-import { useCallback, useState, useEffect } from 'react'
+import { useCallback } from 'react'
 import client from '../../../apollo/apollo-client'
 import styled, { css } from 'styled-components'
 import Link from 'next/link'
 import axios from 'axios'
-import errors from '@twreporter/errors'
 import MockAdvertisement from '../../../components/mock-advertisement'
 import ArticleInfo from '../../../components/story/normal/article-info'
 import ArticleBrief from '../shared/brief'
@@ -25,7 +24,7 @@ import {
   transformTimeDataIntoDotFormat,
   sortArrayWithOtherArrayId,
 } from '../../../utils'
-import { fetchHeaderDataInDefaultPageLayout } from '../../../utils/api'
+// import { fetchHeaderDataInDefaultPageLayout } from '../../../utils/api'
 import { fetchAsidePosts } from '../../../apollo/query/posts'
 import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
 import DableAd from '../../ads/dable/dable-ad'
@@ -340,20 +339,17 @@ const AdvertisementDableMobile = styled(AdvertisementDable)`
     width: 640px;
   }
 `
-const HeaderPlaceHolder = styled.header`
-  background-color: transparent;
-  height: 175px;
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-`
 
 /**
  *
- * @param {{postData: PostData,postContent: PostContent}} param
+ * @param {{postData: PostData,postContent: PostContent, headerData: any}} param
  * @returns {JSX.Element}
  */
-export default function StoryNormalStyle({ postData, postContent }) {
+export default function StoryNormalStyle({
+  postData,
+  postContent,
+  headerData,
+}) {
   const {
     title = '',
     slug = '',
@@ -378,11 +374,6 @@ export default function StoryNormalStyle({ postData, postContent }) {
     manualOrderOfRelateds = [],
   } = postData
 
-  const [headerData, setHeaderData] = useState({
-    sectionsData: [],
-    topicsData: [],
-  })
-  const [isHeaderDataLoaded, setIsHeaderDataLoaded] = useState(false)
   const sectionsWithOrdered =
     manualOrderOfSections && manualOrderOfSections.length
       ? sortArrayWithOtherArrayId(sections, manualOrderOfSections)
@@ -452,50 +443,15 @@ export default function StoryNormalStyle({ postData, postContent }) {
 
   const publishedTaipeiTime = transformTimeDataIntoDotFormat(publishedDate)
   const updatedTaipeiTime = transformTimeDataIntoDotFormat(updatedAt)
-  useEffect(() => {
-    let ignore = false
-    fetchHeaderDataInDefaultPageLayout()
-      .then((res) => {
-        if (!ignore && !isHeaderDataLoaded) {
-          const { sectionsData, topicsData } = res
-          setHeaderData({ sectionsData, topicsData })
-          setIsHeaderDataLoaded(true)
-        }
-      })
-      .catch((error) => {
-        if (!ignore && !isHeaderDataLoaded) {
-          console.log(
-            errors.helpers.printAll(
-              error,
-              {
-                withStack: true,
-                withPayload: true,
-              },
-              0,
-              0
-            )
-          )
-          setIsHeaderDataLoaded(true)
-        }
-      })
-
-    return () => {
-      ignore = true
-    }
-  }, [isHeaderDataLoaded])
   return (
     <>
-      {isHeaderDataLoaded ? (
-        <ShareHeader
-          pageLayoutType="default"
-          headerData={{
-            sectionsData: headerData.sectionsData,
-            topicsData: headerData.topicsData,
-          }}
-        ></ShareHeader>
-      ) : (
-        <HeaderPlaceHolder />
-      )}
+      <ShareHeader
+        pageLayoutType="default"
+        headerData={{
+          sectionsData: headerData?.sectionsData,
+          topicsData: headerData?.topicsData,
+        }}
+      ></ShareHeader>
 
       <PC_HD_Advertisement
         width="970px"

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -1,10 +1,7 @@
-import { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import DraftRenderBlock from '../shared/draft-renderer-block'
 import ArticleBrief from '../shared/brief'
-import { fetchHeaderDataInPremiumPageLayout } from '../../../utils/api'
 import { sortArrayWithOtherArrayId } from '../../../utils'
-import errors from '@twreporter/errors'
 import TitleAndInfoAndHero from './title-and-info-and-hero'
 import CopyrightWarning from '../shared/copyright-warning'
 import SupportMirrorMediaBanner from '../shared/support-mirrormedia-banner'
@@ -33,17 +30,6 @@ const { getContentBlocksH2H3 } = MirrorMedia
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
  */
-
-const HeaderPlaceHolder = styled.header`
-  background-color: transparent;
-  height: 101px;
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  ${({ theme }) => theme.breakpoint.md} {
-    height: 115px;
-  }
-`
 
 const Main = styled.main`
   width: 100%;
@@ -111,14 +97,16 @@ function getSectionLabelFirst(sections) {
  * @param {Object} props
  * @param {PostData} props.postData
  * @param {PostContent} props.postContent
+ * @param {any} props.headerData
  * @returns {JSX.Element}
  */
-export default function StoryPremiumStyle({ postData, postContent }) {
-  const [headerData, setHeaderData] = useState({
-    sectionsData: [],
-  })
+export default function StoryPremiumStyle({
+  postData,
+  postContent,
+  headerData,
+}) {
   const { isLoggedIn } = useMembership()
-  const [isHeaderDataLoaded, setIsHeaderDataLoaded] = useState(false)
+
   const {
     id = '',
     title,
@@ -171,38 +159,6 @@ export default function StoryPremiumStyle({ postData, postContent }) {
     { extend_byline: extend_byline },
   ]
 
-  useEffect(() => {
-    let ignore = false
-    fetchHeaderDataInPremiumPageLayout()
-      .then((res) => {
-        if (!ignore && !isHeaderDataLoaded) {
-          const { sectionsData } = res
-          setHeaderData({ sectionsData })
-          setIsHeaderDataLoaded(true)
-        }
-      })
-      .catch((error) => {
-        if (!ignore && !isHeaderDataLoaded) {
-          console.log(
-            errors.helpers.printAll(
-              error,
-              {
-                withStack: true,
-                withPayload: true,
-              },
-              0,
-              0
-            )
-          )
-          setIsHeaderDataLoaded(true)
-        }
-      })
-
-    return () => {
-      ignore = true
-    }
-  }, [isHeaderDataLoaded])
-
   const { memberInfo } = useMembership()
   const { memberType } = memberInfo
 
@@ -217,17 +173,13 @@ export default function StoryPremiumStyle({ postData, postContent }) {
 
   return (
     <>
-      {isHeaderDataLoaded ? (
-        <PremiumHeader
-          premiumHeaderData={{
-            sections: headerData.sectionsData,
-          }}
-          h2AndH3Block={h2AndH3Block}
-          shouldShowSubtitleNavigator={true}
-        ></PremiumHeader>
-      ) : (
-        <HeaderPlaceHolder />
-      )}
+      <PremiumHeader
+        premiumHeaderData={{
+          sections: headerData?.sectionsData,
+        }}
+        h2AndH3Block={h2AndH3Block}
+        shouldShowSubtitleNavigator={true}
+      ></PremiumHeader>
 
       <Main>
         <article>

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -13,9 +13,9 @@ import ButtonCopyLink from '../shared/button-copy-link'
 import ButtonSocialNetworkShare from '../shared/button-social-network-share'
 import DonateLink from '../shared/donate-link'
 import SubscribeLink from '../shared/subscribe-link'
-import PremiumHeader from '../../premium-header'
 import ArticleMask from './article-mask'
 import { useMembership } from '../../../context/membership'
+import ShareHeader from '../../shared/share-header'
 const { getContentBlocksH2H3 } = MirrorMedia
 /**
  * @typedef {import('../../../apollo/fragments/post').Post} PostData
@@ -173,13 +173,13 @@ export default function StoryPremiumStyle({
 
   return (
     <>
-      <PremiumHeader
-        premiumHeaderData={{
-          sections: headerData?.sectionsData,
+      <ShareHeader
+        pageLayoutType="premium"
+        headerData={{
+          sectionsData: headerData?.sectionsData,
+          h2AndH3Block: h2AndH3Block,
         }}
-        h2AndH3Block={h2AndH3Block}
-        shouldShowSubtitleNavigator={true}
-      ></PremiumHeader>
+      />
 
       <Main>
         <article>

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -181,7 +181,6 @@ export async function getServerSideProps({ res, req }) {
             ...globalLogFields,
           })
         )
-        throw new Error(errorMessage)
       }
     })
 

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -39,32 +39,22 @@ const fetchHeaderDataInDefaultPageLayout = async () => {
   /** @type {Topics} */
   let topicsData = []
   try {
-    const responses = await Promise.all([fetchNormalSections(), fetchTopics()])
-    if (responses[0]?.data?.sections) {
-      sectionsData = responses[0]?.data?.sections
-    }
-    const sectionsDataContainMagazine = sectionsData.map((section) => {
-      if (section.slug === 'member') {
-        return {
-          ...section,
-          categories: [
-            {
-              id: '7a7482edb739242537f11e24760d2c79', //hash for ensure it is unique from other category, no other usage.
-              slug: 'magazine',
-              name: '動態雜誌',
-              isMemberOnly: false,
-            },
-            ...section.categories,
-          ],
-        }
-      }
-      return { ...section }
-    })
+    const responses = await Promise.allSettled([
+      fetchNormalSections(),
+      fetchTopics(),
+    ])
 
-    if (responses[1]?.data?.topics) {
-      topicsData = responses[1].data.topics
-    }
-    return { sectionsData: sectionsDataContainMagazine, topicsData }
+    const sectionsResponse = responses[0].status === 'fulfilled' && responses[0]
+    sectionsData = Array.isArray(sectionsResponse?.value?.data?.sections)
+      ? sectionsResponse?.value?.data?.sections
+      : []
+
+    const topicsResponse = responses[1].status === 'fulfilled' && responses[1]
+    topicsData = Array.isArray(topicsResponse?.value?.data?.topics)
+      ? topicsResponse?.value?.data?.topics
+      : []
+
+    return { sectionsData: sectionsData, topicsData }
   } catch (err) {
     errorLogger(err)
   }


### PR DESCRIPTION
## Notable Change
1. 調整文章頁邏輯，於server-side就抓取所需header資料，並將其透過getServersideProps，傳入文章頁元件中。
2. 於header中新增錯誤處理：如果無法抓取資料失敗的話，則使用預設值或不顯示資料。
3. 調整一般header資料抓取方式，改為使用`Promise.allSettled`（原為Promise.all），避免任一Promise失敗後，造成另一份成功抓取的資料也無法顯示。
4. 於文章頁新增函式`getStoryLayout`，該函式會決定要顯示哪種layout，該函式會用於server-side。
5. 於文章頁getServersideProps中，新增一變數`storyLayoutType`，該變數的值是由函式`getStoryLayout`所決定。該變數會決定是否要抓取header資料、該抓取哪種header資料，且該變數會傳入文章頁元件中，並決定要顯示哪種layout component
6. 新增、調整既有元件的jsDoc。