### PR TITLE
refactor(story): if isAdvertised, pageKey for gptAd is other

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -147,6 +147,7 @@ export const asideListingPost = gql`
  * @property {string} redirect - post redirect slug or external url
  * @property {HeroImage | null} og_image - og image of the post
  * @property {boolean} hiddenAdvertised - decide whether to display advertisements
+ * @property {boolean} isAdvertised - the field called '廣告文案' in cms
  */
 
 export const post = gql`
@@ -232,6 +233,7 @@ export const post = gql`
       }
     }
     hiddenAdvertised
+    isAdvertised
   }
 `
 

--- a/packages/mirror-media-next/components/story/normal/article-content.js
+++ b/packages/mirror-media-next/components/story/normal/article-content.js
@@ -51,18 +51,20 @@ const StyledGPTAd = styled(GPTAd)`
  * @param {Content} props.content
  * @param {string | undefined} props.sectionSlug
  * @param {boolean} [props.hiddenAdvertised] - CMS Posts「google廣告違規」
+ * @param {string} [props.pageKeyForGptAd]
  * @returns {JSX.Element}
  */
 export default function ArticleContent({
   content = { blocks: [], entityMap: {} },
   sectionSlug,
   hiddenAdvertised = false,
+  pageKeyForGptAd,
 }) {
   const shouldShowAd = useDisplayAd(hiddenAdvertised)
   const windowDimensions = useWindowDimensions()
 
   const blocksLength = getBlocksCount(content)
-  const GPTpageKey = getSectionGPTPageKey(sectionSlug)
+  const GPTpageKey = pageKeyForGptAd || getSectionGPTPageKey(sectionSlug)
 
   //The GPT advertisement for the `mobile` version includes `AT1` & `AT2`
   const MB_contentJsx = (

--- a/packages/mirror-media-next/components/story/normal/article-content.js
+++ b/packages/mirror-media-next/components/story/normal/article-content.js
@@ -4,7 +4,6 @@ import { copyAndSliceDraftBlock, getBlocksCount } from '../../../utils/story'
 import dynamic from 'next/dynamic'
 import useWindowDimensions from '../../../hooks/use-window-dimensions'
 import { useDisplayAd } from '../../../hooks/useDisplayAd'
-import { getSectionGPTPageKey } from '../../../utils/ad'
 
 const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -49,22 +48,19 @@ const StyledGPTAd = styled(GPTAd)`
  *
  * @param {Object} props
  * @param {Content} props.content
- * @param {string | undefined} props.sectionSlug
  * @param {boolean} [props.hiddenAdvertised] - CMS Posts「google廣告違規」
