### PR TITLE
feat(mm-next): set pages cache

### DIFF
--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -3,8 +3,10 @@ import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
 import AuthorArticles from '../../components/author/author-articles'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { setPageCache } from '../../utils/cache-setting'
+
 import Layout from '../../components/shared/layout'
 import { Z_INDEX } from '../../constants/index'
 import {
@@ -12,7 +14,6 @@ import {
   fetchPostsByAuthorId,
 } from '../../utils/api/author'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
-
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
 })
@@ -119,7 +120,13 @@ export default function Author({ postsCount, posts, author, headerData }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ query, req }) {
+export async function getServerSideProps({ query, req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 600 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
+
   const authorId = Array.isArray(query.id) ? query.id[0] : query.id
   const mockError = query.error === '500'
 

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -3,11 +3,12 @@ import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
 import CategoryArticles from '../../components/category/category-articles'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import {
   fetchHeaderDataInDefaultPageLayout,
   fetchHeaderDataInPremiumPageLayout,
 } from '../../utils/api'
+import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { Z_INDEX } from '../../constants/index'
 import {
@@ -240,7 +241,12 @@ export default function Category({
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ query, req }) {
+export async function getServerSideProps({ query, req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 600 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
   const categorySlug = Array.isArray(query.slug) ? query.slug[0] : query.slug
   const mockError = query.error === '500'
 

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -1,8 +1,8 @@
 //TODO: add component to add html head dynamically, not jus write head in every pag
 import client from '../../apollo/apollo-client'
 import errors from '@twreporter/errors'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
-
+import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
+import { setPageCache } from '../../utils/cache-setting'
 import { fetchExternalBySlug } from '../../apollo/query/externals'
 import ExternalNormalStyle from '../../components/external/external-normal-style'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
@@ -34,7 +34,13 @@ export default function External({ external, headerData }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ params, req }) {
+export async function getServerSideProps({ params, req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 300 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
+
   const { slug } = params
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -4,8 +4,9 @@ import dynamic from 'next/dynamic'
 
 import client from '../../apollo/apollo-client'
 import ExternalArticles from '../../components/externals/partner-articles'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 
 import {
@@ -154,7 +155,12 @@ export default function ExternalPartner({
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ params, req }) {
+export async function getServerSideProps({ params, req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 600 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
   const { partnerSlug } = params
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -7,8 +7,10 @@ import {
   GCP_PROJECT_ID,
   API_TIMEOUT,
   URL_STATIC_EXTERNALS_WARMLIFE,
+  ENV,
 } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import axios from 'axios'
 import { Z_INDEX, SECTION_IDS } from '../../constants/index'
@@ -128,7 +130,12 @@ export default function WarmLife({ warmLifeData, headerData }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ req, query }) {
+export async function getServerSideProps({ req, query, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 600 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
   const mockError = query.error === '500'
 
   const traceHeader = req.headers?.['x-cloud-trace-context']

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -19,7 +19,7 @@ import {
   fetchHeaderDataInDefaultPageLayoutNoAllHeaderData,
 } from '../utils/api'
 import { getSectionNameGql, getSectionTitleGql, getArticleHref } from '../utils'
-
+import { setPageCache } from '../utils/cache-setting'
 import EditorChoice from '../components/editor-choice'
 import LatestNews from '../components/latest-news'
 import Layout from '../components/shared/layout'
@@ -178,9 +178,12 @@ export default function Home({
  * @type {import('next').GetServerSideProps}
  */
 export async function getServerSideProps({ res, req, query }) {
-  if (ENV === 'dev' || ENV === 'staging' || ENV === 'prod') {
-    res.setHeader('Cache-Control', 'public, max-age=180')
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 180 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
   }
+
   let post_external_url = URL_STATIC_POST_EXTERNAL
   let flash_news_url = URL_STATIC_POST_FLASH_NEWS
   let queryHeaderDataFunction = fetchHeaderDataInDefaultPageLayout

--- a/packages/mirror-media-next/pages/magazine/[book]/[issue].js
+++ b/packages/mirror-media-next/pages/magazine/[book]/[issue].js
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import client from '../../../apollo/apollo-client'
 import { GCP_PROJECT_ID } from '../../../config/index.mjs'
+import { setPageCache } from '../../../utils/cache-setting'
 import { fetchWeeklys } from '../../../apollo/query/magazines'
 import Layout from '../../../components/shared/layout'
 
@@ -57,7 +58,9 @@ export default function BookBIssuePublish({ weeklys }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ req }) {
+export async function getServerSideProps({ req, res }) {
+  setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}
   if (traceHeader && !Array.isArray(traceHeader)) {

--- a/packages/mirror-media-next/pages/magazine/index.js
+++ b/packages/mirror-media-next/pages/magazine/index.js
@@ -6,7 +6,7 @@ import client from '../../apollo/apollo-client'
 import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { fetchSpecials, fetchWeeklys } from '../../apollo/query/magazines'
 import { fetchHeaderDataInPremiumPageLayout } from '../../utils/api'
-
+import { setPageCache } from '../../utils/cache-setting'
 import MagazinePlatforms from '../../components/magazine/magazine-platforms'
 import MagazineSpecials from '../../components/magazine/magazine-specials'
 import MagazineWeeklys from '../../components/magazine/magazine-weeklys'
@@ -174,7 +174,9 @@ export default function Magazine({ sectionsData = [] }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ req }) {
+export async function getServerSideProps({ req, res }) {
+  setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}
   if (traceHeader && !Array.isArray(traceHeader)) {

--- a/packages/mirror-media-next/pages/premiumsection/[slug].js
+++ b/packages/mirror-media-next/pages/premiumsection/[slug].js
@@ -3,8 +3,9 @@ import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
 import SectionArticles from '../../components/shared/section-articles'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import { fetchHeaderDataInPremiumPageLayout } from '../../utils/api'
+import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import {
   fetchPremiumPostsBySectionSlug,
@@ -160,7 +161,12 @@ export default function Section({ postsCount, posts, section, headerData }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ query, req }) {
+export async function getServerSideProps({ query, req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 600 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
   const sectionSlug = Array.isArray(query.slug) ? query.slug[0] : query.slug
   const mockError = query.error === '500'
 

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -3,8 +3,9 @@ import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
 import SectionArticles from '../../components/shared/section-articles'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { Z_INDEX } from '../../constants/index'
 import {
@@ -149,7 +150,12 @@ export default function Section({ postsCount, posts, section, headerData }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ query, req }) {
+export async function getServerSideProps({ query, req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 600 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
   const sectionSlug = Array.isArray(query.slug) ? query.slug[0] : query.slug
   const mockError = query.error === '500'
 

--- a/packages/mirror-media-next/pages/section/topic.js
+++ b/packages/mirror-media-next/pages/section/topic.js
@@ -3,8 +3,9 @@ import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
 import SectionTopics from '../../components/section/topic/section-topics'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { fetchTopicList } from '../../utils/api/section-topic'
 import { Z_INDEX } from '../../constants/index'
@@ -122,7 +123,12 @@ export default function Topics({ topics, topicsCount, headerData }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ req, query }) {
+export async function getServerSideProps({ req, query, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 600 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
   const mockError = query.error === '500'
 
   const traceHeader = req.headers?.['x-cloud-trace-context']

--- a/packages/mirror-media-next/pages/section/videohub.js
+++ b/packages/mirror-media-next/pages/section/videohub.js
@@ -1,9 +1,10 @@
 import errors from '@twreporter/errors'
 import dynamic from 'next/dynamic'
 
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import { VIDEOHUB_CATEGORIES_PLAYLIST_MAPPING } from '../../constants'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api/index.js'
+import { setPageCache } from '../../utils/cache-setting'
 import styled from 'styled-components'
 import VideoList from '../../components/section/videohub/video-list.js'
 import SubscribeChannels from '../../components/section/videohub/subscribe-channels.js'
@@ -169,7 +170,12 @@ export default function SectionVideohub({
   )
 }
 
-export async function getServerSideProps({ query, req }) {
+export async function getServerSideProps({ query, req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 900 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
   const mockError = query.error === '500'
 
   const traceHeader = req.headers?.['x-cloud-trace-context']

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -4,7 +4,7 @@ import client from '../../apollo/apollo-client'
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import WineWarning from '../../components/story/shared/wine-warning'
 import AdultOnlyWarning from '../../components/story/shared/adult-only-warning'
 import { useMembership } from '../../context/membership'
@@ -20,6 +20,8 @@ import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import { fetchHeaderDataInPremiumPageLayout } from '../../utils/api'
 import { sendGAEvent } from '../../utils/gtag'
+import { setPageCache } from '../../utils/cache-setting'
+
 import FullScreenAds from '../../components/ads/full-screen-ads'
 const { hasContentInRawContentBlock } = MirrorMedia
 
@@ -223,7 +225,13 @@ export default function Story({ postData, headerData, storyLayoutType }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ params, req }) {
+export async function getServerSideProps({ params, req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 300 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
+
   const { slug } = params
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -10,8 +10,13 @@ import {
   getCategoryOfWineSlug,
 } from '../../../utils'
 import { handleStoryPageRedirect } from '../../../utils/story'
+import { setPageCache } from '../../../utils/cache-setting'
 import { fetchPostBySlug } from '../../../apollo/query/posts'
-import { GCP_PROJECT_ID, GA_MEASUREMENT_ID } from '../../../config/index.mjs'
+import {
+  GCP_PROJECT_ID,
+  ENV,
+  GA_MEASUREMENT_ID,
+} from '../../../config/index.mjs'
 import styled from 'styled-components'
 import AdultOnlyWarning from '../../../components/story/shared/adult-only-warning'
 import WineWarning from '../../../components/story/shared/wine-warning'
@@ -111,7 +116,12 @@ function StoryAmpPage({ postData }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ params, req }) {
+export async function getServerSideProps({ params, req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 300 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
   const { slug } = params
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -3,13 +3,13 @@ import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
 import TagArticles from '../../components/tag/tag-articles'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import Layout from '../../components/shared/layout'
 import { Z_INDEX } from '../../constants/index'
 import { fetchPostsByTagSlug, fetchTagByTagSlug } from '../../utils/api/tag'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
-
+import { setPageCache } from '../../utils/cache-setting'
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
 })
@@ -145,7 +145,12 @@ export default function Tag({ postsCount, posts, tag, headerData }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ query, req }) {
+export async function getServerSideProps({ query, req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 600 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
   const tagSlug = Array.isArray(query.slug) ? query.slug[0] : query.slug
   const mockError = query.error === '500'
 

--- a/packages/mirror-media-next/pages/topic/[id].js
+++ b/packages/mirror-media-next/pages/topic/[id].js
@@ -1,9 +1,10 @@
 import errors from '@twreporter/errors'
 
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import TopicList from '../../components/topic/list/topic-list'
 import TopicGroup from '../../components/topic/group/topic-group'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { parseUrl } from '../../utils/topic'
 import {
@@ -84,7 +85,12 @@ export default function Topic({ topic, slideshowImages, headerData }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ query, req }) {
+export async function getServerSideProps({ query, req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 300 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
   const topicId = Array.isArray(query.id) ? query.id[0] : query.id
   const mockError = query.error === '500'
 

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -3,11 +3,12 @@ import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import {
   simplifyYoutubeSearchedVideo,
   simplifyYoutubeVideo,
 } from '../../utils/youtube'
+import { setPageCache } from '../../utils/cache-setting'
 import YoutubeIframe from '../../components/shared/youtube-iframe'
 import YoutubeArticle from '../../components/video/youtube-article'
 import VideoList from '../../components/video/video-list'
@@ -164,7 +165,12 @@ export default function Video({ video, latestVideos, headerData }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ query, req }) {
+export async function getServerSideProps({ query, req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 900 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
   const videoId = Array.isArray(query.id) ? query.id[0] : query.id
   const mockError = query.error === '500'
 

--- a/packages/mirror-media-next/pages/video_category/[slug].js
+++ b/packages/mirror-media-next/pages/video_category/[slug].js
@@ -1,12 +1,13 @@
 import errors from '@twreporter/errors'
 import dynamic from 'next/dynamic'
 
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
+import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import CategoryVideos from '../../components/video_category/category-videos.js'
 import { VIDEOHUB_CATEGORIES_PLAYLIST_MAPPING } from '../../constants/index.js'
 import styled from 'styled-components'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api/index.js'
 import { simplifyYoutubePlaylistVideo } from '../../utils/youtube.js'
+import { setPageCache } from '../../utils/cache-setting.js'
 import LeadingVideo from '../../components/shared/leading-video.js'
 import Layout from '../../components/shared/layout.js'
 import {
@@ -128,7 +129,12 @@ export default function VideoCategory({
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ query, req }) {
+export async function getServerSideProps({ query, req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 900 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
   const videoCategorySlug = Array.isArray(query.slug)
     ? query.slug[0]
     : query.slug


### PR DESCRIPTION
## Notable Change
設定各頁面的快取設定。
目前設定的頁面為：
-  首頁
- story文章頁
- amp文章頁
- topic內頁
- 列表頁，包含：
   - author頁（作者頁）
   - category頁
   - externals頁（external列表頁）
   - externals/warmlife (生活暖流頁)
   - section頁
   - section/topic 頁（topic列表頁）
   - tag頁（標籤頁）
- premium-section頁
- section/videohub頁
- video_category頁
- vidoe頁
- magazine頁
- external頁
