### PR TITLE
feat(mm-next/premiumsection): add gpt ads

### DIFF
--- a/packages/mirror-media-next/components/shared/premium-article-list.js
+++ b/packages/mirror-media-next/components/shared/premium-article-list.js
@@ -1,5 +1,12 @@
 import styled from 'styled-components'
+import dynamic from 'next/dynamic'
 import PremiumArticleListItem from './premium-article-list-item'
+import { useDisplayAd } from '../../hooks/useDisplayAd'
+import { SECTION_IDS } from '../../constants/index'
+
+const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
 
 const ItemContainer = styled.div`
   display: grid;
@@ -17,6 +24,20 @@ const ItemContainer = styled.div`
   }
 `
 
+const StyledGPTAd = styled(GPTAd)`
+  width: 100%;
+  height: auto;
+  max-width: 336px;
+  max-height: 280px;
+  margin: 20px auto;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 970px;
+    max-height: 250px;
+    margin: 35px auto;
+  }
+`
+
 /**
  * @typedef {import('./premium-article-list-item').Article} Article
  * @typedef {import('./premium-article-list-item').Section} Section
@@ -29,11 +50,28 @@ const ItemContainer = styled.div`
  * @returns {React.ReactElement}
  */
 export default function PremiumArticleList({ renderList, section }) {
+  const shouldShowAd = useDisplayAd()
+
+  const renderListBeforeAd = renderList.slice(0, 12)
+  const renderListAfterAd = renderList.slice(12)
+
   return (
-    <ItemContainer>
-      {renderList.map((item) => (
-        <PremiumArticleListItem key={item.id} item={item} section={section} />
-      ))}
-    </ItemContainer>
+    <>
+      <ItemContainer>
+        {renderListBeforeAd.map((item) => (
+          <PremiumArticleListItem key={item.id} item={item} section={section} />
+        ))}
+      </ItemContainer>
+
+      {shouldShowAd && (
+        <StyledGPTAd pageKey={SECTION_IDS['member']} adKey="FT" />
+      )}
+
+      <ItemContainer>
+        {renderListAfterAd.map((item) => (
+          <PremiumArticleListItem key={item.id} item={item} section={section} />
+        ))}
+      </ItemContainer>
+    </>
   )
 }

--- a/packages/mirror-media-next/pages/premiumsection/[slug].js
+++ b/packages/mirror-media-next/pages/premiumsection/[slug].js
@@ -1,5 +1,6 @@
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
+import dynamic from 'next/dynamic'
 
 import SectionArticles from '../../components/shared/section-articles'
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
@@ -9,6 +10,13 @@ import {
   fetchPremiumPostsBySectionSlug,
   fetchSectionBySectionSlug,
 } from '../../utils/api/premiumsection'
+import { SECTION_IDS } from '../../constants/index'
+import { Z_INDEX } from '../../constants/index'
+import { useDisplayAd } from '../../hooks/useDisplayAd'
+
+const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -71,6 +79,35 @@ const SectionTitle = styled.h1`
   }
 `
 
+const StyledGPTAd_HD = styled(GPTAd)`
+  width: 100%;
+  height: auto;
+  max-width: 336px;
+  max-height: 280px;
+  margin: 20px auto 0px;
+  ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 970px;
+    max-height: 250px;
+  }
+`
+
+const StickyGPTAd_MB_ST = styled(GPTAd)`
+  display: block;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: auto;
+  max-width: 320px;
+  max-height: 50px;
+  margin: auto;
+  z-index: ${Z_INDEX.top};
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
+  }
+`
+
 const RENDER_PAGE_SIZE = 12
 
 /**
@@ -89,6 +126,9 @@ const RENDER_PAGE_SIZE = 12
  */
 export default function Section({ postsCount, posts, section, headerData }) {
   const sectionName = section.name || ''
+
+  const shouldShowAd = useDisplayAd()
+
   return (
     <Layout
       head={{ title: `${sectionName}分類報導` }}
@@ -96,6 +136,9 @@ export default function Section({ postsCount, posts, section, headerData }) {
       footer={{ type: 'default' }}
     >
       <SectionContainer>
+        {shouldShowAd && (
+          <StyledGPTAd_HD pageKey={SECTION_IDS['member']} adKey="HD" />
+        )}
         {sectionName && (
           <SectionTitle sectionName={section.slug}>{sectionName}</SectionTitle>
         )}
@@ -106,6 +149,9 @@ export default function Section({ postsCount, posts, section, headerData }) {
           renderPageSize={RENDER_PAGE_SIZE}
           isPremium={true}
         />
+        {shouldShowAd && (
+          <StickyGPTAd_MB_ST pageKey={SECTION_IDS['member']} adKey="MB_ST" />
+        )}
       </SectionContainer>
     </Layout>
   )


### PR DESCRIPTION
於 /premiumsection 新增 member gpt 廣告

- 桌機及手機頁首：`PC_HD`、`MB_HD` 
- 手機頁緣：`MB_ST`
- 桌機及手機第12則文章之後： `PC_FT`、`MB_FT`