### PR TITLE
feat(mm-next): unshow certain ad on story page if has wine category

### DIFF
--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -21,7 +21,10 @@ import HeroImageAndVideo from './hero-image-and-video'
 import Divider from '../shared/divider'
 import ShareHeader from '../../shared/share-header'
 import Footer from '../../shared/footer'
-import { transformTimeDataIntoDotFormat } from '../../../utils'
+import {
+  transformTimeDataIntoDotFormat,
+  getCategoryOfWineSlug,
+} from '../../../utils'
 import { fetchAsidePosts } from '../../../apollo/query/posts'
 import { URL_STATIC_POPULAR_NEWS, API_TIMEOUT } from '../../../config/index.mjs'
 import { useDisplayAd } from '../../../hooks/useDisplayAd'
@@ -467,6 +470,7 @@ export default function StoryNormalStyle({
     title = '',
     slug = '',
     sections = [],
+    categories = [],
     sectionsInInputOrder = [],
     heroImage = null,
     heroVideo = null,
@@ -576,7 +580,8 @@ export default function StoryNormalStyle({
   const updatedTaipeiTime = transformTimeDataIntoDotFormat(updatedAt)
 
   const shouldShowAd = useDisplayAd(hiddenAdvertised)
-
+  //If no wine category, then should show gpt ST ad, otherwise, then should not show gpt ST ad.
+  const noCategoryOfWineSlug = getCategoryOfWineSlug(categories).length === 0
   return (
     <>
       <ShareHeader
@@ -763,12 +768,12 @@ export default function StoryNormalStyle({
         />
       )}
 
-      {shouldShowAd && (
+      {shouldShowAd && noCategoryOfWineSlug ? (
         <StickyGPTAd_MB_ST
           pageKey={getSectionGPTPageKey(section?.slug)}
           adKey="MB_ST"
         />
-      )}
+      ) : null}
 
       <Footer footerType="default" />
     </>

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -20,7 +20,7 @@ import Footer from '../../shared/footer'
 import { useDisplayAd } from '../../../hooks/useDisplayAd'
 import { Z_INDEX } from '../../../constants/index'
 import { SECTION_IDS } from '../../../constants/index'
-
+import { getCategoryOfWineSlug } from '../../../utils'
 const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
   ssr: false,
 })
@@ -210,6 +210,7 @@ export default function StoryPremiumStyle({
     title,
     brief = { blocks: [], entityMap: {} },
     sections = [],
+    categories = [],
     sectionsInInputOrder = [],
     writers = [],
     writersInInputOrder = [],
@@ -268,7 +269,9 @@ export default function StoryPremiumStyle({
       supportBanner = <SupportSingleArticleBanner />
     }
   }
-
+  console.log(categories)
+  //If no wine category, then should show gpt ST ad, otherwise, then should not show gpt ST ad.
+  const noCategoryOfWineSlug = getCategoryOfWineSlug(categories).length === 0
   return (
     <>
       <ShareHeader
@@ -363,11 +366,11 @@ export default function StoryPremiumStyle({
       />
 
       {shouldShowAd && (
-        <>
-          <StyledGPTAd_FT pageKey={SECTION_IDS['member']} adKey="FT" />
-          <StickyGPTAd_MB_ST pageKey={SECTION_IDS['member']} adKey="MB_ST" />
-        </>
+        <StyledGPTAd_FT pageKey={SECTION_IDS['member']} adKey="FT" />
       )}
+      {shouldShowAd && noCategoryOfWineSlug ? (
+        <StickyGPTAd_MB_ST pageKey={SECTION_IDS['member']} adKey="MB_ST" />
+      ) : null}
 
       <Footer footerType="default" />
     </>

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -14,7 +14,11 @@ import {
 } from '../../apollo/query/posts'
 import StoryNormalStyle from '../../components/story/normal'
 import Layout from '../../components/shared/layout'
-import { convertDraftToText, getResizedUrl } from '../../utils/index'
+import {
+  convertDraftToText,
+  getResizedUrl,
+  getCategoryOfWineSlug,
+} from '../../utils'
 import { handleStoryPageRedirect } from '../../utils/story'
 import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
@@ -93,7 +97,6 @@ export default function Story({ postData, headerData, storyLayoutType }) {
     trimmedContent = null,
     hiddenAdvertised = false,
   } = postData
-
   /**
    * The logic for rendering the article content:
    * We use the state `postContent` to manage the content should render in the story page.
@@ -192,6 +195,8 @@ export default function Story({ postData, headerData, storyLayoutType }) {
     }
   }
   const storyLayoutJsx = renderStoryLayout()
+  //If no wine category, then should show gpt ST ad, otherwise, then should not show gpt ST ad.
+  const noCategoryOfWineSlug = getCategoryOfWineSlug(categories).length === 0
 
   return (
     <Layout
@@ -216,7 +221,9 @@ export default function Story({ postData, headerData, storyLayoutType }) {
         {storyLayoutJsx}
         <WineWarning categories={categories} />
         <AdultOnlyWarning isAdult={isAdult} />
-        <FullScreenAds hiddenAdvertised={hiddenAdvertised} />
+        {noCategoryOfWineSlug && (
+          <FullScreenAds hiddenAdvertised={hiddenAdvertised} />
+        )}
       </>
     </Layout>
   )


### PR DESCRIPTION
## Notable Change
調整文章頁顯示廣告邏輯，如果有酒類相關的category，則不顯示蓋板廣告與gpt ST廣告