### PR TITLE
fix(mm-next/story/amp): use draft-renderer in server-side

### DIFF
--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -69,6 +69,7 @@ function StoryAmpPage({ postData }) {
       <Head>
         <title>{title}</title>
       </Head>
+      {/* @ts-ignore */}
       <amp-analytics
         type="googleanalytics"
         config="https://amp.analytics-debugger.com/ga4.json"
@@ -92,8 +93,8 @@ function StoryAmpPage({ postData }) {
             }),
           }}
         />
+        {/* @ts-ignore */}
       </amp-analytics>
-
       <AmpBody>
         <section
           id="amp-page"


### PR DESCRIPTION
## Notable Change
1. 由於在amp頁面中，頁面並沒有useState、useEffect等hook可使用，所以必須將draft-renderer改為於server-side使用。