### PR TITLE
refactor(mm-next): add error handling for video related pages

### DIFF
--- a/packages/mirror-media-next/components/shared/leading-video.js
+++ b/packages/mirror-media-next/components/shared/leading-video.js
@@ -75,8 +75,10 @@ const Title = styled.h2`
 export default function LeadingVideo({ video, title, slug }) {
   return (
     <Wrapper>
-      <Title categorySlug={slug}>{title}</Title>
-      <LeadingVideoItem video={video} slug={slug} playlistTitle={title} />
+      {title && <Title categorySlug={slug}>{title}</Title>}
+      {video && (
+        <LeadingVideoItem video={video} slug={slug} playlistTitle={title} />
+      )}
       <YoutubePolicy />
     </Wrapper>
   )

--- a/packages/mirror-media-next/components/story/shared/button-copy-link.js
+++ b/packages/mirror-media-next/components/story/shared/button-copy-link.js
@@ -61,7 +61,11 @@ export default function ButtonCopyLink({ width = 35, height = 35 }) {
         已複製連結
       </CopiedMessage>
 
-      <ClickButton onClick={handleCopyLink} on="tap:clipboard-example.copy">
+      <ClickButton
+        onClick={handleCopyLink}
+        // @ts-ignore
+        on="tap:clipboard-example.copy"
+      >
         <Image
           src={'/images/link-logo.svg'}
           width={width}

--- a/packages/mirror-media-next/components/video/youtube-article.js
+++ b/packages/mirror-media-next/components/video/youtube-article.js
@@ -90,9 +90,13 @@ export default function YoutubeArticle({ video }) {
   }
   return (
     <Wrapper>
-      <Title>{video.title}</Title>
-      <Date>{transformTimeDataIntoSlashFormat(video.publishedAt)}</Date>
-      <Description dangerouslySetInnerHTML={{ __html: description }} />
+      {video.title && <Title>{video.title}</Title>}
+      {video.publishedAt && (
+        <Date>{transformTimeDataIntoSlashFormat(video.publishedAt)}</Date>
+      )}
+      {video.description && (
+        <Description dangerouslySetInnerHTML={{ __html: description }} />
+      )}
       <ShareIcons>
         <a href={shareFbUrl} target="_blank" rel="noreferrer">
           <Icon src="/images/video-share-fb.svg" alt="share to facebook" />

--- a/packages/mirror-media-next/components/video/youtube-article.js
+++ b/packages/mirror-media-next/components/video/youtube-article.js
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import { transformTimeDataIntoSlashFormat } from '../../utils'
 import { useShareFbUrl } from '../../hooks/useShareFbUrl'
 import { useShareLineUrl } from '../../hooks/useShareLineUrl'
+import ButtonCopyLink from '../story/shared/button-copy-link'
 
 const Wrapper = styled.div`
   padding: 0 16px;
