### PR TITLE
fix(gpt): insert `GPT_FT` ad behind 12th lists

### DIFF
--- a/packages/mirror-media-next/components/externals/externals-list.js
+++ b/packages/mirror-media-next/components/externals/externals-list.js
@@ -1,9 +1,15 @@
-import { Fragment } from 'react'
+import { Fragment, useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 import ExternalListItem from './externals-list-item'
 import { needInsertMicroAdAfter, getMicroAdUnitId } from '../../utils/ad'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
+import { SECTION_IDS } from '../../constants/index'
+import { getPageKeyByPartnerSlug } from '../../utils/ad'
+
+const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
 
 const StyledMicroAd = dynamic(
   () => import('../../components/ads/micro-ad/micro-ad-with-label'),
@@ -28,10 +34,22 @@ const ItemContainer = styled.div`
   }
 `
 
+const StyledGPTAd = styled(GPTAd)`
+  width: 100%;
+  height: auto;
+  max-width: 336px;
+  max-height: 280px;
+  margin: 20px auto;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 970px;
+    max-height: 250px;
+    margin: 35px auto;
+  }
+`
 /**
  * @typedef {import('../../apollo/fragments/external').ListingExternal} ListingExternal
  */
-
 /**
  * @param {Object} props
  * @param {ListingExternal[]} props.renderList
@@ -39,20 +57,52 @@ const ItemContainer = styled.div`
  */
 export default function ExternalList({ renderList }) {
   const shouldShowAd = useDisplayAd()
+  const GPT_PAGE_KEY = useRef('other')
+
+  useEffect(() => {
+    const urlElements = window.location.pathname.split('/')
+    const lastUrlElement = urlElements[urlElements.length - 1]
+
+    // the default section of `warmlife` page is `時事`
+    GPT_PAGE_KEY.current =
+      lastUrlElement === 'warmlife'
+        ? SECTION_IDS.news
+        : getPageKeyByPartnerSlug(lastUrlElement)
+  }, [])
+
+  const renderListWithAd = shouldShowAd
+    ? renderList.slice(0, 9)
+    : renderList.slice(0, 12)
+
+  const renderListWithoutAd = shouldShowAd
+    ? renderList.slice(9)
+    : renderList.slice(12)
 
   return (
-    <ItemContainer>
-      {renderList.map((item, index) => (
-        <Fragment key={item.id}>
-          <ExternalListItem item={item} />
-          {shouldShowAd && needInsertMicroAdAfter(index) && (
-            <StyledMicroAd
-              unitId={getMicroAdUnitId(index, 'LISTING', 'RWD')}
-              microAdType="LISTING"
-            />
-          )}
-        </Fragment>
-      ))}
-    </ItemContainer>
+    <>
+      <ItemContainer>
+        {renderListWithAd.map((item, index) => (
+          <Fragment key={item.id}>
+            <ExternalListItem item={item} />
+            {shouldShowAd && needInsertMicroAdAfter(index) && (
+              <StyledMicroAd
+                unitId={getMicroAdUnitId(index, 'LISTING', 'RWD')}
+                microAdType="LISTING"
+              />
+            )}
+          </Fragment>
+        ))}
+      </ItemContainer>
+
+      {shouldShowAd && (
+        <StyledGPTAd pageKey={GPT_PAGE_KEY.current} adKey="FT" />
+      )}
+
+      <ItemContainer>
+        {renderListWithoutAd.map((item) => (
+          <ExternalListItem key={item.id} item={item} />
+        ))}
+      </ItemContainer>
+    </>
   )
 }

--- a/packages/mirror-media-next/components/shared/article-list.js
+++ b/packages/mirror-media-next/components/shared/article-list.js
@@ -1,9 +1,14 @@
-import { Fragment } from 'react'
+import { Fragment, useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 import ArticleListItem from './article-list-item'
 import { needInsertMicroAdAfter, getMicroAdUnitId } from '../../utils/ad'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
+import { getSectionGPTPageKey } from '../../utils/ad'
+
+const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
 
 const StyledMicroAd = dynamic(
   () => import('../../components/ads/micro-ad/micro-ad-with-label'),
@@ -28,6 +33,20 @@ const ItemContainer = styled.div`
   }
 `
 
+const StyledGPTAd = styled(GPTAd)`
+  width: 100%;
+  height: auto;
+  max-width: 336px;
+  max-height: 280px;
+  margin: 20px auto;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 970px;
+    max-height: 250px;
+    margin: 35px auto;
+  }
+`
+
 /**
  * @typedef {import('./article-list-item').Article} Article
  * @typedef {import('./article-list-item').Section} Section
@@ -41,20 +60,57 @@ const ItemContainer = styled.div`
  */
 export default function ArticleList({ renderList, section }) {
   const shouldShowAd = useDisplayAd()
+  const GPT_PAGE_KEY = useRef('other')
+
+  useEffect(() => {
+    const urlElements = window.location.pathname.split('/')
+    const pageType = urlElements[urlElements.length - 2]
+
+    switch (pageType) {
+      case 'author':
+      case 'tag':
+        GPT_PAGE_KEY.current = 'other'
+        break
+      case 'section':
+      case 'category':
+        GPT_PAGE_KEY.current = getSectionGPTPageKey(section.slug)
+        break
+    }
+  }, [section])
+
+  const renderListWithAd = shouldShowAd
+    ? renderList.slice(0, 9)
+    : renderList.slice(0, 12)
+
+  const renderListWithoutAd = shouldShowAd
+    ? renderList.slice(9)
+    : renderList.slice(12)
 
   return (
-    <ItemContainer>
-      {renderList.map((item, index) => (
-        <Fragment key={item.id}>
-          <ArticleListItem item={item} section={section} />
-          {shouldShowAd && needInsertMicroAdAfter(index) && (
-            <StyledMicroAd
-              unitId={getMicroAdUnitId(index, 'LISTING', 'RWD')}
-              microAdType="LISTING"
-            />
-          )}
-        </Fragment>
-      ))}
-    </ItemContainer>
+    <>
+      <ItemContainer>
+        {renderListWithAd.map((item, index) => (
+          <Fragment key={item.id}>
+            <ArticleListItem item={item} section={section} />
+            {shouldShowAd && needInsertMicroAdAfter(index) && (
+              <StyledMicroAd
+                unitId={getMicroAdUnitId(index, 'LISTING', 'RWD')}
+                microAdType="LISTING"
+              />
+            )}
+          </Fragment>
+        ))}
+      </ItemContainer>
+
+      {shouldShowAd && (
+        <StyledGPTAd pageKey={GPT_PAGE_KEY.current} adKey="FT" />
+      )}
+
+      <ItemContainer>
+        {renderListWithoutAd.map((item) => (
+          <ArticleListItem key={item.id} item={item} />
+        ))}
+      </ItemContainer>
+    </>
   )
 }

--- a/packages/mirror-media-next/constants/index.js
+++ b/packages/mirror-media-next/constants/index.js
@@ -177,6 +177,20 @@ const Z_INDEX = {
   coverContent: 100,
 }
 
+const SECTIONS_TYPE = {
+  MEMBER: 'member',
+  NEWS: 'news',
+  ENTERTAINMENT: 'entertainment',
+  BUSINESSMONAY: 'businessmoney',
+  PEOPLE: 'people',
+  INTERNATIONAL: 'international',
+  FOODTRAVEL: 'foodtravel',
+  MAFALDA: 'mafalda',
+  CULTURE: 'culture',
+  CRANDWATCH: 'carandwatch',
+  MIRRORCOLUMN: 'mirrorcolumn',
+}
+
 const SECTION_IDS = {
   member: '5fe15f1e123c831000ee54c2',
   news: '57e1e0e5ee85930e00cad4e9',
@@ -208,4 +222,5 @@ export {
   EMAIL_LINK,
   FOOTER_PROMOTION_LINKS,
   SECTION_IDS,
+  SECTIONS_TYPE,
 }

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -110,12 +110,7 @@ export default function Author({ postsCount, posts, author, headerData }) {
           authorId={author.id}
           renderPageSize={RENDER_PAGE_SIZE}
         />
-        {shouldShowAd && (
-          <>
-            <StyledGPTAd pageKey="other" adKey="FT" />
-            <StickyGPTAd pageKey="other" adKey="ST" />
-          </>
-        )}
+        {shouldShowAd && <StickyGPTAd pageKey="other" adKey="ST" />}
       </AuthorContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -15,6 +15,7 @@ import {
   fetchPostsByCategorySlug,
 } from '../../utils/api/category'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
+import { getSectionGPTPageKey } from '../../utils/ad'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -192,25 +193,30 @@ export default function Category({
   isPremium,
   headerData,
 }) {
-  const categroyName = category.name || ''
+  const categoryName = category.name || ''
   const shouldShowAd = useDisplayAd()
+
+  //The type of GPT ad to display depends on which category the section belongs to.
+  const sectionSlug = category?.sections?.[0]?.slug ?? ''
 
   return (
     <Layout
-      head={{ title: `${categroyName}分類報導` }}
+      head={{ title: `${categoryName}分類報導` }}
       header={{ type: isPremium ? 'premium' : 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
       <CategoryContainer isPremium={isPremium}>
-        {shouldShowAd && <StyledGPTAd pageKey="other" adKey="HD" />}
+        {shouldShowAd && (
+          <StyledGPTAd pageKey={getSectionGPTPageKey(sectionSlug)} adKey="HD" />
+        )}
 
         {isPremium ? (
           <PremiumCategoryTitle sectionName={category?.sections?.[0].slug}>
-            {categroyName}
+            {categoryName}
           </PremiumCategoryTitle>
         ) : (
           <CategoryTitle sectionName={category?.sections?.[0].slug}>
-            {categroyName}
+            {categoryName}
           </CategoryTitle>
         )}
 
@@ -223,10 +229,7 @@ export default function Category({
         />
 
         {shouldShowAd && (
-          <>
-            <StyledGPTAd pageKey="other" adKey="FT" />
-            <StickyGPTAd pageKey="other" adKey="ST" />
-          </>
+          <StickyGPTAd pageKey={getSectionGPTPageKey(sectionSlug)} adKey="ST" />
         )}
       </CategoryContainer>
     </Layout>

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -13,10 +13,9 @@ import {
   fetchExternalCounts,
 } from '../../apollo/query/externals'
 import { fetchPartnerBySlug } from '../../apollo/query/partner'
-import {
-  getExternalPartnerColor,
-  getPageKeyByPartnerSlug,
-} from '../../utils/external'
+import { getExternalPartnerColor } from '../../utils/external'
+
+import { getPageKeyByPartnerSlug } from '../../utils/ad'
 import { Z_INDEX } from '../../constants/index'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
 
@@ -142,16 +141,10 @@ export default function ExternalPartner({
           renderPageSize={RENDER_PAGE_SIZE}
         />
         {shouldShowAd && (
-          <>
-            <StyledGPTAd
-              pageKey={getPageKeyByPartnerSlug(partner.slug)}
-              adKey="FT"
-            />
-            <StickyGPTAd
-              pageKey={getPageKeyByPartnerSlug(partner.slug)}
-              adKey="ST"
-            />
-          </>
+          <StickyGPTAd
+            pageKey={getPageKeyByPartnerSlug(partner.slug)}
+            adKey="ST"
+          />
         )}
       </PartnerContainer>
     </Layout>

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -19,9 +19,9 @@ const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
 })
 
 const RENDER_PAGE_SIZE = 12
-const WARMLIFE_DEFAULT_TITLE = `生活暖流`
+const WARMLIFE_DEFAULT_TITLE = '生活暖流'
 const WARMLIFE_DEFAULT_COLOR = 'lightBlue'
-const WARMLIFE_GPT_SECTION_IDS = SECTION_IDS.news // The default section of `warmlife` page is `時事`
+const WARMLIFE_GPT_SECTION_IDS = SECTION_IDS.news // the default section of `warmlife` page is `時事`
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -118,10 +118,7 @@ export default function WarmLife({ warmLifeData, headerData }) {
           renderPageSize={RENDER_PAGE_SIZE}
         />
         {shouldShowAd && (
-          <>
-            <StyledGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} adKey="FT" />
-            <StickyGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} adKey="ST" />
-          </>
+          <StickyGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} adKey="ST" />
         )}
       </WarmLifeContainer>
     </Layout>

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -7,12 +7,12 @@ import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
 import { Z_INDEX } from '../../constants/index'
-import { SECTION_IDS } from '../../constants/index'
 import {
   fetchPostsBySectionSlug,
   fetchSectionBySectionSlug,
 } from '../../utils/api/section'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
+import { getSectionGPTPageKey } from '../../utils/ad'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -108,12 +108,6 @@ const RENDER_PAGE_SIZE = 12
  */
 export default function Section({ postsCount, posts, section, headerData }) {
   const sectionName = section.name || ''
-  //When the section is `論壇`, use the `culture` AD unit.
-  const GPT_PAGE_KEY =
-    section.slug === 'mirrorcolumn'
-      ? SECTION_IDS['culture']
-      : SECTION_IDS[section.slug]
-
   const shouldShowAd = useDisplayAd()
 
   return (
@@ -123,7 +117,12 @@ export default function Section({ postsCount, posts, section, headerData }) {
       footer={{ type: 'default' }}
     >
       <SectionContainer>
-        {shouldShowAd && <StyledGPTAd pageKey={GPT_PAGE_KEY} adKey="HD" />}
+        {shouldShowAd && (
+          <StyledGPTAd
+            pageKey={getSectionGPTPageKey(section.slug)}
+            adKey="HD"
+          />
+        )}
 
         {sectionName && (
           <SectionTitle sectionName={section.slug}>{sectionName}</SectionTitle>
@@ -137,10 +136,10 @@ export default function Section({ postsCount, posts, section, headerData }) {
         />
 
         {shouldShowAd && (
-          <>
-            <StyledGPTAd pageKey={GPT_PAGE_KEY} adKey="FT" />
-            <StickyGPTAd pageKey={GPT_PAGE_KEY} adKey="ST" />
-          </>
+          <StickyGPTAd
+            pageKey={getSectionGPTPageKey(section.slug)}
+            adKey="ST"
+          />
         )}
       </SectionContainer>
     </Layout>

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -136,12 +136,7 @@ export default function Tag({ postsCount, posts, tag, headerData }) {
           renderPageSize={RENDER_PAGE_SIZE}
         />
 
-        {shouldShowAd && (
-          <>
-            <StyledGPTAd pageKey="other" adKey="FT" />
-            <StickyGPTAd pageKey="other" adKey="ST" />
-          </>
-        )}
+        {shouldShowAd && <StickyGPTAd pageKey="other" adKey="ST" />}
       </TagContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/utils/ad.js
+++ b/packages/mirror-media-next/utils/ad.js
@@ -1,4 +1,5 @@
 import { MICRO_AD_UNITS } from '../constants/ads'
+import { SECTION_IDS, SECTIONS_TYPE } from '../constants/index'
 
 /**
  * Determining whether to insert a `Micro` advertisement after a specific post index.
@@ -16,12 +17,8 @@ const needInsertMicroAdAfter = (index = 0) => {
 
 /**
  * @typedef {'HOME' | 'LISTING' | 'STORY' } MicroAdType
- */
-/**
  * @typedef {'PC' | 'MB' | 'RWD' } Device
- */
-
-/**
+ *
  * Determining which Micro advertisement ID to take based on the `index`.
  *
  * @param {number} index
@@ -51,4 +48,43 @@ const getMicroAdUnitId = (
   return unitId
 }
 
-export { needInsertMicroAdAfter, getMicroAdUnitId }
+/**
+ * Returns the GPT pageKey associated with partner's slug.
+ *
+ * @param {string} partnerSlug - The slug of the partner.
+ * @return {string} - The GPT pageKey associated with the partner slug.
+ * Returns 'SECTION_IDS.news' if partnerSlug is valid, otherwise returns 'other'.
+ */
+function getPageKeyByPartnerSlug(partnerSlug = '') {
+  const validPartnerSlugs = ['ebc', 'healthnews', 'zuchi', '5678news']
+  return validPartnerSlugs.includes(partnerSlug) ? SECTION_IDS.news : 'other'
+}
+
+/**
+ * Returns the GPT pageKey associated with section's slug.
+ *
+ * @param {string} sectionSlug
+ * @returns {string | undefined}
+ */
+const getSectionGPTPageKey = (sectionSlug = '') => {
+  if (typeof sectionSlug !== 'string') {
+    console.error(
+      `The value for 'sectionSlug' is not of the correct data type 'string'. Please check the data type of the value being passed.`
+    )
+    return undefined
+  }
+
+  //if sectionSlug is `論壇(mirrorcolumn)`, use the `culture` ad unit.
+  if (sectionSlug === SECTIONS_TYPE.MIRRORCOLUMN) {
+    return SECTION_IDS[SECTIONS_TYPE.CULTURE]
+  } else {
+    return SECTION_IDS[sectionSlug]
+  }
+}
+
+export {
+  needInsertMicroAdAfter,
+  getMicroAdUnitId,
+  getPageKeyByPartnerSlug,
+  getSectionGPTPageKey,
+}

--- a/packages/mirror-media-next/utils/external.js
+++ b/packages/mirror-media-next/utils/external.js
@@ -1,5 +1,3 @@
-import { SECTION_IDS } from '../constants/index'
-
 /**
  * The `brief` of the externals is string and not in the format of a draft.
  * Here convert the string into a data format with `blocks` and `entityMap`.
@@ -107,22 +105,9 @@ function getCreditsHtml(credits = '') {
   }
 }
 
-/**
- * Returns the GPT pageKey associated with partner's slug.
- *
- * @param {string} partnerSlug - The slug of the partner.
- * @return {string} - The GPT pageKey associated with the partner slug.
- * Returns 'SECTION_IDS.news' if partnerSlug is valid, otherwise returns 'other'.
- */
-function getPageKeyByPartnerSlug(partnerSlug = '') {
-  const validSlugs = ['ebc', 'healthnews', 'zuchi', '5678news']
-  return validSlugs.includes(partnerSlug) ? SECTION_IDS.news : 'other'
-}
-
 export {
   transformStringToDraft,
   getExternalSectionTitle,
   getCreditsHtml,
   getExternalPartnerColor,
-  getPageKeyByPartnerSlug,
 }


### PR DESCRIPTION
## Notable Changes 
- 將一般列表頁中的 `FT` 類別廣告位置，改至第 12 則貼文後（修改共用元件： `externals-list`、`article-list`）。
- 新增 constants： `SECTIONS_TYPE`，管理 sections 類別。
- 新增 utils `getSectionGPTPageKey`，管理不同 section 下的 pageKey 取得邏輯。
- 修正 `category/[slug]` 頁面中 pageKey 資訊，從 `other` 改為 `section.slug` 。

## 影響頁面
- 作者列表 `/author/[id]`  ：皆為「其他」(other) 廣告單元。
- 生活暖流列表 `/externals/warmlife`：皆為「時事」廣告單元。
- 合作夥伴列表 `/externals/[partnerSlug]`
- tag 列表 `/tag/[slug]`  ：皆為「其他」(other) 廣告單元。
- category 列表 `/category/[slug]`  ：以 category 所屬的 section 作設定。
- section 列表 `/section/[slug]` ：如 section.slug 為論壇，請使用「文化」廣告單元，其餘正常顯示。