### PR TITLE
feat(mm-next/wide): modify supportBanner logic for premium articles

### DIFF
--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -203,7 +203,8 @@ export default function StoryPremiumStyle({
   postContent,
   headerData,
 }) {
-  const { isLoggedIn } = useMembership()
+  const { isLoggedIn, memberInfo } = useMembership()
+  const { memberType } = memberInfo
 
   const {
     id = '',
@@ -259,8 +260,6 @@ export default function StoryPremiumStyle({
   ]
 
   const shouldShowAd = useDisplayAd(hiddenAdvertised)
-  const { memberInfo } = useMembership()
-  const { memberType } = memberInfo
 
   let supportBanner
   if (postContent.type === 'fullContent') {

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -5,6 +5,7 @@ import DraftRenderBlock from '../shared/draft-renderer-block'
 import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
 const { getContentBlocksH2H3 } = MirrorMedia
 import { sortArrayWithOtherArrayId } from '../../../utils'
+import { useMembership } from '../../../context/membership'
 
 import Header from './header'
 import ArticleMask from '../shared/article-mask'
@@ -13,6 +14,7 @@ import SubscribeLink from '../shared/subscribe-link'
 import HeroImageAndVideo from '../shared/hero-image-and-video'
 import Credits from '../shared/credits'
 import SupportMirrorMediaBanner from '../shared/support-mirrormedia-banner'
+import SupportSingleArticleBanner from '../shared/support-single-article-banner'
 import NavSubtitleNavigator from '../shared/nav-subtitle-navigator'
 import MoreInfoAndTag from '../shared/more-info-and-tag'
 import Date from '../shared/date'
@@ -172,6 +174,21 @@ export default function StoryWideStyle({ postData, postContent }) {
 
   const shouldShowArticleMask = postContent.type === 'trimmedContent'
 
+  const { memberInfo } = useMembership()
+  const { memberType } = memberInfo
+  const isPremiumMember =
+    memberType.includes('premium') || memberType.includes('staff')
+
+  let supportBanner
+
+  if (!shouldShowArticleMask) {
+    if (isPremiumMember) {
+      supportBanner = <SupportSingleArticleBanner />
+    } else {
+      supportBanner = <SupportMirrorMediaBanner />
+    }
+  }
+
   return (
     <>
       <Header h2AndH3Block={h2AndH3Block} />
@@ -220,7 +237,7 @@ export default function StoryWideStyle({ postData, postContent }) {
             <MoreInfoAndTag tags={tags} />
 
             {shouldShowArticleMask && <ArticleMask postId={id} />}
-            <SupportMirrorMediaBanner />
+            {supportBanner}
           </ContentWrapper>
           <Aside
             relateds={relatedsWithOrdered}


### PR DESCRIPTION
修正 wide 文章頁 support banner 顯示邏輯，僅在 fullContent 情境下顯示，若使用者為 premium member 顯示 SupportSingleArticleBanner，其它使用者顯示 SupportMirrorMediaBanner。