@@ -78,16 +79,6 @@ export default function YoutubeArticle({ video }) {
     .replace(/↵|\n/g, '<br>')
     .split('-----')[0]
 
-  const copyLink = () => {
-    navigator.clipboard
-      .writeText(window.location.href)
-      .then(() => {
-        console.log('URL copied to clipboard:', window.location.href)
-      })
-      .catch((error) => {
-        console.error('Failed to copy URL to clipboard:', error)
-      })
-  }
   return (
     <Wrapper>
       {video.title && <Title>{video.title}</Title>}
@@ -104,11 +95,7 @@ export default function YoutubeArticle({ video }) {
         <a href={shareLineUrl} target="_blank" rel="noreferrer">
           <Icon src="/images/video-share-line.svg" alt="share to facebook" />
         </a>
-        <Icon
-          onClick={copyLink}
-          src="/images/video-share-copy-link.svg"
-          alt="share to facebook"
-        />
+        <ButtonCopyLink width={40} height={40} />
       </ShareIcons>
     </Wrapper>
   )

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -158,6 +158,20 @@ export default function Video({ video, latestVideos, headerData }) {
   )
 }
 
+function fetchYoutubeVideoByVideoId(videoId) {
+  return axios({
+    method: 'get',
+    url: `${URL_RESTFUL_SERVER}/youtube/videos`,
+    // use URLSearchParams to add two values for key 'part'
+    params: new URLSearchParams([
+      ['id', videoId],
+      ['part', 'snippet'],
+      ['part', 'status'],
+      ['maxResults', '1'],
+    ]),
+  })
+}
+
 export async function getServerSideProps({ query, req }) {
   const videoId = query.id
   const traceHeader = req.headers?.['x-cloud-trace-context']
@@ -171,17 +185,7 @@ export async function getServerSideProps({ query, req }) {
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
-    axios({
-      method: 'get',
-      url: `${URL_RESTFUL_SERVER}/youtube/videos`,
-      // use URLSearchParams to add two values for key 'part'
-      params: new URLSearchParams([
-        ['id', videoId],
-        ['part', 'snippet'],
-        ['part', 'status'],
-        ['maxResults', '1'],
-      ]),
-    }),
+    fetchYoutubeVideoByVideoId(videoId),
   ])
 
   const handledResponses = responses.map((response) => {

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -1,10 +1,9 @@
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
-import axios from 'axios'
 import dynamic from 'next/dynamic'
 
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
-import { GCP_PROJECT_ID, URL_RESTFUL_SERVER } from '../../config/index.mjs'
+import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import {
   simplifyYoutubeSearchedVideo,
   simplifyYoutubeVideo,
@@ -16,6 +15,10 @@ import YoutubePolicy from '../../components/shared/youtube-policy'
 import Layout from '../../components/shared/layout'
 import { Z_INDEX } from '../../constants/index'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
+import {
+  fetchYoutubeLatestVideosByChannelId,
+  fetchYoutubeVideoByVideoId,
+} from '../../utils/api/video'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -127,9 +130,9 @@ export default function Video({ video, latestVideos, headerData }) {
   return (
     <Layout
       head={{
-        title: `${video?.title}`,
-        description: video?.description,
-        imageUrl: video?.thumbnail,
+        title: `${video?.title || ''}`,
+        description: video?.description || '',
+        imageUrl: video?.thumbnail || '',
       }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
@@ -142,7 +145,7 @@ export default function Video({ video, latestVideos, headerData }) {
         <ContentWrapper>
           <YoutubeArticle video={video} />
           {shouldShowAd && <StyledGPTAd_E1 pageKey="videohub" adKey="E1" />}
-          <VideoList videos={latestVideos} />
+          {latestVideos.length > 0 && <VideoList videos={latestVideos} />}
         </ContentWrapper>
 
         <YoutubePolicy />
@@ -158,22 +161,13 @@ export default function Video({ video, latestVideos, headerData }) {
   )
 }
 
-function fetchYoutubeVideoByVideoId(videoId) {
-  return axios({
-    method: 'get',
-    url: `${URL_RESTFUL_SERVER}/youtube/videos`,
-    // use URLSearchParams to add two values for key 'part'
-    params: new URLSearchParams([
-      ['id', videoId],
-      ['part', 'snippet'],
-      ['part', 'status'],
-      ['maxResults', '1'],
-    ]),
-  })
-}
-
+/**
+ * @type {import('next').GetServerSideProps}
+ */
 export async function getServerSideProps({ query, req }) {
-  const videoId = query.id
+  const videoId = Array.isArray(query.id) ? query.id[0] : query.id
+  const mockError = query.error === '500'
+
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}
   if (traceHeader && !Array.isArray(traceHeader)) {
@@ -190,6 +184,10 @@ export async function getServerSideProps({ query, req }) {
 
   const handledResponses = responses.map((response) => {
     if (response.status === 'fulfilled') {
+      if ('data' in response.value) {
+        // handle simple axios request
+        return response.value.data
+      }
       return response.value
     } else if (response.status === 'rejected') {
       const annotatingError = errors.helpers.wrap(
@@ -217,6 +215,7 @@ export async function getServerSideProps({ query, req }) {
     }
   })
 
+  // handle header data
   const headerData =
     handledResponses[0] && 'sectionsData' in handledResponses[0]
       ? handledResponses[0]
@@ -228,11 +227,8 @@ export async function getServerSideProps({ query, req }) {
     ? headerData.topicsData
     : []
 
-  const video =
-    handledResponses[1] && 'data' in handledResponses[1]
-      ? simplifyYoutubeVideo(handledResponses[1]?.data?.items)[0]
-      : { channelId: '' }
-  if (!video) {
+  // handle fetch video data
+  if (handledResponses[1]?.items?.length === 0) {
     console.log(
       JSON.stringify({
         severity: 'ERROR',
@@ -243,27 +239,20 @@ export async function getServerSideProps({ query, req }) {
     return {
       redirect: {
         destination: '/section/videohub',
-        premanent: false,
+        permanent: false,
       },
     }
   }
+  const video = handledResponses[1]?.items
+    ? simplifyYoutubeVideo(handledResponses[1]?.items)[0]
+    : { id: videoId, channelId: '' }
   const channelId = video?.channelId
 
   /** @type {import('../../type/youtube').YoutubeVideo[]} */
   let latestVideos = []
   if (channelId) {
     try {
-      const { data } = await axios({
-        method: 'get',
-        url: `${URL_RESTFUL_SERVER}/youtube/search`,
-        // use URLSearchParams to add two values for key 'part'
-        params: new URLSearchParams([
-          ['channelId', channelId],
-          ['part', 'snippet'],
-          ['order', 'date'],
-          ['maxResults', '6'],
-        ]),
-      })
+      const { data } = await fetchYoutubeLatestVideosByChannelId(channelId)
       latestVideos = simplifyYoutubeSearchedVideo(data.items)
     } catch (error) {
       const annotatingAxiosError = errors.helpers.annotateAxiosError(error)
@@ -280,11 +269,17 @@ export async function getServerSideProps({ query, req }) {
     }
   }
 
-  const props = {
-    video,
-    latestVideos,
-    headerData: { sectionsData, topicsData },
-  }
+  const props = mockError
+    ? {
+        video: { id: videoId, channelId: '' },
+        latestVideos: [],
+        headerData: { sectionsData, topicsData },
+      }
+    : {
+        video,
+        latestVideos,
+        headerData: { sectionsData, topicsData },
+      }
 
   return { props }
 }

--- a/packages/mirror-media-next/pages/video_category/[slug].js
+++ b/packages/mirror-media-next/pages/video_category/[slug].js
@@ -1,16 +1,17 @@
 import errors from '@twreporter/errors'
-import axios from 'axios'
 
-import { GCP_PROJECT_ID, URL_RESTFUL_SERVER } from '../../config/index.mjs'
+import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import CategoryVideos from '../../components/video_category/category-videos.js'
 import { VIDEOHUB_CATEGORIES_PLAYLIST_MAPPING } from '../../constants/index.js'
 import styled from 'styled-components'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api/index.js'
-import client from '../../apollo/apollo-client.js'
-import { fetchCategory } from '../../apollo/query/categroies.js'
 import { simplifyYoutubePlaylistVideo } from '../../utils/youtube.js'
 import LeadingVideo from '../../components/shared/leading-video.js'
 import Layout from '../../components/shared/layout.js'
+import {
+  fetchVideoCategory,
+  fetchYoutubePlaylistByPlaylistId,
+} from '../../utils/api/video-category.js'
 
 const Wrapper = styled.div`
   width: 320px;
@@ -40,31 +41,43 @@ export default function VideoCategory({
   headerData,
   category,
 }) {
+  const hasMoreThanOneVideo = videos.length > 1
   const firstVideo = videos[0]
   const remainingVideos = videos.slice(1)
+  const categoryName = category.name || ''
   return (
     <Layout
-      head={{ title: `${category.name}影音` }}
+      head={{ title: `${categoryName}影音` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
       <Wrapper>
         <LeadingVideo
           video={firstVideo}
-          title={category.name}
+          title={categoryName}
           slug={category.slug}
         />
-        <CategoryVideos
-          videoItems={remainingVideos}
-          initialNextPageToken={ytNextPageToken}
-        />
+        {hasMoreThanOneVideo && (
+          <CategoryVideos
+            videoItems={remainingVideos}
+            initialNextPageToken={ytNextPageToken}
+            categorySlug={category.slug}
+          />
+        )}
       </Wrapper>
     </Layout>
   )
 }
 
+/**
+ * @type {import('next').GetServerSideProps}
+ */
 export async function getServerSideProps({ query, req }) {
-  const videoCategorySlug = query.slug
+  const videoCategorySlug = Array.isArray(query.slug)
+    ? query.slug[0]
+    : query.slug
+  const mockError = query.error === '500'
+
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}
   if (traceHeader && !Array.isArray(traceHeader)) {
@@ -74,30 +87,36 @@ export async function getServerSideProps({ query, req }) {
     ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
   }
 
+  const playlistId = VIDEOHUB_CATEGORIES_PLAYLIST_MAPPING[videoCategorySlug]
+
+  if (!playlistId) {
+    console.log(
+      JSON.stringify({
+        severity: 'WARNING',
+        message: `video_category page got unknown slug ${videoCategorySlug}, redirect back to section/videohub`,
+        globalLogFields,
+      })
+    )
+    return {
+      redirect: {
+        destination: '/section/videohub',
+        permanent: false,
+      },
+    }
+  }
+
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
-    axios({
-      method: 'get',
-      url: `${URL_RESTFUL_SERVER}/youtube/playlistItems`,
-      // use URLSearchParams to add two values for key 'part'
-      params: new URLSearchParams([
-        ['playlistId', VIDEOHUB_CATEGORIES_PLAYLIST_MAPPING[videoCategorySlug]],
-        ['part', 'snippet'],
-        ['part', 'status'],
-        ['maxResults', '15'],
-        ['pageToken', ''],
-      ]),
-    }),
-    client.query({
-      query: fetchCategory,
-      variables: {
-        categorySlug: videoCategorySlug,
-      },
-    }),
+    fetchYoutubePlaylistByPlaylistId(playlistId),
+    fetchVideoCategory(videoCategorySlug),
   ])
 
   const handledResponses = responses.map((response) => {
     if (response.status === 'fulfilled') {
+      if ('data' in response.value) {
+        // handle simple axios and gql response
+        return response.value.data
+      }
       return response.value
     } else if (response.status === 'rejected') {
       const annotatingError = errors.helpers.wrap(
@@ -125,6 +144,7 @@ export async function getServerSideProps({ query, req }) {
     }
   })
 
+  // handle header data
   const headerData =
     handledResponses[0] && 'sectionsData' in handledResponses[0]
       ? handledResponses[0]
@@ -136,34 +156,38 @@ export async function getServerSideProps({ query, req }) {
     ? headerData.topicsData
     : []
 
-  const videos =
-    handledResponses[1] && 'data' in handledResponses[1]
-      ? simplifyYoutubePlaylistVideo(
-          handledResponses[1]?.data?.items.filter(
-            /**
-             * @param {import('../section/videohub.js').YoutubeRawPlaylistVideo} item
-             * @returns
-             */
-            (item) => item.status.privacyStatus === 'public'
-          )
-        )
-      : []
-  const ytNextPageToken =
-    handledResponses[1] && 'data' in handledResponses[1]
-      ? handledResponses[1]?.data?.nextPageToken
-      : ''
+  // handle fetch videos and get nextPageToken for infinite scroll
 
-  const category =
-    handledResponses[2] && 'data' in handledResponses[2]
-      ? handledResponses[2]?.data?.category
-      : {}
-
-  const props = {
-    videos,
-    ytNextPageToken,
-    headerData: { sectionsData, topicsData },
-    category,
+  if (handledResponses[1]?.items?.length === 0) {
   }
+  const videos = handledResponses[1]?.items
+    ? simplifyYoutubePlaylistVideo(
+        handledResponses[1]?.items.filter(
+          /**
+           * @param {import('../section/videohub.js').YoutubeRawPlaylistVideo} item
+           * @returns
+           */
+          (item) => item.status.privacyStatus === 'public'
+        )
+      )
+    : []
+  const ytNextPageToken = handledResponses[1]?.nextPageToken || ''
+
+  const category = handledResponses[2]?.category || { slug: videoCategorySlug }
+
+  const props = mockError
+    ? {
+        videos: [],
+        ytNextPageToken: '',
+        headerData: { sectionsData, topicsData },
+        category: { slug: videoCategorySlug },
+      }
+    : {
+        videos,
+        ytNextPageToken,
+        headerData: { sectionsData, topicsData },
+        category,
+      }
 
   return { props }
 }

--- a/packages/mirror-media-next/utils/api/section-videohub.js
+++ b/packages/mirror-media-next/utils/api/section-videohub.js
@@ -1,0 +1,98 @@
+import axios from 'axios'
+import { URL_RESTFUL_SERVER } from '../../config/index.mjs'
+import client from '../../apollo/apollo-client'
+import { fetchSectionWithCategory } from '../../apollo/query/sections'
+
+/**
+ * fetch highest VC video published in latest one week in Mirror Media Channel
+ */
+export function fetchYoutubeHighestViewCountInOneWeek() {
+  const date = new Date()
+  // 1 week ago
+  date.setDate(date.getDate() - 7)
+  const oneWeekAgoTS = date.toISOString()
+  return fetchYoutubeHighestViewCountAfterTS(oneWeekAgoTS)
+}
+
+/**
+ * fetch highest VC video published after [ts] in Mirror Media channel
+ * @param {string} ts - ISO timestamp string, ex: 2023-06-13T12:53:54.422Z
+ */
+function fetchYoutubeHighestViewCountAfterTS(ts) {
+  return axios({
+    method: 'get',
+    url: `${URL_RESTFUL_SERVER}/youtube/search`,
+    params: new URLSearchParams([
+      ['channelId', 'UCYkldEK001GxR884OZMFnRw'],
+      ['part', 'snippet'],
+      ['order', 'viewCount'],
+      ['maxResults', '1'],
+      ['publishedAfter', ts],
+      ['type', 'video'],
+    ]),
+  })
+}
+
+/**
+ * fetch video for full data like non-truncated snippet.description
+ * @param {string} videoId
+ */
+export function fetcYoutubeVideoForFullDescription(videoId) {
+  return axios({
+    method: 'get',
+    url: `${URL_RESTFUL_SERVER}/youtube/videos`,
+    // use URLSearchParams to add two values for key 'part'
+    params: new URLSearchParams([
+      ['id', videoId],
+      ['part', 'snippet'],
+      ['part', 'status'],
+      ['maxResults', '1'],
+    ]),
+  })
+}
+
+/**
+ * fetch latest four video in Mirror Media channel
+ */
+export function fetchYoutubeLatestVideos() {
+  return axios({
+    method: 'get',
+    url: `${URL_RESTFUL_SERVER}/youtube/search`,
+    params: new URLSearchParams([
+      ['channelId', 'UCYkldEK001GxR884OZMFnRw'],
+      ['part', 'snippet'],
+      ['order', 'date'],
+      ['maxResults', '4'],
+      ['type', 'video'],
+    ]),
+  })
+}
+
+/**
+ * fetch section data for videohub
+ */
+export function fetchVideohubSection() {
+  return client.query({
+    query: fetchSectionWithCategory,
+    variables: {
+      where: {
+        slug: 'videohub',
+      },
+    },
+  })
+}
+
+export function fetchYoutubePlaylistByChannelId(channelId) {
+  return axios({
+    method: 'get',
+    url: `${URL_RESTFUL_SERVER}/youtube/playlistItems`,
+    // use URLSearchParams to add two values for key 'part'
+    params: new URLSearchParams([
+      ['playlistId', channelId],
+      ['part', 'snippet'],
+      ['part', 'status'],
+      ['maxResults', '10'],
+      ['pageToken', ''],
+    ]),
+  })
+}

--- a/packages/mirror-media-next/utils/api/video-category.js
+++ b/packages/mirror-media-next/utils/api/video-category.js
@@ -1,0 +1,33 @@
+import axios from 'axios'
+import { URL_RESTFUL_SERVER } from '../../config/index.mjs'
+import client from '../../apollo/apollo-client'
+import { fetchCategory } from '../../apollo/query/categroies'
+
+/**
+ * @param {string} playlistId - youtube playlist id
+ * @param {string} nextToken - youtube next page token to fetch more playlist item
+ * @returns
+ */
+export function fetchYoutubePlaylistByPlaylistId(playlistId, nextToken = '') {
+  return axios({
+    method: 'get',
+    url: `${URL_RESTFUL_SERVER}/youtube/playlistItems`,
+    // use URLSearchParams to add two values for key 'part'
+    params: new URLSearchParams([
+      ['playlistId', playlistId],
+      ['part', 'snippet'],
+      ['part', 'status'],
+      ['maxResults', '15'],
+      ['pageToken', nextToken],
+    ]),
+  })
+}
+
+export function fetchVideoCategory(videoCategorySlug) {
+  return client.query({
+    query: fetchCategory,
+    variables: {
+      categorySlug: videoCategorySlug,
+    },
+  })
+}

--- a/packages/mirror-media-next/utils/api/video.js
+++ b/packages/mirror-media-next/utils/api/video.js
@@ -1,0 +1,36 @@
+import axios from 'axios'
+import { URL_RESTFUL_SERVER } from '../../config/index.mjs'
+
+/**
+ * @param {string} videoId - youtube video id
+ */
+export function fetchYoutubeVideoByVideoId(videoId) {
+  return axios({
+    method: 'get',
+    url: `${URL_RESTFUL_SERVER}/youtube/videos`,
+    // use URLSearchParams to add two values for key 'part'
+    params: new URLSearchParams([
+      ['id', videoId],
+      ['part', 'snippet'],
+      ['part', 'status'],
+      ['maxResults', '1'],
+    ]),
+  })
+}
+
+/**
+ * @param {string} channelId - youtube channel id
+ */
+export function fetchYoutubeLatestVideosByChannelId(channelId) {
+  return axios({
+    method: 'get',
+    url: `${URL_RESTFUL_SERVER}/youtube/search`,
+    // use URLSearchParams to add two values for key 'part'
+    params: new URLSearchParams([
+      ['channelId', channelId],
+      ['part', 'snippet'],
+      ['order', 'date'],
+      ['maxResults', '6'],
+    ]),
+  })
+}


### PR DESCRIPTION
# Pages
- /section/videohub
- /video_category/{categorySlug}
- /video/{videoId}

# 404 
redirect back to /section/videohub

# 500
simply hide UI rather than show 500 UI

# Todo
- [ ] replace hiding UI with error prompt UI 
- [ ] remove mockError logic