### PR TITLE
feat(mm-next): show ordered field of `sections`, `writers`,`related`

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -119,10 +119,10 @@ export const asideListingPost = gql`
  * @property {boolean} isMember - whether this post is a member article
  * @property {boolean} isAdult - whether this post only adults can read
  * @property {Section[] | null } sections - which sections does this post belong to
- * @property {Section[] | null} manualOrderOfSections - sections with adjusted order
+ * @property {Section[] | null} sectionsInInputOrder - sections with adjusted order
  * @property {Pick<Category, 'id' | 'name'  | 'slug'>[] } categories - which categories does this post belong to
  * @property {Contact[] | null} writers -  the field called '作者' in cms
- * @property {Contact[] | null} manualOrderOfWriters - writers with adjusted order
+ * @property {Contact[] | null} writersInInputOrder - writers with adjusted order
  * @property {Contact[] } photographers - the field called '攝影' in cms
  * @property {Contact[] } camera_man - the field called '影音' in cms
  * @property {Contact[] } designers - the field called '設計' in cms
@@ -137,7 +137,7 @@ export const asideListingPost = gql`
  * @property {Draft} content - post content
  * @property {Draft} trimmedContent - post trimmed content
  * @property {Related[] } relateds related articles selected by cms users
- * @property {Related[] | null} manualOrderOfRelateds related articles with adjusted order
+ * @property {Related[] } relatedsInInputOrder related articles with adjusted order
  * @property {boolean} isFeatured
  * @property {import('./tag').Tag[]} tags
  * @property {string} redirect - post redirect slug or external url
@@ -165,14 +165,19 @@ export const post = gql`
     sections {
       ...section
     }
+    sectionsInInputOrder {
+      ...section
+    }
     categories {
       ...category
     }
-    manualOrderOfSections
+
     writers {
       ...contact
     }
-    manualOrderOfWriters
+    writersInInputOrder {
+      ...contact
+    }
     photographers {
       ...contact
     }
@@ -200,7 +205,6 @@ export const post = gql`
     }
     heroCaption
     brief
