### PR TITLE
feat(ad): add `hiddenAdvertised` props in related/aside lists

### DIFF
--- a/packages/mirror-media-next/components/ads/full-screen-ads/index.js
+++ b/packages/mirror-media-next/components/ads/full-screen-ads/index.js
@@ -31,7 +31,14 @@ import { useDisplayAd } from '../../../hooks/useDisplayAd'
  * 第四層 Innity（AdFourth）:
  * 同 AD2 一樣為不額外帶有樣式的廣告，因此需要先設置修正用樣式
  */
-export default function FullScreenAdsContainer() {
+
+/**
+ *
+ * @param {Object} props
+ * @param {boolean} [props.hiddenAdvertised] - CMS Posts「google廣告違規」
+ * @returns {JSX.Element}
+ */
+export default function FullScreenAdsContainer({ hiddenAdvertised = false }) {
   const [displayedAd, setDisplayedAd] = useState('first')
   const hasAdFirst = displayedAd === 'first'
   const hasAdSecond = displayedAd === 'second'
@@ -39,7 +46,7 @@ export default function FullScreenAdsContainer() {
   const hasAdFourth = displayedAd === 'fourth'
 
   const hasAdThirdOrFourth = hasAdThird || hasAdFourth
-  const shouldShowAd = useDisplayAd()
+  const shouldShowAd = useDisplayAd(hiddenAdvertised)
   /** @type {[FullScreenAdStyle,import('react').Dispatch<FullScreenAdStyle>]} */
   const [fullScreenAdStyle, setFullScreenAdStyle] = useState(
     /** @type {FullScreenAdStyle} */

--- a/packages/mirror-media-next/components/story/normal/aside-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/aside-article-list.js
@@ -259,6 +259,7 @@ const TitleLoading = styled(Title)`
  * - If rejected, it will return an empty array
  * @param {number} [props.renderAmount]
  * - a number of article we want to render, it will determine the height of `ArticleWrapper` to prevent Cumulative Layout Shift (CLS) problem after article is loaded.
+ * @param {boolean} [props.hiddenAdvertised] - CMS Posts「google廣告違規」
  * @returns {JSX.Element}
  */
 export default function AsideArticleList({
@@ -266,8 +267,9 @@ export default function AsideArticleList({
   shouldReverseOrder = false,
   fetchArticle,
   renderAmount = 6,
+  hiddenAdvertised = false,
 }) {
-  const shouldShowAd = useDisplayAd()
+  const shouldShowAd = useDisplayAd(hiddenAdvertised)
 
   const wrapperRef = useRef(null)
   const [item, setItem] = useState([])

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -614,7 +614,11 @@ export default function StoryNormalStyle({
           <SupportMirrorMediaBanner />
           <SocialNetworkServiceSmall />
           <SubscribeInviteBanner />
-          <RelatedArticleList relateds={relatedsWithOrdered} />
+          <RelatedArticleList
+            relateds={relatedsWithOrdered}
+            hiddenAdvertised={hiddenAdvertised}
+          />
+
           {shouldShowAd && (
             <StyledGPTAd_MB_AT3
               pageKey={getSectionGPTPageKey(section?.slug)}
@@ -705,6 +709,7 @@ export default function StoryNormalStyle({
             fetchArticle={handleFetchPopularNews}
             shouldReverseOrder={false}
             renderAmount={6}
+            hiddenAdvertised={hiddenAdvertised}
           />
 
           <AsideFbPagePlugin />

--- a/packages/mirror-media-next/components/story/normal/related-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/related-article-list.js
@@ -154,13 +154,17 @@ const AdvertisementWrapper = styled.div`
  *
  * @param {Object} props
  * @param {Relateds} props.relateds
+ * @param {boolean} [props.hiddenAdvertised] - CMS Posts「google廣告違規」
  * @returns {JSX.Element}
  */
-export default function RelatedArticleList({ relateds }) {
+export default function RelatedArticleList({
+  relateds,
+  hiddenAdvertised = false,
+}) {
   const { width } = useWindowDimensions()
   const device = width >= mediaSize.xl ? 'PC' : 'MB'
 
-  const shouldShowAd = useDisplayAd()
+  const shouldShowAd = useDisplayAd(hiddenAdvertised)
 
   const relatedsArticleJsx = relateds.length ? (
     <ArticleWrapper>

--- a/packages/mirror-media-next/components/whole-site-script.js
+++ b/packages/mirror-media-next/components/whole-site-script.js
@@ -1,11 +1,13 @@
 import GPTScript from './ads/gpt/gpt-script'
 import AvividScript from './ads/avivid/avivid-script'
+import { useDisplayAd } from '../hooks/useDisplayAd'
 
 export default function WholeSiteScript() {
+  const shouldShowAd = useDisplayAd()
   return (
     <>
       <GPTScript />
-      <AvividScript />
+      {shouldShowAd && <AvividScript />}
     </>
   )
 }

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -89,6 +89,7 @@ export default function Story({ postData, headerData, storyLayoutType }) {
     isMember = false,
     content = null,
     trimmedContent = null,
+    hiddenAdvertised = false,
   } = postData
 
   /**
@@ -213,7 +214,7 @@ export default function Story({ postData, headerData, storyLayoutType }) {
         {storyLayoutJsx}
         <WineWarning categories={categories} />
         <AdultOnlyWarning isAdult={isAdult} />
-        <FullScreenAds />
+        <FullScreenAds hiddenAdvertised={hiddenAdvertised} />
       </>
     </Layout>
   )


### PR DESCRIPTION
- 新增 `hiddenAdvertised` props
   - 文章頁 - 側欄熱門文章區塊：如勾選「廣告違規」則不顯示廣告（PopIn）。
   - 文章頁 - 相關文章區塊：如勾選「廣告違規」則不顯示廣告（PopIn/Micro）。
   - 全站 - 蓋版廣告：如勾選「廣告違規」則不顯示廣告。
   
- 全站 Avivid 廣告：新增 `shouldShowAd` 條件判斷，如為指定會員狀態不顯示廣告。