### PR TITLE
feat(mm-next/topic-list): move GPT ad after the 12th article

### DIFF
--- a/packages/mirror-media-next/components/topic/group/topic-group.js
+++ b/packages/mirror-media-next/components/topic/group/topic-group.js
@@ -1,5 +1,11 @@
 import styled from 'styled-components'
 import TopicGroupArticles from './topic-group-articles'
+import dynamic from 'next/dynamic'
+
+import { useDisplayAd } from '../../../hooks/useDisplayAd'
+const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
 
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
@@ -49,6 +55,17 @@ const TopicGroups = styled.div`
   flex-direction: column;
 `
 
+const StyledGPTAd = styled(GPTAd)`
+  width: 100%;
+  height: auto;
+  margin: 20px auto;
+  ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 970px;
+    max-height: 250px;
+    margin: 35px auto;
+  }
+`
+
 /**
  * @typedef {import('../../../apollo/fragments/photo').Photo & {
  *  id: string;
@@ -87,7 +104,8 @@ const TopicGroups = styled.div`
  * @returns {React.ReactElement}
  */
 export default function TopicGroup({ topic }) {
-  const { style, posts, tags } = topic
+  const { style, posts, tags, dfp } = topic
+  const shouldShowAd = useDisplayAd()
 
   return (
     <>
@@ -103,6 +121,7 @@ export default function TopicGroup({ topic }) {
               )}
             />
           ))}
+          {shouldShowAd && dfp && <StyledGPTAd adUnit={dfp} />}
         </TopicGroups>
       </Container>
     </>

--- a/packages/mirror-media-next/components/topic/list/list-articles.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles.js
@@ -1,5 +1,22 @@
 import styled from 'styled-components'
 import ListArticlesItem from './list-articles-item'
+import dynamic from 'next/dynamic'
+
+import { useDisplayAd } from '../../../hooks/useDisplayAd'
+const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
+
+const StyledGPTAd = styled(GPTAd)`
+  width: 100%;
+  height: auto;
+  margin: 0 auto 20px auto;
+  ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 970px;
+    max-height: 250px;
+    margin: 0 auto 35px auto;
+  }
+`
 
 const ItemContainer = styled.div`
   display: grid;
@@ -25,14 +42,27 @@ const ItemContainer = styled.div`
 /**
  * @param {Object} props
  * @param {Article[]} props.renderList
+ * @param {string} props.dfp
  * @returns {React.ReactElement}
  */
-export default function ListArticles({ renderList }) {
+export default function ListArticles({ renderList, dfp }) {
+  const shouldShowAd = useDisplayAd()
+  const renderListBeforeAd = renderList.slice(0, 12)
+  const renderListAfterAd = renderList.slice(12)
+
   return (
-    <ItemContainer>
-      {renderList.map((item) => (
-        <ListArticlesItem key={item.id} item={item} />
-      ))}
-    </ItemContainer>
+    <>
+      <ItemContainer>
+        {renderListBeforeAd.map((item) => (
+          <ListArticlesItem key={item.id} item={item} />
+        ))}
+      </ItemContainer>
+      {shouldShowAd && dfp && <StyledGPTAd adUnit={dfp} />}
+      <ItemContainer>
+        {renderListAfterAd.map((item) => (
+          <ListArticlesItem key={item.id} item={item} />
+        ))}
+      </ItemContainer>
+    </>
   )
 }

--- a/packages/mirror-media-next/components/topic/list/topic-list-articles.js
+++ b/packages/mirror-media-next/components/topic/list/topic-list-articles.js
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 
 import InfiniteScrollList from '../../infinite-scroll-list'
 import Image from 'next/legacy/image'
+// @ts-ignore
 import LoadingPage from '../../../public/images/loading_page.gif'
 import ListArticles from './list-articles'
 import { fetchTopicByTopicId } from '../../../utils/api/topic'
@@ -28,6 +29,7 @@ const Loading = styled.div`
  * @param {Article[]} props.posts
  * @param {string} props.topicId
  * @param {number} props.renderPageSize
+ * @param {string} props.dfp
  * @returns {React.ReactElement}
  */
 export default function TopicListArticles({
@@ -35,6 +37,7 @@ export default function TopicListArticles({
   posts,
   topicId,
   renderPageSize,
+  dfp,
 }) {
   const fetchPageSize = renderPageSize
   async function fetchTopicPostsFromPage(page) {
@@ -67,7 +70,7 @@ export default function TopicListArticles({
       fetchListInPage={fetchTopicPostsFromPage}
       loader={loader}
     >
-      {(renderList) => <ListArticles renderList={renderList} />}
+      {(renderList) => <ListArticles renderList={renderList} dfp={dfp} />}
     </InfiniteScrollList>
   )
 }

--- a/packages/mirror-media-next/components/topic/list/topic-list.js
+++ b/packages/mirror-media-next/components/topic/list/topic-list.js
@@ -51,7 +51,7 @@ const Topic = styled.div`
   }
   ${({ theme }) => theme.breakpoint.xl} {
     height: 600px;
-    padding-top 0;
+    padding-top: 0;
   }
 `
 const TopicTitle = styled.div`
