### PR TITLE
fix(mm-next/video_category): insert GPT Ads `MB_FT`&`PC_FT` into videos list

### DIFF
--- a/packages/mirror-media-next/components/video_category/video-list.js
+++ b/packages/mirror-media-next/components/video_category/video-list.js
@@ -1,5 +1,14 @@
 import styled from 'styled-components'
+import dynamic from 'next/dynamic'
+
+import useWindowDimensions from '../../hooks/use-window-dimensions'
 import VideoListItem from '../shared/video-list-item'
+import { mediaSize } from '../../styles/media'
+import { useDisplayAd } from '../../hooks/useDisplayAd'
+
+const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
 
 const Wrapper = styled.div`
   display: grid;
@@ -20,17 +29,84 @@ const Wrapper = styled.div`
   }
 `
 
+const StyledGPTAd_PC_FT = styled(GPTAd)`
+  display: none;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    width: 100%;
+    height: auto;
+    margin: 20px auto 0px;
+    max-width: 970px;
+    max-height: 250px;
+    display: block;
+  }
+`
+
+const StyledGPTAd_MB_FT = styled(GPTAd)`
+  width: 100%;
+  height: auto;
+  max-width: 336px;
+  max-height: 280px;
+  margin: 20px auto 0px;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
+  }
+`
+
 /**
  * @param {Object} props
  * @param {import('../../type/youtube').YoutubeVideo[]} props.videos
  * @returns {React.ReactElement}
  */
 export default function VideoList({ videos }) {
-  return (
-    <Wrapper>
-      {videos.map((video) => (
-        <VideoListItem key={video.id} video={video} />
-      ))}
-    </Wrapper>
+  const shouldShowAd = useDisplayAd()
+  const { width } = useWindowDimensions()
+  const isDesktopWidth = width >= mediaSize.xl
+
+  /**
+   * Renders a video list component with a maximum of 16 videos displayed at the top,
+   * followed by an Pc ad component, and the remaining videos displayed below.
+   *
+   * @return {JSX.Element} The JSX code for the PC video list.
+   */
+  const renderPcVideoList = () => (
+    <>
+      <Wrapper>
+        {videos.slice(0, 16).map((video) => (
+          <VideoListItem key={video.id} video={video} />
+        ))}
+      </Wrapper>
+      {shouldShowAd && <StyledGPTAd_PC_FT pageKey="videohub" adKey="PC_FT" />}
+      <Wrapper>
+        {videos.slice(16).map((video) => (
+          <VideoListItem key={video.id} video={video} />
+        ))}
+      </Wrapper>
+    </>
   )
+
+  /**
+   * Renders a video list component with a maximum of 6 videos displayed at the top,
+   * followed by an Mb ad component, and the remaining videos displayed below.
+   *
+   * @return {JSX.Element} The rendered video list component.
+   */
+  const renderMbVideoList = () => (
+    <>
+      <Wrapper>
+        {videos.slice(0, 6).map((video) => (
+          <VideoListItem key={video.id} video={video} />
+        ))}
+      </Wrapper>
+      {shouldShowAd && <StyledGPTAd_MB_FT pageKey="videohub" adKey="MB_FT" />}
+      <Wrapper>
+        {videos.slice(6).map((video) => (
+          <VideoListItem key={video.id} video={video} />
+        ))}
+      </Wrapper>
+    </>
+  )
+
+  return <>{isDesktopWidth ? renderPcVideoList() : renderMbVideoList()}</>
 }

--- a/packages/mirror-media-next/pages/video_category/[slug].js
+++ b/packages/mirror-media-next/pages/video_category/[slug].js
@@ -58,19 +58,6 @@ const StyledGPTAd_MB_HD = styled(GPTAd)`
   }
 `
 
-const StyledGPTAd_PC_FT = styled(GPTAd)`
-  display: none;
-
-  ${({ theme }) => theme.breakpoint.xl} {
-    width: 100%;
-    height: auto;
-    margin: 20px auto 0px;
-    max-width: 970px;
-    max-height: 250px;
-    display: block;
-  }
-`
-
 const StickyGPTAd_MB_ST = styled(GPTAd)`
   display: block;
   position: fixed;
@@ -132,7 +119,6 @@ export default function VideoCategory({
             categorySlug={category.slug}
           />
         )}
-        {shouldShowAd && <StyledGPTAd_PC_FT pageKey="videohub" adKey="PC_FT" />}
         {shouldShowAd && <StickyGPTAd_MB_ST pageKey="videohub" adKey="MB_ST" />}
       </Wrapper>
     </Layout>


### PR DESCRIPTION
於影音分類頁 `/video_category` 影音列表中插入 Gpt 廣告，桌機`PC_FT`於第四排之下，平板及手機 `MB_FT` 於第六則影片之後。