### PR TITLE
feat(mm-next): add ga page-view on amp page

### DIFF
--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -11,7 +11,7 @@ import {
 } from '../../../utils'
 import { handleStoryPageRedirect } from '../../../utils/story'
 import { fetchPostBySlug } from '../../../apollo/query/posts'
-import { GCP_PROJECT_ID } from '../../../config/index.mjs'
+import { GCP_PROJECT_ID, GA_MEASUREMENT_ID } from '../../../config/index.mjs'
 import styled from 'styled-components'
 import AdultOnlyWarning from '../../../components/story/shared/adult-only-warning'
 import WineWarning from '../../../components/story/shared/wine-warning'
@@ -64,6 +64,31 @@ function StoryAmpPage({ postData }) {
       <Head>
         <title>{title}</title>
       </Head>
+      <amp-analytics
+        type="googleanalytics"
+        config="https://amp.analytics-debugger.com/ga4.json"
+        data-credentials="include"
+      >
+        <script
+          type="application/json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              vars: {
+                GA4_MEASUREMENT_ID: GA_MEASUREMENT_ID,
+                GA4_ENDPOINT_HOSTNAME: 'www.google-analytics.com',
+                GOOGLE_CONSENT_ENABLED: false,
+                WEBVITALS_TRACKING: false,
+                PERFORMANCE_TIMING_TRACKING: false,
+                DEFAULT_PAGEVIEW_ENABLED: true,
+                SEND_DOUBLECLICK_BEACON: false,
+                DISABLE_REGIONAL_DATA_COLLECTION: false,
+                ENHANCED_MEASUREMENT_SCROLL: false,
+              },
+            }),
+          }}
+        />
+      </amp-analytics>
+
       <AmpBody>
         <section
           id="amp-page"


### PR DESCRIPTION
## Notable Change
1. 於amp頁面中新增ga4
2. 先上到測試機驗收&測試，若驗收後沒問題的話，則會另外重構程式碼。

ref: 
https://github.com/analytics-debugger/google-analytics-4-for-amp
https://www.thyngster.com/how-to-track-amp-pages-with-google-analytics-4#setting-up-the-tracking