### PR TITLE
feat(mm-next/magazine): proceed with the redirect on `premiumsection/member`

### DIFF
--- a/packages/mirror-media-next/pages/magazine/index.js
+++ b/packages/mirror-media-next/pages/magazine/index.js
@@ -50,7 +50,6 @@ const Title = styled.h2`
 
 export default function Magazine({ sectionsData = [] }) {
   const router = useRouter()
-  const [redirectUrl, setRedirectUrl] = useState(null)
 
   const [specials, setSpecials] = useState([])
   const [weeklys, setWeeklys] = useState([])
@@ -64,19 +63,12 @@ export default function Magazine({ sectionsData = [] }) {
   // Redirect to '/login' if the user is not logged in
   useEffect(() => {
     if (isLogInProcessFinished && !isLoggedIn) {
-      // Store the current page URL in state
-      setRedirectUrl(router.asPath)
+      // Store the current page URL in localStorage
+      const redirectUrl = router.asPath
+      localStorage.setItem('redirectUrl', redirectUrl)
       router.push('/login')
     }
   }, [isLogInProcessFinished, isLoggedIn, router])
-
-  // Redirect the user back to the stored URL if available
-  useEffect(() => {
-    if (redirectUrl && isLoggedIn && isLogInProcessFinished) {
-      router.push(redirectUrl)
-      setRedirectUrl(null) // Clear the redirectUrl after redirecting
-    }
-  }, [redirectUrl, isLoggedIn, isLogInProcessFinished, router])
 
   // Fetch Magazines Data only for Premium Member
   useEffect(() => {

--- a/packages/mirror-media-next/pages/premiumsection/[slug].js
+++ b/packages/mirror-media-next/pages/premiumsection/[slug].js
@@ -1,6 +1,8 @@
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
 
 import SectionArticles from '../../components/shared/section-articles'
 import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
@@ -14,6 +16,7 @@ import {
 import { SECTION_IDS } from '../../constants/index'
 import { Z_INDEX } from '../../constants/index'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
+import { useMembership } from '../../context/membership'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -129,6 +132,24 @@ export default function Section({ postsCount, posts, section, headerData }) {
   const sectionName = section.name || ''
 
   const shouldShowAd = useDisplayAd()
+
+  const router = useRouter()
+  const { isLoggedIn, isLogInProcessFinished } = useMembership()
+
+  useEffect(() => {
+    const redirectUrl = localStorage.getItem('redirectUrl')
+    const currentUrl = router.asPath
+
+    if (
+      redirectUrl &&
+      isLoggedIn &&
+      isLogInProcessFinished &&
+      currentUrl === '/premiumsection/member'
+    ) {
+      localStorage.removeItem('redirectUrl')
+      router.push(redirectUrl)
+    }
+  }, [isLoggedIn, isLogInProcessFinished, router])
 
   return (
     <Layout


### PR DESCRIPTION
Store the redirect URL in local storage in the` /magazine` page and then retrieve it in `/PremiumSection`. And proceed with the redirect from the `/PremiumSection/member` page" 