### PR TITLE
feat(mm-next/amp-gpt): add amp-gpt-ad 

### DIFF
--- a/packages/mirror-media-next/components/amp/amp-ads/amp-gpt-ad.js
+++ b/packages/mirror-media-next/components/amp/amp-ads/amp-gpt-ad.js
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import { GPT_AD_NETWORK } from '../../../constants/ads'
 
 const Wrapper = styled.div`
-  background-color: aqua;
   /**
  * 廣告有時會替換掉原本 <Ad> 元件裡頭的根元素 <div>
  * 因此不限定所指定的元素類型（*）
@@ -18,7 +17,7 @@ const Wrapper = styled.div`
   }
 `
 
-export default function AmpGptAd() {
+export default function AmpGptAd({ section, position }) {
   return (
     <Wrapper>
       {/* @ts-ignore */}
@@ -26,7 +25,7 @@ export default function AmpGptAd() {
         width="300"
         height="250"
         type="doubleclick"
-        data-slot={`/${GPT_AD_NETWORK}/mirror_AMP_news_300x250_FT`}
+        data-slot={`/${GPT_AD_NETWORK}/mirror_AMP_${section}_300x250_${position}`}
       />
     </Wrapper>
   )

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -119,11 +119,13 @@ function StoryAmpPage({ postData }) {
             }`}
           >
             <AmpHeader />
+            <AmpGptAd section="news" position="HD" />
+
             <AmpMain postData={postData} isMember={isMember} />
             <AmpRelated relateds={relatedsWithOrdered} />
             <Taboola title="你可能也喜歡這些文章" />
 
-            <AmpGptAd />
+            <AmpGptAd section="news" position="FT" />
 
             <AmpFooter />
           </section>


### PR DESCRIPTION
為未來有幸做AMP GPT廣告的人留下一點筆記
---
Implement DFP in AMP is pretty easy, just use amp-ad as below:
import amp-ad component
```
<script async custom-element="amp-ad"
src="https://cdn.ampproject.org/v0/amp-ad-0.1.js"></script>
```
2. add ad element
```
<amp-ad
  width="320"
  height="100"
  type="doubleclick"
  data-slot="/21737763597/adunit-1"
></amp-ad>
```