- * @param {string} [props.pageKeyForGptAd]
+ * @param {string | undefined} [props.pageKeyForGptAd]
  * @returns {JSX.Element}
  */
 export default function ArticleContent({
   content = { blocks: [], entityMap: {} },
-  sectionSlug,
   hiddenAdvertised = false,
-  pageKeyForGptAd,
+  pageKeyForGptAd = '',
 }) {
   const shouldShowAd = useDisplayAd(hiddenAdvertised)
   const windowDimensions = useWindowDimensions()
 
   const blocksLength = getBlocksCount(content)
-  const GPTpageKey = pageKeyForGptAd || getSectionGPTPageKey(sectionSlug)
 
   //The GPT advertisement for the `mobile` version includes `AT1` & `AT2`
   const MB_contentJsx = (
@@ -77,7 +73,9 @@ export default function ArticleContent({
 
       {blocksLength > 1 && (
         <>
-          {shouldShowAd && <StyledGPTAd pageKey={GPTpageKey} adKey="MB_AT1" />}
+          {shouldShowAd && (
+            <StyledGPTAd pageKey={pageKeyForGptAd} adKey="MB_AT1" />
+          )}
 
           <DraftRenderBlock
             rawContentBlock={copyAndSliceDraftBlock(content, 1, 5)}
@@ -91,7 +89,9 @@ export default function ArticleContent({
 
       {blocksLength > 5 && (
         <>
-          {shouldShowAd && <StyledGPTAd pageKey={GPTpageKey} adKey="MB_AT2" />}
+          {shouldShowAd && (
+            <StyledGPTAd pageKey={pageKeyForGptAd} adKey="MB_AT2" />
+          )}
 
           <DraftRenderBlock
             rawContentBlock={copyAndSliceDraftBlock(content, 5)}
@@ -116,7 +116,9 @@ export default function ArticleContent({
 
       {blocksLength > 3 && (
         <>
-          {shouldShowAd && <StyledGPTAd pageKey={GPTpageKey} adKey="PC_AT1" />}
+          {shouldShowAd && (
+            <StyledGPTAd pageKey={pageKeyForGptAd} adKey="PC_AT1" />
+          )}
 
           <DraftRenderBlock
             rawContentBlock={copyAndSliceDraftBlock(content, 3)}

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -635,6 +635,7 @@ export default function StoryNormalStyle({
             content={postContent.data}
             sectionSlug={section?.slug}
             hiddenAdvertised={hiddenAdvertised}
+            pageKeyForGptAd={pageKeyForGptAd}
           />
 
           <DateUnderContent>

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -517,6 +517,7 @@ export default function StoryNormalStyle({
 
   const [section] = sectionsWithOrdered
 
+  // 廣編文章的 pageKey 是 other
   const pageKeyForGptAd = postData.isAdvertised
     ? 'other'
     : getSectionGPTPageKey(section?.slug)
@@ -633,7 +634,6 @@ export default function StoryNormalStyle({
 
           <ArticleContent
             content={postContent.data}
-            sectionSlug={section?.slug}
             hiddenAdvertised={hiddenAdvertised}
             pageKeyForGptAd={pageKeyForGptAd}
           />

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -517,6 +517,10 @@ export default function StoryNormalStyle({
 
   const [section] = sectionsWithOrdered
 
+  const pageKeyForGptAd = postData.isAdvertised
+    ? 'other'
+    : getSectionGPTPageKey(section?.slug)
+
   /**
    * @returns {Promise<AsideArticleDataContainSectionsWithOrdered[] | []>}
    */
@@ -602,12 +606,7 @@ export default function StoryNormalStyle({
         }}
       />
 
-      {shouldShowAd && (
-        <StyledGPTAd_HD
-          pageKey={getSectionGPTPageKey(section?.slug)}
-          adKey="HD"
-        />
-      )}
+      {shouldShowAd && <StyledGPTAd_HD pageKey={pageKeyForGptAd} adKey="HD" />}
 
       <Main>
         <Article>
@@ -652,20 +651,14 @@ export default function StoryNormalStyle({
           />
 
           {shouldShowAd && (
-            <StyledGPTAd_MB_AT3
-              pageKey={getSectionGPTPageKey(section?.slug)}
-              adKey="MB_AT3"
-            />
+            <StyledGPTAd_MB_AT3 pageKey={pageKeyForGptAd} adKey="MB_AT3" />
           )}
           <SocialNetworkServiceLarge
             shouldShowLargePagePlugin={true}
             flexDirection="column"
           />
           {shouldShowAd && (
-            <StyledGPTAd_MB_E1
-              pageKey={getSectionGPTPageKey(section?.slug)}
-              adKey="MB_E1"
-            />
+            <StyledGPTAd_MB_E1 pageKey={pageKeyForGptAd} adKey="MB_E1" />
           )}
 
           {shouldShowAd && (
@@ -694,14 +687,8 @@ export default function StoryNormalStyle({
 
             {shouldShowAd && (
               <GPTAdContainer>
-                <StyledGPTAd_PC_E1
-                  pageKey={getSectionGPTPageKey(section?.slug)}
-                  adKey="PC_E1"
-                />
-                <StyledGPTAd_PC_E2
-                  pageKey={getSectionGPTPageKey(section?.slug)}
-                  adKey="PC_E2"
-                />
+                <StyledGPTAd_PC_E1 pageKey={pageKeyForGptAd} adKey="PC_E1" />
+                <StyledGPTAd_PC_E2 pageKey={pageKeyForGptAd} adKey="PC_E2" />
               </GPTAdContainer>
             )}
 
@@ -714,10 +701,7 @@ export default function StoryNormalStyle({
         </Article>
         <Aside>
           {shouldShowAd && (
-            <StyledGPTAd_PC_R1
-              pageKey={getSectionGPTPageKey(section?.slug)}
-              adKey="PC_R1"
-            />
+            <StyledGPTAd_PC_R1 pageKey={pageKeyForGptAd} adKey="PC_R1" />
           )}
           <AsideArticleList
             heading="最新文章"
@@ -727,10 +711,7 @@ export default function StoryNormalStyle({
           />
           <FixedContainer>
             {shouldShowAd && (
-              <StyledGPTAd_PC_R2
-                pageKey={getSectionGPTPageKey(section?.slug)}
-                adKey="PC_R2"
-              />
+              <StyledGPTAd_PC_R2 pageKey={pageKeyForGptAd} adKey="PC_R2" />
             )}
 
             <Divider />
@@ -771,18 +752,10 @@ export default function StoryNormalStyle({
         )}
       </StoryEndMobileTablet>
 
-      {shouldShowAd && (
-        <StyledGPTAd_FT
-          pageKey={getSectionGPTPageKey(section?.slug)}
-          adKey="FT"
-        />
-      )}
+      {shouldShowAd && <StyledGPTAd_FT pageKey={pageKeyForGptAd} adKey="FT" />}
 
       {shouldShowAd && noCategoryOfWineSlug ? (
-        <StickyGPTAd_MB_ST
-          pageKey={getSectionGPTPageKey(section?.slug)}
-          adKey="MB_ST"
-        />
+        <StickyGPTAd_MB_ST pageKey={pageKeyForGptAd} adKey="MB_ST" />
       ) : null}
 
       <Footer footerType="default" />

--- a/packages/mirror-media-next/components/story/premium/article-content.js
+++ b/packages/mirror-media-next/components/story/premium/article-content.js
@@ -37,12 +37,14 @@ const ContentContainer = styled.section`
  * @param {Content} props.content
  * @param {string} [props.className]
  * @param {boolean} [props.hiddenAdvertised] - CMS Posts「google廣告違規」
+ * @param {string} [props.pageKeyForGptAd]
  * @returns {JSX.Element}
  */
 export default function PremiumArticleContent({
   content = { blocks: [], entityMap: {} },
   className = '',
   hiddenAdvertised = false,
+  pageKeyForGptAd = 'other',
 }) {
   const shouldShowAd = useDisplayAd(hiddenAdvertised)
   const windowDimensions = useWindowDimensions()
@@ -60,7 +62,7 @@ export default function PremiumArticleContent({
       {blocksLength > 1 && (
         <>
           {shouldShowAd && (
-            <StyledGPTAd pageKey={SECTION_IDS['member']} adKey="MB_AT1" />
+            <StyledGPTAd pageKey={pageKeyForGptAd} adKey="MB_AT1" />
           )}
 
           <DraftRenderBlock

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -230,6 +230,7 @@ export default function StoryPremiumStyle({
     relatedsInInputOrder = [],
     slug = '',
     hiddenAdvertised = false,
+    isAdvertised = fasle,
   } = postData
 
   const shouldShowArticleMask =
@@ -258,6 +259,7 @@ export default function StoryPremiumStyle({
     { vocals: vocals },
     { extend_byline: extend_byline },
   ]
+  const pageKeyForGptAd = isAdvertised ? 'other' : SECTION_IDS['member']
 
   const shouldShowAd = useDisplayAd(hiddenAdvertised)
 
@@ -282,9 +284,7 @@ export default function StoryPremiumStyle({
         }}
       />
 
-      {shouldShowAd && (
-        <StyledGPTAd_HD pageKey={SECTION_IDS['member']} adKey="HD" />
-      )}
+      {shouldShowAd && <StyledGPTAd_HD pageKey={pageKeyForGptAd} adKey="HD" />}
 
       <Main>
         <article>
@@ -333,26 +333,19 @@ export default function StoryPremiumStyle({
                 contentLayout="premium"
               />
             </section>
-
             <PremiumArticleContent
               className="content"
               content={postContent.data}
               hiddenAdvertised={hiddenAdvertised}
+              pageKeyForGptAd={pageKeyForGptAd}
             />
-
             <CopyrightWarning />
-
             {shouldShowArticleMask && <ArticleMask postId={id} />}
-
             {supportBanner}
-
             {shouldShowAd && (
               <GPTAdContainer>
-                <StyledGPTAd_E1 pageKey={SECTION_IDS['member']} adKey="E1" />
-                <StyledGPTAd_PC_E2
-                  pageKey={SECTION_IDS['member']}
-                  adKey="PC_E2"
-                />
+                <StyledGPTAd_E1 pageKey={pageKeyForGptAd} adKey="E1" />
+                <StyledGPTAd_PC_E2 pageKey={pageKeyForGptAd} adKey="PC_E2" />
               </GPTAdContainer>
             )}
           </ContentWrapper>
@@ -365,11 +358,9 @@ export default function StoryPremiumStyle({
         storySlug={slug}
       />
 
-      {shouldShowAd && (
-        <StyledGPTAd_FT pageKey={SECTION_IDS['member']} adKey="FT" />
-      )}
+      {shouldShowAd && <StyledGPTAd_FT pageKey={pageKeyForGptAd} adKey="FT" />}
       {shouldShowAd && noCategoryOfWineSlug ? (
-        <StickyGPTAd_MB_ST pageKey={SECTION_IDS['member']} adKey="MB_ST" />
+        <StickyGPTAd_MB_ST pageKey={pageKeyForGptAd} adKey="MB_ST" />
       ) : null}
 
       <Footer footerType="default" />


### PR DESCRIPTION
廣編文章頁補上廣告，廣告單元＝ other

### notable change
1. post 多打資料 `isAdvertised`
2. 將 `pageKeyForGptAd` 給全頁面的 gptAd
3. 若 `isAdvertised` 是 true，直接使用 `other`，否則進入 `getSectionGPTPageKey` 判斷。

### can be better?
1. 目前只有修改 normal 版型，但廣編文章是否會有其他版型 >> 需求方說還需補上會員文章 >> 列如 todo
2. 如果要所有版型共用，要不要將邏輯抽出來？怎麼抽比較方便？ >> 想和 reviewer 討論
3. 沒有 section 也不是廣編的文章目前不會顯示廣告 >> 需求方表示沒問題

### todo
- [x] 讓會員文章也吃相同邏輯