### PR TITLE
feat(story): insert GPT ad in context

### DIFF
--- a/packages/mirror-media-next/components/story/normal/article-content.js
+++ b/packages/mirror-media-next/components/story/normal/article-content.js
@@ -1,13 +1,47 @@
 import styled from 'styled-components'
 import DraftRenderBlock from '../shared/draft-renderer-block'
+import { copyAndSliceDraftBlock, getBlocksCount } from '../../../utils/story'
+import dynamic from 'next/dynamic'
+import useWindowDimensions from '../../../hooks/use-window-dimensions'
+import { useDisplayAd } from '../../../hooks/useDisplayAd'
+import { getSectionGPTPageKey } from '../../../utils/ad'
+
+const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
+
 /**
  * @typedef {import('../../../type/draft-js').Draft} Content
  */
 
 const Wrapper = styled.section`
   margin-top: 32px;
+  display: grid;
+  gap: 32px;
+
   ${({ theme }) => theme.breakpoint.md} {
     margin-top: 20px;
+  }
+`
+
+const StyledGPTAd = styled(GPTAd)`
+  width: 100%;
+  height: auto;
+  max-width: 336px;
+  max-height: 280px;
+  margin: auto;
+
+  display: ${
+    /**
+     * @param {Object} props
+     * @param {string | undefined} props.pageKey
+     */
+    (props) => (props.pageKey ? 'block' : 'none')
+  };
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 640px;
+    max-height: 390px;
   }
 `
 
