### PR TITLE
style(mm-next): remove `display:grid` to prevent style break

### DIFF
--- a/packages/mirror-media-next/components/story/normal/article-content.js
+++ b/packages/mirror-media-next/components/story/normal/article-content.js
@@ -16,21 +16,21 @@ const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
 
 const Wrapper = styled.section`
   margin-top: 32px;
-  display: grid;
-  gap: 32px;
 
   ${({ theme }) => theme.breakpoint.md} {
     margin-top: 20px;
   }
 `
-
+const ContentContainer = styled.section`
+  margin-top: 32px;
+  margin-bottom: 32px;
+`
 const StyledGPTAd = styled(GPTAd)`
   width: 100%;
   height: auto;
   max-width: 336px;
   max-height: 280px;
-  margin: auto;
-
+  margin: 32px auto;
   display: ${
     /**
      * @param {Object} props
@@ -70,6 +70,7 @@ export default function ArticleContent({
       <DraftRenderBlock
         rawContentBlock={copyAndSliceDraftBlock(content, 0, 1)}
         contentLayout="normal"
+        wrapper={(children) => <ContentContainer>{children}</ContentContainer>}
       />
 
       {blocksLength > 1 && (
@@ -79,6 +80,9 @@ export default function ArticleContent({
           <DraftRenderBlock
             rawContentBlock={copyAndSliceDraftBlock(content, 1, 5)}
             contentLayout="normal"
+            wrapper={(children) => (
+              <ContentContainer>{children}</ContentContainer>
+            )}
           />
         </>
       )}
@@ -90,6 +94,9 @@ export default function ArticleContent({
           <DraftRenderBlock
             rawContentBlock={copyAndSliceDraftBlock(content, 5)}
             contentLayout="normal"
+            wrapper={(children) => (
+              <ContentContainer>{children}</ContentContainer>
+            )}
           />
         </>
       )}
@@ -102,6 +109,7 @@ export default function ArticleContent({
       <DraftRenderBlock
         rawContentBlock={copyAndSliceDraftBlock(content, 0, 3)}
         contentLayout="normal"
+        wrapper={(children) => <ContentContainer>{children}</ContentContainer>}
       />
 
       {blocksLength > 3 && (
@@ -111,6 +119,9 @@ export default function ArticleContent({
           <DraftRenderBlock
             rawContentBlock={copyAndSliceDraftBlock(content, 3)}
             contentLayout="normal"
+            wrapper={(children) => (
+              <ContentContainer>{children}</ContentContainer>
+            )}
           />
         </>
       )}

--- a/packages/mirror-media-next/components/story/premium/article-content.js
+++ b/packages/mirror-media-next/components/story/premium/article-content.js
@@ -14,22 +14,21 @@ const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
  * @typedef {import('../../../type/draft-js').Draft} Content
  */
 
-const Wrapper = styled.section`
-  display: grid;
-  gap: 32px;
-`
-
 const StyledGPTAd = styled(GPTAd)`
   width: 100%;
   height: auto;
   max-width: 336px;
   max-height: 280px;
-  margin: auto;
+  margin: 32px auto;
 
   ${({ theme }) => theme.breakpoint.xl} {
     max-width: 640px;
     max-height: 390px;
   }
+`
+const ContentContainer = styled.section`
+  margin-top: 32px;
+  margin-bottom: 32px;
 `
 
 /**
@@ -51,10 +50,11 @@ export default function PremiumArticleContent({
 
   //The GPT advertisement for the `mobile` version includes `AT1`
   const MB_contentJsx = (
-    <Wrapper className={className}>
+    <section className={className}>
       <DraftRenderBlock
         rawContentBlock={copyAndSliceDraftBlock(content, 0, 1)}
         contentLayout="premium"
+        wrapper={(children) => <ContentContainer>{children}</ContentContainer>}
       />
 
       {blocksLength > 1 && (
@@ -66,16 +66,23 @@ export default function PremiumArticleContent({
           <DraftRenderBlock
             rawContentBlock={copyAndSliceDraftBlock(content, 1)}
             contentLayout="premium"
+            wrapper={(children) => (
+              <ContentContainer>{children}</ContentContainer>
+            )}
           />
         </>
       )}
-    </Wrapper>
+    </section>
   )
 
   const PC_contentJsx = (
-    <Wrapper className={className}>
-      <DraftRenderBlock rawContentBlock={content} contentLayout="premium" />
-    </Wrapper>
+    <section className={className}>
+      <DraftRenderBlock
+        rawContentBlock={content}
+        contentLayout="premium"
+        wrapper={(children) => <ContentContainer>{children}</ContentContainer>}
+      />
+    </section>
   )
 
   const contentJsx =


### PR DESCRIPTION
when content has full-screen size element (such as [scrollable-video](https://github.com/twreporter/orangutan-monorepo/tree/master/packages/scrollable-video), if we use css property `display:gird`,  content width will increase as full-screen size, which is not we want. To prevent this issue, we remove `display:grid` and use other css property