-
     relateds {
       id
       slug
@@ -209,7 +213,14 @@ export const post = gql`
         ...heroImage
       }
     }
-    manualOrderOfRelateds
+    relatedsInInputOrder {
+      id
+      slug
+      title
+      heroImage {
+        ...heroImage
+      }
+    }
     redirect
     og_image {
       resized {

--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -48,6 +48,7 @@ export const listingPost = gql`
  * @property {string} slug
  * @property {string} title
  * @property {import('./section').Section[]} sections
+ * @property {import('./section').Section[]} sectionsInInputOrder
  * @property {import('./photo').Photo | null} heroImage
  */
 
@@ -59,6 +60,9 @@ export const asideListingPost = gql`
     slug
     title
     sections {
+      ...section
+    }
+    sectionsInInputOrder {
       ...section
     }
     heroImage {

--- a/packages/mirror-media-next/components/external/external-normal-style.js
+++ b/packages/mirror-media-next/components/external/external-normal-style.js
@@ -1,5 +1,6 @@
 //TODO: adjust margin and padding of all margin and padding after implement advertisement.
 //TODO: refactor jsx structure, make it more readable.
+//TODO: adjust function `handleFetchPopularNews` and `handleFetchPopularNews`, make it more reuseable in other pages.
 
 import { useCallback } from 'react'
 import client from '../../apollo/apollo-client'
@@ -43,7 +44,8 @@ const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
  * @typedef {import('../../type/theme').Theme} Theme
  */
 /**
- * @typedef {import('../../components/story/normal/aside-article-list').ArticleData} AsideArticleData
+ * @typedef {import('../story/normal/aside-article-list').ArticleData} AsideArticleData
+ * @typedef {import('../story/normal/aside-article-list').ArticleDataContainSectionsWithOrdered} AsideArticleDataContainSectionsWithOrdered
  */
 /**
  * @typedef {import('../../apollo/fragments/external').External} External
@@ -453,7 +455,7 @@ export default function ExternalNormalStyle({ external }) {
   const partnerColor = getExternalPartnerColor(partner)
 
   /**
-   * @returns {Promise<AsideArticleData[] | []>}
+   * @returns {Promise<AsideArticleDataContainSectionsWithOrdered[] |[]>}
    */
   const handleFetchLatestNews = useCallback(async () => {
     try {
@@ -468,7 +470,13 @@ export default function ExternalNormalStyle({ external }) {
           storySlug: slug,
         },
       })
-      return res.data?.posts
+      return res.data?.posts.map((post) => {
+        const sectionsWithOrdered =
+          post.sectionsInInputOrder && post.sectionsInInputOrder.length
+            ? post.sectionsInInputOrder
+            : post.sections
+        return { sectionsWithOrdered, ...post }
+      })
     } catch (err) {
       console.error(err)
       return []
@@ -476,7 +484,7 @@ export default function ExternalNormalStyle({ external }) {
   }, [slug, EXTERNAL_DEFAULT_SECTION.slug])
 
   /**
-   * @returns {Promise<AsideArticleData[] | []>}
+   * @returns {Promise<AsideArticleDataContainSectionsWithOrdered[] |[]>}
    */
   const handleFetchPopularNews = async () => {
     try {
@@ -488,7 +496,17 @@ export default function ExternalNormalStyle({ external }) {
         url: URL_STATIC_POPULAR_NEWS,
         timeout: API_TIMEOUT,
       })
-      return data.filter((data) => data).slice(0.6)
+      const popularNews = data
+        .map((post) => {
+          const sectionsWithOrdered =
+            post.sectionsInInputOrder && post.sectionsInInputOrder.length
+              ? post.sectionsInInputOrder
+              : post.sections
+          return { sectionsWithOrdered, ...post }
+        })
+        .slice(0, 6)
+
+      return popularNews
     } catch (err) {
       return []
     }

--- a/packages/mirror-media-next/components/story/normal/aside-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/aside-article-list.js
@@ -25,6 +25,8 @@ const PopInAdInHotList = dynamic(
 
 /** @typedef {import('../../../apollo/fragments/post').AsideListingPost} ArticleData */
 
+/** @typedef {ArticleData & {sectionsWithOrdered: ArticleData["sectionsInInputOrder"]} } ArticleDataContainSectionsWithOrdered */
+
 const Wrapper = styled.section`
   margin: 20px auto 0;
 
@@ -253,7 +255,7 @@ const TitleLoading = styled(Title)`
  * - If is true, image of article should display at right, title and label should display at left.
  * - If is false, image of article should display at left, title and label should display at right.
  * optional, default value is `false`.
- * @param {()=>Promise<ArticleData[] | []>} props.fetchArticle
+ * @param {()=> Promise<ArticleDataContainSectionsWithOrdered[]> | Promise<[]>} props.fetchArticle
  * - A Promise base function for fetching article.
  * - If fulfilled, it will return a array of object, which item is a article.
  * - If rejected, it will return an empty array
@@ -308,8 +310,8 @@ export default function AsideArticleList({
   }, [isLoaded, handleLoadMore])
 
   const newsJsx = item.map((item, index) => {
-    const sectionName = getSectionNameGql(item.sections, undefined)
-    const sectionTitle = getSectionTitleGql(item.sections, undefined)
+    const sectionName = getSectionNameGql(item.sectionsWithOrdered, undefined)
+    const sectionTitle = getSectionTitleGql(item.sectionsWithOrdered, undefined)
     const articleHref = getArticleHref(item.slug, item.style, undefined)
 
     /**

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -21,10 +21,7 @@ import HeroImageAndVideo from './hero-image-and-video'
 import Divider from '../shared/divider'
 import ShareHeader from '../../shared/share-header'
 import Footer from '../../shared/footer'
-import {
-  transformTimeDataIntoDotFormat,
-  sortArrayWithOtherArrayId,
-} from '../../../utils'
+import { transformTimeDataIntoDotFormat } from '../../../utils'
 import { fetchAsidePosts } from '../../../apollo/query/posts'
 import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
 import { useDisplayAd } from '../../../hooks/useDisplayAd'
@@ -469,14 +466,14 @@ export default function StoryNormalStyle({
     title = '',
     slug = '',
     sections = [],
-    manualOrderOfSections = [],
+    sectionsInInputOrder = [],
     heroImage = null,
     heroVideo = null,
     heroCaption = '',
     publishedDate = '',
     updatedAt = '',
     writers = [],
-    manualOrderOfWriters = [],
+    writersInInputOrder = [],
     photographers = [],
     camera_man = [],
     designers = [],
@@ -486,22 +483,22 @@ export default function StoryNormalStyle({
     tags = [],
     brief = { blocks: [], entityMap: {} },
     relateds = [],
-    manualOrderOfRelateds = [],
+    relatedsInInputOrder = [],
     hiddenAdvertised = false,
   } = postData
 
   const sectionsWithOrdered =
-    manualOrderOfSections && manualOrderOfSections.length
-      ? sortArrayWithOtherArrayId(sections, manualOrderOfSections)
+    sectionsInInputOrder && sectionsInInputOrder.length
+      ? sectionsInInputOrder
       : sections
   const relatedsWithOrdered =
-    manualOrderOfRelateds && manualOrderOfRelateds.length
-      ? sortArrayWithOtherArrayId(relateds, manualOrderOfRelateds)
+    relatedsInInputOrder && relatedsInInputOrder.length
+      ? relatedsInInputOrder
       : relateds
 
   const writersWithOrdered =
-    manualOrderOfWriters && manualOrderOfWriters.length
-      ? sortArrayWithOtherArrayId(writers, manualOrderOfWriters)
+    writersInInputOrder && writersInInputOrder.length
+      ? writersInInputOrder
       : writers
 
   const [section] = sectionsWithOrdered

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -1,5 +1,5 @@
-//TODO: adjust margin and padding of all margin and padding after implement advertisement.
 //TODO: refactor jsx structure, make it more readable.
+//TODO: adjust function `handleFetchPopularNews` and `handleFetchPopularNews`, make it more reuseable in other pages.
 
 import { useCallback } from 'react'
 import client from '../../../apollo/apollo-client'
@@ -42,6 +42,7 @@ const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
 
 /**
  * @typedef {import('../../../components/story/normal/aside-article-list').ArticleData} AsideArticleData
+ * @typedef {import('../../../components/story/normal/aside-article-list').ArticleDataContainSectionsWithOrdered} AsideArticleDataContainSectionsWithOrdered
  */
 
 /**
@@ -504,7 +505,7 @@ export default function StoryNormalStyle({
   const [section] = sectionsWithOrdered
 
   /**
-   * @returns {Promise<AsideArticleData[] | []>}
+   * @returns {Promise<AsideArticleDataContainSectionsWithOrdered[] | []>}
    */
   const handleFetchLatestNews = useCallback(async () => {
     try {
@@ -519,7 +520,13 @@ export default function StoryNormalStyle({
           storySlug: slug,
         },
       })
-      return res.data?.posts
+      return res.data?.posts.map((post) => {
+        const sectionsWithOrdered =
+          post.sectionsInInputOrder && post.sectionsInInputOrder.length
+            ? post.sectionsInInputOrder
+            : post.sections
+        return { sectionsWithOrdered, ...post }
+      })
     } catch (err) {
       console.error(err)
       return []
@@ -527,7 +534,7 @@ export default function StoryNormalStyle({
   }, [section, slug])
 
   /**
-   * @returns {Promise<AsideArticleData[] | []>}
+   * @returns {Promise<AsideArticleDataContainSectionsWithOrdered[] | []>}
    */
   const handleFetchPopularNews = async () => {
     try {
@@ -539,7 +546,18 @@ export default function StoryNormalStyle({
         url: URL_STATIC_POPULAR_NEWS,
         timeout: API_TIMEOUT,
       })
-      return data.filter((data) => data).slice(0.6)
+
+      const popularNews = data
+        .map((post) => {
+          const sectionsWithOrdered =
+            post.sectionsInInputOrder && post.sectionsInInputOrder.length
+              ? post.sectionsInInputOrder
+              : post.sections
+          return { sectionsWithOrdered, ...post }
+        })
+        .slice(0, 6)
+
+      return popularNews
     } catch (err) {
       return []
     }

--- a/packages/mirror-media-next/components/story/photography/index.js
+++ b/packages/mirror-media-next/components/story/photography/index.js
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import DraftRenderBlock from '../shared/draft-renderer-block'
 import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
 const { getContentTextBlocks } = MirrorMedia
-import { sortArrayWithOtherArrayId } from '../../../utils'
 import Credits from './potography-credits'
 import HeroSection from './hero-section'
 import Header from './photography-header'
@@ -150,7 +149,7 @@ export default function StoryPhotographyStyle({ postData, postContent }) {
     heroImage = null,
     heroCaption = '',
     writers = [],
-    manualOrderOfWriters = [],
+    writersInInputOrder = [],
     photographers = [],
     camera_man = [],
     designers = [],
@@ -158,7 +157,7 @@ export default function StoryPhotographyStyle({ postData, postContent }) {
     vocals = [],
     extend_byline = '',
     relateds = [],
-    manualOrderOfRelateds = [],
+    relatedsInInputOrder = [],
 
     brief = null,
   } = postData
@@ -166,7 +165,7 @@ export default function StoryPhotographyStyle({ postData, postContent }) {
   const filteredBrief = getContentTextBlocks(brief)
 
   const credits = [
-    { writers: manualOrderOfWriters ? manualOrderOfWriters : writers },
+    { writers: writersInInputOrder ? writersInInputOrder : writers },
     { photographers: photographers },
     { camera_man: camera_man },
     { designers: designers },
@@ -176,8 +175,8 @@ export default function StoryPhotographyStyle({ postData, postContent }) {
   ]
 
   const relatedsWithOrdered =
-    manualOrderOfRelateds && manualOrderOfRelateds.length
-      ? sortArrayWithOtherArrayId(relateds, manualOrderOfRelateds)
+    relatedsInInputOrder && relatedsInInputOrder.length
+      ? relatedsInInputOrder
       : relateds
 
   // Get images array from content.entityMap

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 import ArticleBrief from '../shared/brief'
 import PremiumArticleContent from './article-content'
-import { sortArrayWithOtherArrayId } from '../../../utils'
 import TitleAndInfoAndHero from './title-and-info-and-hero'
 import CopyrightWarning from '../shared/copyright-warning'
 import SupportMirrorMediaBanner from '../shared/support-mirrormedia-banner'
@@ -211,9 +210,9 @@ export default function StoryPremiumStyle({
     title,
     brief = { blocks: [], entityMap: {} },
     sections = [],
-    manualOrderOfSections = [],
+    sectionsInInputOrder = [],
     writers = [],
-    manualOrderOfWriters = [],
+    writersInInputOrder = [],
     photographers = [],
     camera_man = [],
     designers = [],
@@ -227,8 +226,8 @@ export default function StoryPremiumStyle({
     heroVideo = null,
     heroCaption = '',
     relateds = [],
+    relatedsInInputOrder = [],
     slug = '',
-    manualOrderOfRelateds = [],
     hiddenAdvertised = false,
   } = postData
 
@@ -236,18 +235,18 @@ export default function StoryPremiumStyle({
     !isLoggedIn || postContent.type === 'trimmedContent'
   const h2AndH3Block = getContentBlocksH2H3(postContent.data)
   const sectionsWithOrdered =
-    manualOrderOfSections && manualOrderOfSections.length
-      ? sortArrayWithOtherArrayId(sections, manualOrderOfSections)
+    sectionsInInputOrder && sectionsInInputOrder.length
+      ? sectionsInInputOrder
       : sections
   const [section] = sectionsWithOrdered
   const sectionLabelFirst = getSectionLabelFirst(sectionsWithOrdered)
   const writersWithOrdered =
-    manualOrderOfWriters && manualOrderOfWriters.length
-      ? sortArrayWithOtherArrayId(writers, manualOrderOfWriters)
+    writersInInputOrder && writersInInputOrder.length
+      ? writersInInputOrder
       : writers
   const relatedsWithOrdered =
-    manualOrderOfRelateds && manualOrderOfRelateds.length
-      ? sortArrayWithOtherArrayId(relateds, manualOrderOfRelateds)
+    relatedsInInputOrder && relatedsInInputOrder.length
+      ? relatedsInInputOrder
       : relateds
   const credits = [
     { writers: writersWithOrdered },

--- a/packages/mirror-media-next/components/story/shared/aside-article-list.js
+++ b/packages/mirror-media-next/components/story/shared/aside-article-list.js
@@ -10,6 +10,8 @@ import Image from '@readr-media/react-image'
 
 /** @typedef {import('../../../apollo/fragments/post').AsideListingPost} ArticleData */
 
+/** @typedef {ArticleData & {sectionsWithOrdered: ArticleData["sectionsInInputOrder"]} } ArticleDataContainSectionsWithOrdered */
+
 const Wrapper = styled.section`
   margin: 24px auto 0;
   width: 100%;
@@ -235,7 +237,7 @@ const TitleLoading = styled(Title)`
  *
  * @param {Object} props
  * @param {string} props.heading - heading of this components, showing user what kind of news is
- * @param {()=>Promise<ArticleData[] | []>} props.fetchArticle
+ * @param {()=>Promise<ArticleDataContainSectionsWithOrdered[] | []>} props.fetchArticle
  * - A Promise base function for fetching article.
  * - If fulfilled, it will return a array of object, which item is a article.
  * - If rejected, it will return an empty array

--- a/packages/mirror-media-next/components/story/shared/aside.js
+++ b/packages/mirror-media-next/components/story/shared/aside.js
@@ -1,3 +1,5 @@
+//TODO: adjust function `handleFetchPopularNews` and `handleFetchPopularNews`, make it more reuseable in other pages.
+
 import styled from 'styled-components'
 import RelatedArticleList from '../wide/related-article-list'
 import AsideArticleList from './aside-article-list'
@@ -12,6 +14,7 @@ import { fetchAsidePosts } from '../../../apollo/query/posts'
  */
 /**
  * @typedef {import('./aside-article-list').ArticleData} AsideArticleData
+ * @typedef {import('./aside-article-list').ArticleDataContainSectionsWithOrdered} ArticleDataContainSectionsWithOrdered
  */
 
 /**
@@ -44,7 +47,7 @@ export default function Aside({
   storySlug = '',
 }) {
   /**
-   * @returns {Promise<AsideArticleData[] | []>}
+   * @returns {Promise<ArticleDataContainSectionsWithOrdered[] | []>}
    */
   const handleFetchLatestNews = async () => {
     try {
@@ -59,7 +62,13 @@ export default function Aside({
           storySlug: storySlug,
         },
       })
-      return res.data?.posts
+      return res.data?.posts.map((post) => {
+        const sectionsWithOrdered =
+          post.sectionsInInputOrder && post.sectionsInInputOrder.length
+            ? post.sectionsInInputOrder
+            : post.sections
+        return { sectionsWithOrdered, ...post }
+      })
     } catch (err) {
       console.error(err)
       return []
@@ -67,7 +76,7 @@ export default function Aside({
   }
 
   /**
-   * @returns {Promise<AsideArticleData[] | []>}
+   * @returns {Promise<ArticleDataContainSectionsWithOrdered[] | []>}
    */
   const handleFetchPopularNews = async () => {
     try {
@@ -79,7 +88,18 @@ export default function Aside({
         url: URL_STATIC_POPULAR_NEWS,
         timeout: API_TIMEOUT,
       })
-      return data.filter((data) => data).slice(0, 6)
+
+      const popularNews = data
+        .map((post) => {
+          const sectionsWithOrdered =
+            post.sectionsInInputOrder && post.sectionsInInputOrder.length
+              ? post.sectionsInInputOrder
+              : post.sections
+          return { sectionsWithOrdered, ...post }
+        })
+        .slice(0, 6)
+
+      return popularNews
     } catch (err) {
       return []
     }

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 import DraftRenderBlock from '../shared/draft-renderer-block'
 import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
 const { getContentBlocksH2H3 } = MirrorMedia
-import { sortArrayWithOtherArrayId } from '../../../utils'
 import { useMembership } from '../../../context/membership'
 
 import Header from './header'
@@ -127,9 +126,9 @@ export default function StoryWideStyle({ postData, postContent }) {
     updatedAt = '',
     publishedDate = '',
     sections = [],
-    manualOrderOfSections = [],
+    sectionsInInputOrder = [],
     writers = [],
-    manualOrderOfWriters = [],
+    writersInInputOrder = [],
     photographers = [],
     camera_man = [],
     designers = [],
@@ -138,26 +137,26 @@ export default function StoryWideStyle({ postData, postContent }) {
     extend_byline = '',
 
     relateds = [],
-    manualOrderOfRelateds = [],
+    relatedsInInputOrder = [],
     slug = '',
     brief = null,
     tags = [],
   } = postData
 
   const sectionsWithOrdered =
-    manualOrderOfSections && manualOrderOfSections.length
-      ? sortArrayWithOtherArrayId(sections, manualOrderOfSections)
+    sectionsInInputOrder && sectionsInInputOrder.length
+      ? sectionsInInputOrder
       : sections
   const [section] = sectionsWithOrdered
 
   const relatedsWithOrdered =
-    manualOrderOfRelateds && manualOrderOfRelateds.length
-      ? sortArrayWithOtherArrayId(relateds, manualOrderOfRelateds)
+    relatedsInInputOrder && relatedsInInputOrder.length
+      ? relatedsInInputOrder
       : relateds
 
   const writersWithOrdered =
-    manualOrderOfWriters && manualOrderOfWriters.length
-      ? sortArrayWithOtherArrayId(writers, manualOrderOfWriters)
+    writersInInputOrder && writersInInputOrder.length
+      ? writersInInputOrder
       : writers
 
   const credits = [


### PR DESCRIPTION
## Notable Change
1. apollo query抓取新的欄位`sectionsInputOrder`, `writersInputOrder`,`relatedInputOrder`
2. 於文章頁、external頁對應元件顯示對應資料