### PR TITLE
fix(mm-next/amp-gpt-ad): add `data-multi-size` and `data-multi-size-validation` attributes

### DIFF
--- a/packages/mirror-media-next/components/amp/amp-ads/amp-gpt-ad.js
+++ b/packages/mirror-media-next/components/amp/amp-ads/amp-gpt-ad.js
@@ -26,6 +26,8 @@ export default function AmpGptAd({ section, position }) {
         height="280"
         type="doubleclick"
         data-slot={`/${GPT_AD_NETWORK}/mirror_AMP_${section}_300x250_${position}`}
+        data-multi-size="336x280,300x250"
+        data-multi-size-validation="false"
       />
     </Wrapper>
   )


### PR DESCRIPTION
Try to solve the issue of GPT ads sometimes not showing.

- reference: https://medium.com/ampfuel/increase-ad-competition-with-multi-size-fluid-ads-in-amp-9cff90066c16