@@ -15,16 +49,74 @@ const Wrapper = styled.section`
  *
  * @param {Object} props
  * @param {Content} props.content
+ * @param {string | undefined} props.sectionSlug
  * @returns {JSX.Element}
  */
 export default function ArticleContent({
   content = { blocks: [], entityMap: {} },
+  sectionSlug,
 }) {
-  return (
-    <DraftRenderBlock
-      rawContentBlock={content}
-      contentLayout="normal"
-      wrapper={(children) => <Wrapper>{children}</Wrapper>}
-    />
+  const shouldShowAd = useDisplayAd()
+  const windowDimensions = useWindowDimensions()
+
+  const blocksLength = getBlocksCount(content)
+  const GPTpageKey = getSectionGPTPageKey(sectionSlug)
+
+  //The GPT advertisement for the `mobile` version includes `AT1` & `AT2`
+  const MB_contentJsx = (
+    <Wrapper>
+      <DraftRenderBlock
+        rawContentBlock={copyAndSliceDraftBlock(content, 0, 1)}
+        contentLayout="normal"
+      />
+
+      {blocksLength > 1 && (
+        <>
+          {shouldShowAd && <StyledGPTAd pageKey={GPTpageKey} adKey="MB_AT1" />}
+
+          <DraftRenderBlock
+            rawContentBlock={copyAndSliceDraftBlock(content, 1, 5)}
+            contentLayout="normal"
+          />
+        </>
+      )}
+
+      {blocksLength > 5 && (
+        <>
+          {shouldShowAd && <StyledGPTAd pageKey={GPTpageKey} adKey="MB_AT2" />}
+
+          <DraftRenderBlock
+            rawContentBlock={copyAndSliceDraftBlock(content, 5)}
+            contentLayout="normal"
+          />
+        </>
+      )}
+    </Wrapper>
   )
+
+  //The GPT advertisement for the `desktop` version only `AT1`
+  const PC_contentJsx = (
+    <Wrapper>
+      <DraftRenderBlock
+        rawContentBlock={copyAndSliceDraftBlock(content, 0, 3)}
+        contentLayout="normal"
+      />
+
+      {blocksLength > 3 && (
+        <>
+          {shouldShowAd && <StyledGPTAd pageKey={GPTpageKey} adKey="PC_AT1" />}
+
+          <DraftRenderBlock
+            rawContentBlock={copyAndSliceDraftBlock(content, 3)}
+            contentLayout="normal"
+          />
+        </>
+      )}
+    </Wrapper>
+  )
+
+  const contentJsx =
+    windowDimensions.width > 1200 ? PC_contentJsx : MB_contentJsx
+
+  return <>{contentJsx}</>
 }

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -25,7 +25,6 @@ import {
   transformTimeDataIntoDotFormat,
   sortArrayWithOtherArrayId,
 } from '../../../utils'
-// import { fetchHeaderDataInDefaultPageLayout } from '../../../utils/api'
 import { fetchAsidePosts } from '../../../apollo/query/posts'
 import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
 import { useDisplayAd } from '../../../hooks/useDisplayAd'
@@ -561,6 +560,7 @@ export default function StoryNormalStyle({
   const updatedTaipeiTime = transformTimeDataIntoDotFormat(updatedAt)
 
   const shouldShowAd = useDisplayAd()
+
   return (
     <>
       <ShareHeader
@@ -601,7 +601,10 @@ export default function StoryNormalStyle({
           </InfoAndHero>
 
           <ArticleBrief sectionSlug={section?.slug} brief={brief} />
-          <ArticleContent content={postContent.data} />
+          <ArticleContent
+            content={postContent.data}
+            sectionSlug={section?.slug}
+          />
           <DateUnderContent>
             <span>更新時間｜</span>
             <span className="time">{updatedTaipeiTime} 臺北時間</span>

--- a/packages/mirror-media-next/components/story/premium/article-content.js
+++ b/packages/mirror-media-next/components/story/premium/article-content.js
@@ -1,0 +1,83 @@
+import styled from 'styled-components'
+import DraftRenderBlock from '../shared/draft-renderer-block'
+import dynamic from 'next/dynamic'
+import { copyAndSliceDraftBlock, getBlocksCount } from '../../../utils/story'
+import useWindowDimensions from '../../../hooks/use-window-dimensions'
+import { useDisplayAd } from '../../../hooks/useDisplayAd'
+import { SECTION_IDS } from '../../../constants'
+
+const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
+
+/**
+ * @typedef {import('../../../type/draft-js').Draft} Content
+ */
+
+const Wrapper = styled.section`
+  display: grid;
+  gap: 32px;
+`
+
+const StyledGPTAd = styled(GPTAd)`
+  width: 100%;
+  height: auto;
+  max-width: 336px;
+  max-height: 280px;
+  margin: auto;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 640px;
+    max-height: 390px;
+  }
+`
+
+/**
+ *
+ * @param {Object} props
+ * @param {Content} props.content
+ *  @param {string} [props.className]
+ * @returns {JSX.Element}
+ */
+export default function PremiumArticleContent({
+  content = { blocks: [], entityMap: {} },
+  className = '',
+}) {
+  const shouldShowAd = useDisplayAd()
+  const windowDimensions = useWindowDimensions()
+  const blocksLength = getBlocksCount(content)
+
+  //The GPT advertisement for the `mobile` version includes `AT1`
+  const MB_contentJsx = (
+    <Wrapper className={className}>
+      <DraftRenderBlock
+        rawContentBlock={copyAndSliceDraftBlock(content, 0, 1)}
+        contentLayout="premium"
+      />
+
+      {blocksLength > 1 && (
+        <>
+          {shouldShowAd && (
+            <StyledGPTAd pageKey={SECTION_IDS['member']} adKey="MB_AT1" />
+          )}
+
+          <DraftRenderBlock
+            rawContentBlock={copyAndSliceDraftBlock(content, 1)}
+            contentLayout="premium"
+          />
+        </>
+      )}
+    </Wrapper>
+  )
+
+  const PC_contentJsx = (
+    <Wrapper className={className}>
+      <DraftRenderBlock rawContentBlock={content} contentLayout="premium" />
+    </Wrapper>
+  )
+
+  const contentJsx =
+    windowDimensions.width > 1200 ? PC_contentJsx : MB_contentJsx
+
+  return <>{contentJsx}</>
+}

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
-import DraftRenderBlock from '../shared/draft-renderer-block'
 import ArticleBrief from '../shared/brief'
+import PremiumArticleContent from './article-content'
 import { sortArrayWithOtherArrayId } from '../../../utils'
 import TitleAndInfoAndHero from './title-and-info-and-hero'
 import CopyrightWarning from '../shared/copyright-warning'
@@ -331,12 +331,12 @@ export default function StoryPremiumStyle({
                 contentLayout="premium"
               />
             </section>
-            <section className="content">
-              <DraftRenderBlock
-                contentLayout="premium"
-                rawContentBlock={postContent.data}
-              />
-            </section>
+
+            <PremiumArticleContent
+              className="content"
+              content={postContent.data}
+            />
+
             <CopyrightWarning />
 
             {shouldShowArticleMask && <ArticleMask postId={id} />}

--- a/packages/mirror-media-next/utils/ad.js
+++ b/packages/mirror-media-next/utils/ad.js
@@ -63,7 +63,7 @@ const getMicroAdUnitId = (
  */
 function getPageKeyByPartnerSlug(partnerSlug = '') {
   const validPartnerSlugs = ['ebc', 'healthnews', 'zuchi', '5678news']
-  return validPartnerSlugs.includes(partnerSlug) ? SECTION_IDS.news : 'other'
+  return validPartnerSlugs.includes(partnerSlug) ? SECTION_IDS['news'] : 'other'
 }
 
 /**

--- a/packages/mirror-media-next/utils/story.js
+++ b/packages/mirror-media-next/utils/story.js
@@ -1,3 +1,6 @@
+import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
+const { removeEmptyContentBlock, hasContentInRawContentBlock } = MirrorMedia
+
 /**
  * @typedef {Object} Redirect
  * @property {{ destination: string, permanent: boolean }} redirect
@@ -40,4 +43,54 @@ const handleStoryPageRedirect = (redirect) => {
   }
 }
 
-export { handleStoryPageRedirect }
+/**
+ * @typedef {import('../type/draft-js').Draft} Content
+ */
+
+/**
+ * Copy draft data and returns a new data after slice.
+ *
+ * @param {Content} content - The original draft data object.
+ * @param {number} startIndex - The start index of the block to slice.
+ * @param {number} [endIndex] - The end index of the block to slice.
+ * @return {Content}
+ */
+const copyAndSliceDraftBlock = (
+  content = { blocks: [], entityMap: {} },
+  startIndex,
+  endIndex
+) => {
+  const shouldRenderDraft = hasContentInRawContentBlock(content)
+
+  if (shouldRenderDraft) {
+    const contentWithoutEmptyBlock = removeEmptyContentBlock(content)
+    const newContent = JSON.parse(JSON.stringify(contentWithoutEmptyBlock))
+
+    if (newContent.blocks.length >= endIndex) {
+      newContent.blocks = newContent.blocks.slice(startIndex, endIndex)
+    } else if (newContent.blocks.length > startIndex) {
+      newContent.blocks = newContent.blocks.slice(startIndex)
+    } else {
+      return { blocks: [], entityMap: {} }
+    }
+
+    return newContent
+  }
+}
+
+/**
+ * Return the total number of non-empty content blocks.
+ *
+ * @param {Content} content
+ * @return {number} The number of non-empty content blocks.
+ */
+
+const getBlocksCount = (content) => {
+  if (hasContentInRawContentBlock(content)) {
+    return removeEmptyContentBlock(content).blocks.length
+  } else {
+    return 0
+  }
+}
+
+export { handleStoryPageRedirect, copyAndSliceDraftBlock, getBlocksCount }


### PR DESCRIPTION
### Notable Change 
- `story/normal`、`story/premium` 新增文內 GPT 廣告（AT1、AT2）

   - 手機：AT1 放第一段後，AT2 放第五段後。  
   - 桌機：AT1 放第三段後，AT2 不顯示。  

- `external/[slug]` 廣告修改
   - GPT 廣告：
      - partner 為東森、慈濟、健康醫療網、好醫師者，為「時事」(news)  廣告單元。
      - 其餘為「其他」(other)  廣告單元。 
   - 新增文末： Dable 廣告。
   - 延伸閱讀區塊新增：PopIn 特企 ＋ Micro 特企
   - 側欄熱門文章區塊新增：PopIn 特企（第三、五篇）