@@ -233,6 +233,7 @@ export default function TopicList({ topic, renderPageSize, slideshowImages }) {
           posts={posts}
           postsCount={postsCount}
           renderPageSize={renderPageSize}
+          dfp={topic.dfp}
         />
       </Container>
     </>

--- a/packages/mirror-media-next/pages/topic/[id].js
+++ b/packages/mirror-media-next/pages/topic/[id].js
@@ -1,6 +1,4 @@
 import errors from '@twreporter/errors'
-import styled from 'styled-components'
-import dynamic from 'next/dynamic'
 
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import TopicList from '../../components/topic/list/topic-list'
@@ -14,20 +12,6 @@ import {
   sortArrayWithOtherArrayId,
 } from '../../utils/index'
 import { fetchTopicByTopicId } from '../../utils/api/topic'
-import { useDisplayAd } from '../../hooks/useDisplayAd'
-const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
-  ssr: false,
-})
-
-const StyledGPTAd = styled(GPTAd)`
-  width: 100%;
-  height: auto;
-  margin: 20px auto 0px;
-  ${({ theme }) => theme.breakpoint.xl} {
-    max-width: 970px;
-    max-height: 250px;
-  }
-`
 
 const RENDER_PAGE_SIZE = 12
 
@@ -44,7 +28,6 @@ const RENDER_PAGE_SIZE = 12
  * @returns
  */
 export default function Topic({ topic, slideshowImages, headerData }) {
-  const shouldShowAd = useDisplayAd()
   let topicJSX
 
   switch (topic.type) {
@@ -56,7 +39,6 @@ export default function Topic({ topic, slideshowImages, headerData }) {
             renderPageSize={RENDER_PAGE_SIZE}
             slideshowImages={slideshowImages}
           />
-          {shouldShowAd && topic.dfp && <StyledGPTAd adUnit={topic.dfp} />}
         </>
       )
       break
@@ -64,7 +46,6 @@ export default function Topic({ topic, slideshowImages, headerData }) {
       topicJSX = (
         <>
           <TopicGroup topic={topic} />
-          {shouldShowAd && topic.dfp && <StyledGPTAd adUnit={topic.dfp} />}
         </>
       )
       break
@@ -76,7 +57,6 @@ export default function Topic({ topic, slideshowImages, headerData }) {
             renderPageSize={RENDER_PAGE_SIZE}
             slideshowImages={slideshowImages}
           />
-          {shouldShowAd && topic.dfp && <StyledGPTAd adUnit={topic.dfp} />}
         </>
       )
   }


### PR DESCRIPTION
移動 topic 頁 gpt 廣告位置
- topic-list: 移動至第12則文章之後
- topic-group: 移動至 TopicGroups container 內
