### PR TITLE
feat(mm-next): add full screen ads

### DIFF
--- a/packages/mirror-media-next/components/ads/full-screen-ads/ad-item.js
+++ b/packages/mirror-media-next/components/ads/full-screen-ads/ad-item.js
@@ -1,0 +1,137 @@
+import styled, { css } from 'styled-components'
+import { Z_INDEX } from '../../../constants'
+import { useState } from 'react'
+
+/**
+ * @typedef {'default' | 'bottom' | 'modified'| 'unset'} FullScreenAdStyle
+ */
+
+const defaultWrapperStyle = css`
+  z-index: ${Z_INDEX.top};
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  background-color: rgba(0, 0, 0, 0.7);
+
+  .ad-item {
+    position: relative;
+    width: 320px;
+    height: 480px;
+  }
+`
+const bottomWrapperStyle = css`
+  background-color: transparent;
+  position: fixed;
+  top: initial;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: ${Z_INDEX.top};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  .ad-item {
+    position: relative;
+
+    height: 180px;
+  }
+`
+const modifiedWrapperStyle = css`
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  z-index: ${Z_INDEX.top};
+`
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 32px;
+  height: 32px;
+  padding: 5px;
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  box-shadow: 2px 2px 5px #d3d3d3;
+  background-color: #d3d3d3;
+  &::before,
+  &::after {
+    position: absolute;
+    content: '';
+    top: calc((20px + 5px) / 2);
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: white;
+    border-radius: 2px;
+  }
+  &:before {
+    transform: rotate(45deg);
+  }
+
+  &:after {
+    transform: rotate(-45deg);
+  }
+  &:focus {
+    outline: none;
+  }
+`
+
+const Wrapper = styled.div`
+  ${
+    /**
+     * @param {Object} param
+     * @param {FullScreenAdStyle} param.fullScreenAdStyle
+     */
+    ({ fullScreenAdStyle }) => {
+      switch (fullScreenAdStyle) {
+        case 'default':
+          return defaultWrapperStyle
+        case 'bottom':
+          return bottomWrapperStyle
+        case 'modified':
+          return modifiedWrapperStyle
+        case 'unset':
+          return null
+        default:
+          return null
+      }
+    }
+  }
+`
+/**
+ *
+ * @param {Object} props
+ * @param {boolean} [props.isAdFirstClosedBtnVisible]
+ * @param {FullScreenAdStyle } props.fullScreenAdStyle
+ * @param {JSX.Element} props.children
+ * @returns {JSX.Element}
+ */
+export default function FullScreenAdItem({
+  fullScreenAdStyle = 'unset',
+  isAdFirstClosedBtnVisible = false,
+  children,
+}) {
+  const [isEnabled, setIsEnabled] = useState(true)
+  const closeFullAd = () => {
+    setIsEnabled(false)
+  }
+  return (
+    <>
+      {isEnabled && (
+        <Wrapper fullScreenAdStyle={fullScreenAdStyle}>
+          <div className="ad-item">
+            {children}
+            {isAdFirstClosedBtnVisible && <CloseButton onClick={closeFullAd} />}
+          </div>
+        </Wrapper>
+      )}
+    </>
+  )
+}

--- a/packages/mirror-media-next/components/ads/full-screen-ads/index.js
+++ b/packages/mirror-media-next/components/ads/full-screen-ads/index.js
@@ -1,0 +1,172 @@
+import { useState, useEffect, useCallback } from 'react'
+
+import FullScreenAd from './ad-item'
+import GPTAd from '../gpt/gpt-ad'
+import { useDisplayAd } from '../../../hooks/useDisplayAd'
+
+/**
+ * @typedef {'default' | 'bottom' | 'modified'| 'unset'} FullScreenAdStyle
+ */
+
+/**
+ * 蓋板廣告有四層，分別為：第一層 FS、第二層BT、第三層 AD2、第四層 Innity
+ *
+ * 第一層 FS（AdFirst）：
+ * 帶有自定義的樣式和關閉按鈕，關閉按鈕在發送廣告請求後，延遲 3 秒才顯示
+ * 因為帶有自定義的透明灰底樣式，所以在廣告載入結束後才顯示（透過`setFullScreenAdStyle('default')`實作）
+ * 若沒有 FS 則顯示下一層 FS 廣告
+ *
+ * 第二層 BT（AdSecond）：
+ * 帶有自定義的樣式和關閉按鈕，關閉按鈕在發送廣告請求後，延遲 3 秒才顯示
+ * 若沒有 BT 則顯示下一層 AD2 廣告
+ *
+ * 第三層 AD2（AdThird）:
+ * AD2 為不額外帶有樣式的廣告，但因為 GPT Lazy loading 需要知道何時載入的位置
+ * 因此需要設置修正用樣式（`setFullScreenAdStyle('modified')`），來觸發廣告載入
+ * 當廣告載入完成後，就將該樣式移除 (`setFullScreenAdStyle('unset')`)
+ *
+ * 而 AD2 無法透過 GPT 的事件來確認是否有廣告，跟廠商協調後
+ * 當 AD2 沒廣告時，由廠商傳遞 noad2 事件，由我們監聽來顯示下一層 Innity 廣告
+ *
+ * 第四層 Innity（AdFourth）:
+ * 同 AD2 一樣為不額外帶有樣式的廣告，因此需要先設置修正用樣式
+ */
+export default function FullScreenAdsContainer() {
+  const [displayedAd, setDisplayedAd] = useState('first')
+  const hasAdFirst = displayedAd === 'first'
+  const hasAdSecond = displayedAd === 'second'
+  const hasAdThird = displayedAd === 'third'
+  const hasAdFourth = displayedAd === 'fourth'
+
+  const hasAdThirdOrFourth = hasAdThird || hasAdFourth
+  const shouldShowAd = useDisplayAd()
+  /** @type {[FullScreenAdStyle,import('react').Dispatch<FullScreenAdStyle>]} */
+  const [fullScreenAdStyle, setFullScreenAdStyle] = useState(
+    /** @type {FullScreenAdStyle} */
+    ('unset')
+  )
+  const [isAdFirstClosedBtnVisible, setIsAdFirstClosedBtnVisible] =
+    useState(false)
+  /**
+   * 監聽 noad2 事件，如果觸發該事件，代表並沒有第三層(MB_AD2)廣告沒有內容。
+   * 如果沒有內容，則設定目前應顯示的廣告為fourth，並且設置樣式為modified。
+   * 設置後將會顯示第四層廣告(MB_INNITY)的GPT廣告元件
+   */
+  useEffect(() => {
+    if (hasAdThird) {
+      const handleNoAD2 = () => {
+        setDisplayedAd('fourth')
+        setFullScreenAdStyle('modified')
+      }
+      window.addEventListener('noad2', handleNoAD2)
+      return () => window.removeEventListener('noad2', handleNoAD2)
+    }
+  }, [hasAdThird])
+  const setTimerForClosedBtn = useCallback(() => {
+    const timer = setTimeout(() => {
+      setIsAdFirstClosedBtnVisible(true)
+    }, 3000)
+    return () => clearTimeout(timer)
+  }, [])
+  /**
+   * 用於偵測第一層廣告(MB_FS)是否有內容。
+   * 如果有內容的話，則設定目前顯示的廣告為first，並且設置樣式為default。
+   * 如果沒有內容的話，則設定目前應顯示的廣告為second，並且設置樣式為bottom，設置後將會顯示第二層廣告(MB_BT)的GPT廣告元件。
+   */
+  const handleOnSlotRenderEndedFirst = useCallback(
+    (event) => {
+      const hasAd = !event.isEmpty
+      if (hasAd) {
+        setDisplayedAd('first')
+        setFullScreenAdStyle('default')
+      } else {
+        const cleanup = setTimerForClosedBtn()
+        cleanup()
+        setDisplayedAd('second')
+        setFullScreenAdStyle('bottom')
+      }
+    },
+    [setTimerForClosedBtn]
+  )
+  /**
+   * 用於偵測第二層廣告(MB_BT)是否有內容。
+   * 如果有內容的話，則設定目前顯示的廣告為second，並且設置樣式為bottom。
+   * 如果沒有內容的話，則設定目前應顯示的廣告為third，並且設置樣式為modified，設置後將會顯示第三層廣告(MB_BT)的GPT廣告元件。
+   */
+  const handleOnSlotRenderEndedSecond = useCallback(
+    (event) => {
+      const hasAd = !event.isEmpty
+      if (hasAd) {
+        setDisplayedAd('second')
+        setFullScreenAdStyle('bottom')
+      } else {
+        const cleanup = setTimerForClosedBtn()
+        cleanup()
+        setDisplayedAd('third')
+        setFullScreenAdStyle('modified')
+      }
+    },
+    [setTimerForClosedBtn]
+  )
+  const disableModifiedStyle = useCallback(() => {
+    setFullScreenAdStyle('unset')
+  }, [])
+  return (
+    <>
+      {shouldShowAd && (
+        <>
+          {hasAdFirst && (
+            <FullScreenAd
+              fullScreenAdStyle={fullScreenAdStyle}
+              isAdFirstClosedBtnVisible={isAdFirstClosedBtnVisible}
+            >
+              <GPTAd
+                key="ad-first"
+                pageKey="global"
+                adKey="MB_FS"
+                onSlotRequested={setTimerForClosedBtn}
+                onSlotRenderEnded={handleOnSlotRenderEndedFirst}
+              />
+            </FullScreenAd>
+          )}
+          {hasAdSecond && (
+            <FullScreenAd
+              fullScreenAdStyle={fullScreenAdStyle}
+              isAdFirstClosedBtnVisible={isAdFirstClosedBtnVisible}
+            >
+              <GPTAd
+                key="ad-second"
+                pageKey="global"
+                adKey="MB_BT"
+                onSlotRequested={setTimerForClosedBtn}
+                onSlotRenderEnded={handleOnSlotRenderEndedSecond}
+              />
+            </FullScreenAd>
+          )}
+          {hasAdThirdOrFourth && (
+            <FullScreenAd fullScreenAdStyle={fullScreenAdStyle}>
+              <>
+                {hasAdThird && (
+                  <GPTAd
+                    key="ad-third"
+                    pageKey="global"
+                    adKey="MB_AD2"
+                    onSlotRenderEnded={disableModifiedStyle}
+                  />
+                )}
+                {hasAdFourth && (
+                  <GPTAd
+                    key="ad-fourth"
+                    pageKey="global"
+                    adKey="MB_INNITY"
+                    onSlotRenderEnded={disableModifiedStyle}
+                  />
+                )}
+              </>
+            </FullScreenAd>
+          )}
+        </>
+      )}
+    </>
+  )
+}

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -20,7 +20,7 @@ import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import { fetchHeaderDataInPremiumPageLayout } from '../../utils/api'
 import { sendGAEvent } from '../../utils/gtag'
-
+import FullScreenAds from '../../components/ads/full-screen-ads'
 const { hasContentInRawContentBlock } = MirrorMedia
 
 const StoryWideStyle = dynamic(() => import('../../components/story/wide'))
@@ -213,6 +213,7 @@ export default function Story({ postData, headerData, storyLayoutType }) {
         {storyLayoutJsx}
         <WineWarning categories={categories} />
         <AdultOnlyWarning isAdult={isAdult} />
+        <FullScreenAds />
       </>
     </Layout>
   )


### PR DESCRIPTION
## Notable Change
1. 新增蓋板廣告元件。
2. 程式碼內容以[mirror-media-nuxt的對應元件](https://github.com/mirror-media/mirror-media-nuxt/blob/dev/components/ContainerFullScreenAds.vue)為基礎進行撰寫。
3. 小幅度重構程式碼，state減少至三個：該顯示何種廣告，統一由state `displayedAd`管理；廣告wrapper該顯示何種樣式，則由state `fullScreenAdStyle`；是否該顯示關閉按鈕，則由state `isAdFirstClosedBtnVisible`控制。