### PR TITLE
feat(was): pass Israfel/Content GQL authentication

### DIFF
--- a/packages/weekly-api-server/Makefile
+++ b/packages/weekly-api-server/Makefile
@@ -9,7 +9,7 @@ build-lib:
 
 dev-server:
 	@echo "$(P) Start dev server"
-	NODE_ENV=development yarn babel-node src/server
+	RELEASE_BRANCH=local NODE_ENV=development yarn babel-node src/server
 
 dev:
 	yarn nodemon --exec make dev-server

--- a/packages/weekly-api-server/package.json
+++ b/packages/weekly-api-server/package.json
@@ -12,6 +12,7 @@
     "node": ">=14.0.0 <17.0.0"
   },
   "dependencies": {
+    "@google-cloud/secret-manager": "^4.2.2",
     "@twreporter/errors": "^1.1.2",
     "axios": "^1.4.0",
     "cors": "^2.8.5",

--- a/packages/weekly-api-server/src/app.js
+++ b/packages/weekly-api-server/src/app.js
@@ -146,14 +146,19 @@ export function createApp({
     })
   )
 
-  // mini app: isafel GraphQL API
-  app.use(
-    createGraphQLProxy({
-      jwtSecret,
-      proxyOrigin: israfelProxyOrigin,
-      proxyPath: '/member/graphql',
-    })
-  )
+  // TODO:
+  // proxy requests to Israfel GQL API
+  // after Israfel enables role based and
+  // request level authentication.
+  //
+  // mini app: Isafel GraphQL API
+  //app.use(
+  //  createGraphQLProxy({
+  //    jwtSecret,
+  //    proxyOrigin: israfelProxyOrigin,
+  //    proxyPath: '/member/graphql',
+  //  })
+  //)
 
   // mini app: GCS proxy
   app.use(

--- a/packages/weekly-api-server/src/environment-variables.js
+++ b/packages/weekly-api-server/src/environment-variables.js
@@ -7,6 +7,8 @@ const {
   CORS_ALLOW_ORIGINS,
   GCS_ORIGIN,
   YOUTUBE_ORIGIN,
+  SECRET_RESOURCE_ID,
+  RELEASE_BRANCH,
 } = process.env
 
 /**
@@ -35,10 +37,10 @@ const envVar = {
   },
   apis: {
     israfel: {
-      origin: ISRAFEL_GQL_ORIGIN || 'https://israfel-gql.mirrormedia.mg',
+      origin: ISRAFEL_GQL_ORIGIN || 'https://dev-israfel-gql.mirrormedia.mg',
     },
     weekly: {
-      origin: WEEKLY_GQL_ORIGIN || 'https://weekly-gql.mirrormedia.mg',
+      origin: WEEKLY_GQL_ORIGIN || 'https://mirror-cms-dev-ufaummkd5q-de.a.run.app',
     },
   },
   cors: {
@@ -50,6 +52,8 @@ const envVar = {
   youtube: {
     origin: YOUTUBE_ORIGIN || 'https://api.mirrormedia.mg'
   },
+  secretResourceId: SECRET_RESOURCE_ID || 'projects/983956931553/secrets/dev-weekly-api-server/versions/1',
+  releaseBranch: RELEASE_BRANCH || 'prod',
 }
 
 export default envVar

--- a/packages/weekly-api-server/src/middlewares/gql-session-token.js
+++ b/packages/weekly-api-server/src/middlewares/gql-session-token.js
@@ -1,0 +1,246 @@
+import axios from 'axios'
+import errors from  '@twreporter/errors'
+import express from 'express'
+
+export class IsrafelSessionTokenManager {
+  /**
+   * @constructor
+   */
+  constructor(apiUrl = 'http://localhost:3000/api/graphql') {
+    this.apiUrl = apiUrl
+    this.sessionToken = ''
+    this.sessionTokenIssueTimestamp = -1
+  }
+
+  /**
+   *  @param {string} email
+   *  @param {string} password
+   *  @param {number} maxStale - Return stale session token if token's age is less than `maxStale` .unit is second.
+   *  @return {Promise<string>} - session token
+   */
+  async getSessionToken(email, password, maxStale=3600) {
+    const now = Math.round(Date.now() / 1000)
+    if (this.sessionToken &&
+      ((now - this.sessionTokenIssueTimestamp) <= maxStale)
+    ) {
+      return this.sessionToken
+    }
+
+    const apiUrl = this.apiUrl
+    const query = `
+mutation {
+  authenticateuserWithPassword(email: "${email}", password: "${password}") {
+      ... on userAuthenticationWithPasswordSuccess {
+        sessionToken
+      }
+
+      ... on userAuthenticationWithPasswordFailure {
+        code
+        message
+      }
+  }
+}
+    `
+
+    try {
+      const apiRes = await axios.post(apiUrl, {
+        query,
+      })
+
+      const { data, errors: gqlErrors } = apiRes.data
+
+      if (gqlErrors) {
+        const annotatingError = errors.helpers.wrap(
+          new Error('Errors occured while requesting Israfel GQL.'),
+          'GraphQLError',
+          'Errors returned in `authenticateuserWithPassword` mutation',
+          {
+            gqlErrors,
+          },
+        )
+        throw annotatingError
+      }
+
+      const {sessionToken, code, message} = data
+
+      if (code) {
+        const annotatingError = errors.helpers.wrap(
+          new Error('Fail to pass Israfel authentication layer.'),
+          'AuthenticationFailure',
+          `Failure code: ${code}, message: ${message}`,
+        )
+        throw annotatingError
+      }
+
+      if (sessionToken) {
+        this.sessionToken = sessionToken
+        this.sessionTokenIssueTimestamp = Math.round(Date.now() / 1000)
+        return sessionToken
+      }
+    } catch (axiosErr) {
+      throw errors.helpers.wrap(
+        errors.helpers.annotateAxiosError(axiosErr),
+        'IsrafelSessionTokenManagerError',
+        'Can not get access token successfully.',
+      )
+    }
+  }
+}
+
+export class ContentGQLSessionTokenManager {
+  /**
+   * @constructor
+   */
+  constructor(apiUrl = 'http://localhost:3000/api/graphql') {
+    this.apiUrl = apiUrl
+    this.sessionToken = ''
+    this.sessionTokenIssueTimestamp = -1
+  }
+
+  /**
+   *  @param {string} email
+   *  @param {string} password
+   *  @param {number} maxStale - Return stale session token if token's age is less than `maxStale` .unit is second.
+   *  @return {Promise<string>} - session token
+   */
+  async getSessionToken(email, password, maxStale=3600) {
+    const now = Math.round(Date.now() / 1000)
+    if (this.sessionToken &&
+      ((now - this.sessionTokenIssueTimestamp) <= maxStale)
+    ) {
+      return this.sessionToken
+    }
+
+    const apiUrl = this.apiUrl
+    const query = `
+mutation {
+  authenticateUserWithPassword(email: "${email}", password: "${password}") {
+      ... on UserAuthenticationWithPasswordSuccess {
+        sessionToken
+      }
+
+      ... on UserAuthenticationWithPasswordFailure {
+        message
+      }
+  }
+}
+    `
+
+    try {
+      const apiRes = await axios.post(apiUrl, {
+        query,
+      })
+
+      const { data, errors: gqlErrors } = apiRes.data
+
+      if (gqlErrors) {
+        const annotatingError = errors.helpers.wrap(
+          new Error('Errors occured while requesting Content GQL.'),
+          'GraphQLError',
+          'Errors returned in `authenticateUserWithPassword` mutation',
+          {
+            gqlErrors,
+          },
+        )
+        throw annotatingError
+      }
+
+      const {sessionToken, message} = data.authenticateUserWithPassword
+
+      if (message) {
+        const annotatingError = errors.helpers.wrap(
+          new Error('Fail to pass Content GQL authentication layer.'),
+          'AuthenticationFailure',
+          `Failure message: ${message}`,
+        )
+        throw annotatingError
+      }
+
+      if (sessionToken) {
+        this.sessionToken = sessionToken
+        this.sessionTokenIssueTimestamp = Math.round(Date.now() / 1000)
+        return sessionToken
+      }
+    } catch (axiosErr) {
+      throw errors.helpers.wrap(
+        errors.helpers.annotateAxiosError(axiosErr),
+        'ContentGQLSessionTokenManagerError',
+        'Can not get access token successfully.',
+      )
+    }
+  }
+}
+
+/**
+ *  Create an express middleware to get session token from Content GQL
+ *  and set the token to `res.locals.contentGQLSessionToken`.
+ *  @param {Object} opts
+ *  @param {string} opts.apiUrl
+ *  @param {Object} opts.headlessAccount
+ *  @param {string} opts.headlessAccount.email
+ *  @param {string} opts.headlessAccount.password
+ *  @return {express.RequestHandler} express middleware
+ */
+export function createContentGQLSessionTokenMw({
+  apiUrl,
+  headlessAccount: {
+    email,
+    password,
+  },
+}) {
+  const tokenManager = new ContentGQLSessionTokenManager(apiUrl)
+  return async (req, res, next) => {
+
+    try {
+      const sessionToken = await tokenManager.getSessionToken(email, password)
+
+      res.locals.contentGQLSessionToken = sessionToken
+      console.log('sessionToken:', sessionToken)
+    } catch (err) {
+      const annotatingError = errors.helpers.wrap(
+        err,
+        'ContentGQLSessionTokenMwError',
+        `Error to get session token from GQL.`
+      )
+      next(annotatingError)
+    }
+
+    next()
+  }
+}
+
+/**
+ *  Create an express middleware to get session token from Israfel
+ *  and set the token to `res.locals.israfelSessionToken`.
+ *  @param {Object} opts
+ *  @param {string} opts.apiUrl
+ *  @param {Object} opts.headlessAccount
+ *  @param {string} opts.headlessAccount.email
+ *  @param {string} opts.headlessAccount.password
+ *  @return {express.RequestHandler} express middleware
+ */
+export function createIsrafelSessionTokenMw({
+  apiUrl,
+  headlessAccount: {
+    email,
+    password,
+  },
+}) {
+  const tokenManager = new IsrafelSessionTokenManager(apiUrl)
+  return async (req, res, next) => {
+
+    try {
+      const sessionToken = await tokenManager.getSessionToken(email, password)
+      res.locals.israfelSessionToken = sessionToken
+    } catch (err) {
+      const annotatingError = errors.helpers.wrap(
+        err,
+        'IsrafelSessionTokenMwError',
+        `Error to get session token from GQL.`
+      )
+      next(annotatingError)
+    }
+
+    next()
+  }
+}

