### PR TITLE
refactor(mm-next/gpt-ad): add event listener only for certain adSlot

### DIFF
--- a/packages/mirror-media-next/components/ads/gpt/gpt-ad.js
+++ b/packages/mirror-media-next/components/ads/gpt/gpt-ad.js
@@ -108,30 +108,49 @@ export default function GPTAd({
        * Check https://developers.google.com/publisher-tag/guides/get-started?hl=en for the tutorial of the flow.
        */
       let adSlot
+      const pubads = window.googletag.pubads()
+
+      const handleOnSlotRequested = (event) => {
+        if (event.slot === adSlot) {
+          onSlotRequested(event)
+        }
+      }
+      const handleOnSlotRenderEnded = (event) => {
+        if (event.slot === adSlot) {
+          onSlotRenderEnded(event)
+        }
+      }
       window.googletag.cmd.push(() => {
         adSlot = window.googletag
           .defineSlot(adUnitPath, adSize, adDivId)
           .addService(window.googletag.pubads())
-      })
-
-      window.googletag.cmd.push(() => {
         window.googletag.display(adDivId)
-      })
 
-      // all events, check https://developers.google.com/publisher-tag/reference?hl=en#googletag.events.eventtypemap for all events
-      window.googletag.cmd.push(() => {
-        const pubads = window.googletag.pubads()
+        // all events, check https://developers.google.com/publisher-tag/reference?hl=en#googletag.events.eventtypemap for all events
         if (onSlotRequested) {
-          pubads.addEventListener('slotRequested', onSlotRequested)
+          /**
+           * add event listener  to respond only to certain adSlot
+           * @see https://developers.google.com/publisher-tag/reference?hl=zh-tw#googletag.Service_addEventListener
+           */
+          pubads.addEventListener('slotRequested', handleOnSlotRequested)
         }
         if (onSlotRenderEnded) {
-          pubads.addEventListener('slotRenderEnded', onSlotRenderEnded)
+          pubads.addEventListener('slotRenderEnded', handleOnSlotRenderEnded)
         }
       })
 
       return () => {
         window.googletag.cmd.push(() => {
           window.googletag.destroySlots([adSlot])
+          if (onSlotRenderEnded) {
+            pubads.removeEventListener('slotRequested', handleOnSlotRequested)
+          }
+          if (onSlotRenderEnded) {
+            pubads.removeEventListener(
+              'slotRenderEnded',
+              handleOnSlotRenderEnded
+            )
+          }
         })
       }
     }

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -7,7 +7,6 @@ const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
 // The following variables are given values according to different `ENV`
 
 let SITE_URL = ''
-
 let API_TIMEOUT = 5000
 let API_PROTOCOL = 'http'
 let API_HOST = ''


### PR DESCRIPTION
## Notable Change
1. 調整gpt-ad添加事件監聽的程式碼，包含以下改動：
   - 事件監聽僅會添加在特定廣告上，避免造成非預期的錯誤。之所以加入該寫法，是為了避免有多個廣告同時添加事件監聽時，將事件監聽添加在錯誤的廣告上。
   - 新增cleanup function，移除事件監聽。