--- a/packages/weekly-api-server/src/middlewares/index.js
+++ b/packages/weekly-api-server/src/middlewares/index.js
@@ -6,9 +6,12 @@ import {
   signAccessToken,
   signAccessTokenForInternalColleague,
 } from './auth'
+import { createContentGQLSessionTokenMw, createIsrafelSessionTokenMw } from './gql-session-token'
 
 const mws = {
   createLoggerMw,
+  createContentGQLSessionTokenMw,
+  createIsrafelSessionTokenMw,
   queryMemberInfo,
   verifyAccessToken,
   verifyIdTokenByFirebaseAdmin,

--- a/packages/weekly-api-server/src/middlewares/member-info.js
+++ b/packages/weekly-api-server/src/middlewares/member-info.js
@@ -15,6 +15,7 @@ import express from 'express' // eslint-disable-line
  */
 export function queryMemberInfo(opts) {
   return async (req, res, next) => {
+    const sessionToken = res.locals.israfelSessionToken
     const firebaseId = res.locals.auth?.decodedIdToken?.uid
 
     const query = `
@@ -41,6 +42,7 @@ export function queryMemberInfo(opts) {
         {
           headers: {
             'X-Access-Token-Scope': `read:member-info:${firebaseId}`,
+            'Cookie': `keystonejs-session=${sessionToken}`
           },
         }
       )

--- a/packages/weekly-api-server/src/secret-manager.js
+++ b/packages/weekly-api-server/src/secret-manager.js
@@ -1,0 +1,20 @@
+import { SecretManagerServiceClient } from '@google-cloud/secret-manager'
+const secretClient = new SecretManagerServiceClient()
+
+/**
+ *  Get secret value from GCP secret manager.
+ *  @param {string} resourceID - resource ID provided by GCP secret manager
+ *  @return {Promise} Promise.resolve with secret value or Promise.reject with error
+ *
+ */
+async function getSecretValue(resourceID) {
+  const [secrect] = await secretClient.accessSecretVersion({
+    name: resourceID,
+  })
+
+  return secrect.payload.data.toString()
+}
+
+export default {
+  getSecretValue,
+}

--- a/packages/weekly-api-server/src/server.js
+++ b/packages/weekly-api-server/src/server.js
@@ -1,10 +1,47 @@
 import http from 'http'
 import { createApp } from './app'
 import envVar from './environment-variables'
+import secretManager from './secret-manager'
 
 const port = process.env.PORT || '8080'
 
 async function start() {
+  let israfelHeadlessAccount
+  let contentGQLHeadlessAccount
+  try {
+    let jsonObj
+    if (envVar.releaseBranch === 'local') {
+      jsonObj = {
+        israfelHeadlessAccount: {
+          email: 'weekly-api-server@mirrormedia.mg',
+          password: 'get_password_from_israfel_cms',
+        },
+        contentGQLHeadlessAccount: {
+          email: 'weekly-api-server@mirrormedia.mg',
+          password: 'get_password_from_content_cms',
+        },
+      }
+    } else {
+      const value = await secretManager.getSecretValue(envVar.secretResourceId)
+      jsonObj = JSON.parse(value)
+    }
+    israfelHeadlessAccount = jsonObj.israfelHeadlessAccount
+    contentGQLHeadlessAccount = jsonObj.contentGQLHeadlessAccount
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        severity: 'ALERT',
+        // All exceptions that include a stack trace will be
+        // integrated with Error Reporting.
+        // See https://cloud.google.com/run/docs/error-reporting
+        message: err.stack
+          ? `Error to get secrets: ${err.stack}`
+          : new Error('Error to get secrets').stack,
+      })
+    )
+    return
+  }
+
   let server
   try {
     const app = createApp({
@@ -16,6 +53,8 @@ async function start() {
       gcsProxyOrigin: envVar.gcs.origin,
       corsAllowOrigin: envVar.cors.allowOrigins,
       youtubeProxyOrigin: envVar.youtube.origin,
+      israfelHeadlessAccount,
+      contentGQLHeadlessAccount,
     })
     server = http.createServer(app).listen(port, () => {
       console.log(

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,6 +311,11 @@
     regenerator-runtime "^0.13.11"
     v8flags "^3.1.1"
 
+"@babel/parser@^7.20.15":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.5.tgz#721fd042f3ce1896238cf1b341c77eb7dee7dbea"
+  integrity sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==
+
 "@babel/parser@^7.20.7", "@babel/parser@^7.9.4":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.7.tgz#66fe23b3c8569220817d5feb8b9dcdc95bb4f71b"
@@ -1560,6 +1565,13 @@
   resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-3.0.1.tgz#8d724fb280f47d1ff99953aee0c1669b25238c2e"
   integrity sha512-z1CjRjtQyBOYL+5Qr9DdYIfrdLBe746jRTYfaYU6MeXkqp7UfYs/jX16lFFVzZ7PGEJvqZNqYUEtb1mvDww4pA==
 
+"@google-cloud/secret-manager@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@google-cloud/secret-manager/-/secret-manager-4.2.2.tgz#4c0e7a169e91d3f6f27d31252e9065c85d8fe802"
+  integrity sha512-76yXN21ahrZMJKjs+gNoVWrSmioxqF2A2jKyDxRRq0DjSfoLHXb8POipjsTMErc1R1S7J7LToK2iLsi8lJyZqw==
+  dependencies:
+    google-gax "^3.5.8"
+
 "@google-cloud/storage@^6.5.2":
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/@google-cloud/storage/-/storage-6.9.0.tgz#6808487208c6dc9c8698a420f74b87e8fd010e23"
@@ -1592,6 +1604,14 @@
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.7.3.tgz#f2ea79f65e31622d7f86d4b4c9ae38f13ccab99a"
   integrity sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==
+  dependencies:
+    "@grpc/proto-loader" "^0.7.0"
+    "@types/node" ">=12.12.47"
+
+"@grpc/grpc-js@~1.8.0":
+  version "1.8.16"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.8.16.tgz#9a1b93703c065fde20b90d854126aadb89f4f0bd"
+  integrity sha512-Nvlq4V7XQmdRVDGgecR8ZPPCeY+uH1LhzbC+QxklwAahpQlq8YLsiOQgfkub9FiakRiohaDy361xqlTLkq9EHw==
   dependencies:
     "@grpc/proto-loader" "^0.7.0"
     "@types/node" ">=12.12.47"
@@ -1681,6 +1701,13 @@
   dependencies:
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
+
+"@jsdoc/salty@^0.2.1":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@jsdoc/salty/-/salty-0.2.5.tgz#1b2fa5bb8c66485b536d86eee877c263d322f692"
+  integrity sha512-TfRP53RqunNe2HBobVBJ0VLhK1HbfvBYeTC1ahnN64PWvyYyGebmMiPkuwvD9fpw2ZbkoPb8Q7mwy0aR8Z9rvw==
+  dependencies:
+    lodash "^4.17.21"
 
 "@mirrormedia/lilith-draft-renderer@^1.2.0-alpha.28":
   version "1.2.0-alpha.28"
@@ -2040,6 +2067,14 @@
   resolved "https://registry.yarnpkg.com/@types/facebook-js-sdk/-/facebook-js-sdk-3.3.6.tgz#a07bc686304c34953931546a207df455777d9ccf"
   integrity sha512-CxTLMVtZsgrj9Ven5Pn1vcFumCFs+CG8Jfc63xWq/8b9e6uWjGyZlMnvQk7lIVn97Zd1vpu0ZK/OFWAoap0RCw==
 
+"@types/glob@*":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-8.1.0.tgz#b63e70155391b0584dce44e7ea25190bbc38f2fc"
+  integrity sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==
+  dependencies:
+    "@types/minimatch" "^5.1.2"
+    "@types/node" "*"
+
 "@types/google-publisher-tag@^1.20230410.0":
   version "1.20230410.0"
   resolved "https://registry.yarnpkg.com/@types/google-publisher-tag/-/google-publisher-tag-1.20230410.0.tgz#f6b866f3710c46b729b3f7cfb60f3975a2ecf4a4"
@@ -2097,6 +2132,11 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
   integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
 
+"@types/minimatch@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
+
 "@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
   version "18.11.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
@@ -2116,6 +2156,14 @@
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/rimraf@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.2.tgz#a63d175b331748e5220ad48c901d7bbf1f44eef8"
+  integrity sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 "@types/serve-static@*":
   version "1.15.0"
@@ -4007,6 +4055,27 @@ google-gax@^3.5.1:
     protobufjs-cli "1.0.2"
     retry-request "^5.0.0"
 
+google-gax@^3.5.8:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-3.6.0.tgz#0f4ae350159737fe0aa289815c0d92838b19f6af"
+  integrity sha512-2fyb61vWxUonHiArRNJQmE4tx5oY1ni8VPo08fzII409vDSCWG7apDX4qNOQ2GXXT82gLBn3d3P1Dydh7pWjyw==
+  dependencies:
+    "@grpc/grpc-js" "~1.8.0"
+    "@grpc/proto-loader" "^0.7.0"
+    "@types/long" "^4.0.0"
+    "@types/rimraf" "^3.0.2"
+    abort-controller "^3.0.0"
+    duplexify "^4.0.0"
+    fast-text-encoding "^1.0.3"
+    google-auth-library "^8.0.2"
+    is-stream-ended "^0.1.4"
+    node-fetch "^2.6.1"
+    object-hash "^3.0.0"
+    proto3-json-serializer "^1.0.0"
+    protobufjs "7.2.3"
+    protobufjs-cli "1.1.1"
+    retry-request "^5.0.0"
+
 google-p12-pem@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-4.0.1.tgz#82841798253c65b7dc2a4e5fe9df141db670172a"
@@ -4495,6 +4564,27 @@ jsdoc@^3.6.3:
     requizzle "^0.2.3"
     strip-json-comments "^3.1.0"
     taffydb "2.6.2"
+    underscore "~1.13.2"
+
+jsdoc@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-4.0.2.tgz#a1273beba964cf433ddf7a70c23fd02c3c60296e"
+  integrity sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==
+  dependencies:
+    "@babel/parser" "^7.20.15"
+    "@jsdoc/salty" "^0.2.1"
+    "@types/markdown-it" "^12.2.3"
+    bluebird "^3.7.2"
+    catharsis "^0.9.0"
+    escape-string-regexp "^2.0.0"
+    js2xmlparser "^4.0.2"
+    klaw "^3.0.0"
+    markdown-it "^12.3.2"
+    markdown-it-anchor "^8.4.1"
+    marked "^4.0.10"
+    mkdirp "^1.0.4"
+    requizzle "^0.2.3"
+    strip-json-comments "^3.1.0"
     underscore "~1.13.2"
 
 jsesc@^2.5.1:
@@ -5442,10 +5532,44 @@ protobufjs-cli@1.0.2:
     tmp "^0.2.1"
     uglify-js "^3.7.7"
 
+protobufjs-cli@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/protobufjs-cli/-/protobufjs-cli-1.1.1.tgz#f531201b1c8c7772066aa822bf9a08318b24a704"
+  integrity sha512-VPWMgIcRNyQwWUv8OLPyGQ/0lQY/QTQAVN5fh+XzfDwsVw1FZ2L3DM/bcBf8WPiRz2tNpaov9lPZfNcmNo6LXA==
+  dependencies:
+    chalk "^4.0.0"
+    escodegen "^1.13.0"
+    espree "^9.0.0"
+    estraverse "^5.1.0"
+    glob "^8.0.0"
+    jsdoc "^4.0.0"
+    minimist "^1.2.0"
+    semver "^7.1.2"
+    tmp "^0.2.1"
+    uglify-js "^3.7.7"
+
 protobufjs@7.1.2, protobufjs@^7.0.0:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.1.2.tgz#a0cf6aeaf82f5625bffcf5a38b7cd2a7de05890c"
   integrity sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/node" ">=13.7.0"
+    long "^5.0.0"
+
+protobufjs@7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.3.tgz#01af019e40d9c6133c49acbb3ff9e30f4f0f70b2"
+  integrity sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
### 前置作業 
- 在 Israfel CMS 上，新增 weekly-api-server 使用者，並將其 role 設定好。（目前已經在 dev israfel 上，新增 email 為 `weekly-api-server@mirrormedia.mg` 的使用者，其 role 目前為 `admin`）
- 在 Content CMS 上，新增 weekly-api-server 使用者，並將其 role 設定好。（目前已經在 dev content CMS 上，新增 email 為 `weekly-api-server@mirrormedia.mg` 的使用者，其 role 目前為 `admin`）
- 在 GCP 的 Secret Manager 中，新增 secret，該 secret 包含 Israfel 和 Content GQL 的 headless account 帳密。請見 https://console.cloud.google.com/security/secret-manager/secret/dev-weekly-api-server/versions?project=mirrormedia-1470651750304


### 實作細節
- 透過環境變數 `SECRET_RESOURCE_ID`，傳入 Secret Manager 所需的 resource 位置。
- 透過 GCP Secret Manager 拿取 headless account 的帳密。
- 新增 `RELEASE_BRANCH` 環境變數，當 `RELEASE_BRANCH` 為 `local` 時，程式碼不會去 Secret Manager 拿取 secret。
- 使用 Israfel 和 Content GQL 提供的 mutation，透過 headless account 拿取 session token。
- 將 Israfel 和 Content GQL 核發的 session token，新增到 `Cookie` header 上，讓要發送到 Israfel 或 Content GQL 的 requests 能夠通過 KeystoneJS6 role based authentication 的驗證。

### 後續調整
- 目前 weekly-api-server 在 CMS 上的 role 是 `admin`，權限太大，可以特地為 was 新增一個屬於它自己的 role。
- 目前 `getSessionToken` 的設計會優先使用 cache 的版本，只要 cache 版本的 age 小於 `maxStale`。
但為了防止 stale session token 無法通過 authentication layer，我們應該要有機制強制去拿新的 session token。
因為時間關係，此 PR 沒有實作該機制，在此留言提醒接手的同事。