### PR TITLE
feat(mm-next/amp-related): add amp-gpt E1 ad conditional rendering logic

### DIFF
--- a/packages/mirror-media-next/components/amp/amp-ads/amp-gpt-ad.js
+++ b/packages/mirror-media-next/components/amp/amp-ads/amp-gpt-ad.js
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import { GPT_AD_NETWORK } from '../../../constants/ads'
 
 const Wrapper = styled.div`
-  background-color: aqua;
   /**
  * 廣告有時會替換掉原本 <Ad> 元件裡頭的根元素 <div>
  * 因此不限定所指定的元素類型（*）

--- a/packages/mirror-media-next/components/amp/amp-ads/amp-gpt-ad.js
+++ b/packages/mirror-media-next/components/amp/amp-ads/amp-gpt-ad.js
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 import { GPT_AD_NETWORK } from '../../../constants/ads'
 
 const Wrapper = styled.div`
+  background-color: aqua;
   /**
  * 廣告有時會替換掉原本 <Ad> 元件裡頭的根元素 <div>
  * 因此不限定所指定的元素類型（*）
@@ -16,10 +17,16 @@ const Wrapper = styled.div`
     }
   }
 `
-
-export default function AmpGptAd({ section, position }) {
+/**
+ * @param {Object} props - The component props.
+ * @param {string} [props.className] - The class name for the component.
+ * @param {string} props.section - The section for the ad.
+ * @param {string} props.position - The position of the ad within the section.
+ * @return {JSX.Element} The rendered AMP GPT ad component.
+ */
+export default function AmpGptAd({ className, section, position }) {
   return (
-    <Wrapper>
+    <Wrapper className={className}>
       {/* @ts-ignore */}
       <amp-ad
         width="300"

--- a/packages/mirror-media-next/components/amp/amp-related.js
+++ b/packages/mirror-media-next/components/amp/amp-related.js
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import styled from 'styled-components'
-import AmpPopIn from '../amp/amp-ads/amp-popin-ad'
+import AmpPopIn from './amp-ads/amp-popin-ad'
+import AmpGptAd from './amp-ads/amp-gpt-ad'
 
 const RelatedWrapper = styled.section`
   width: 100%;
@@ -30,6 +31,10 @@ const RelatedItem = styled(Link)`
   }
 `
 
+const StyledAmpGptAd = styled(AmpGptAd)`
+  margin-top: 20px;
+`
+
 /**
  * @typedef {(import('../../apollo/fragments/post').Related)[]} Relateds
  */
@@ -37,9 +42,13 @@ const RelatedItem = styled(Link)`
  *
  * @param {Object} props
  * @param {Relateds} props.relateds
+ * @param {string} props.section
  * @returns {JSX.Element}
  */
-export default function AmpHeader({ relateds }) {
+
+export default function AmpHeader({ relateds, section }) {
+  console.log(relateds.length, section)
+
   return (
     <RelatedWrapper>
       <RelatedTitle>相關文章</RelatedTitle>
@@ -55,6 +64,7 @@ export default function AmpHeader({ relateds }) {
           </RelatedItem>
         )
       })}
+      <StyledAmpGptAd section={section} position="E1" />
       <AmpPopIn />
     </RelatedWrapper>
   )

--- a/packages/mirror-media-next/components/amp/amp-related.js
+++ b/packages/mirror-media-next/components/amp/amp-related.js
@@ -32,7 +32,7 @@ const RelatedItem = styled(Link)`
 `
 
 const StyledAmpGptAd = styled(AmpGptAd)`
-  margin-top: 20px;
+  margin: 20px 0;
 `
 
 /**
@@ -46,26 +46,50 @@ const StyledAmpGptAd = styled(AmpGptAd)`
  * @returns {JSX.Element}
  */
 
-export default function AmpHeader({ relateds, section }) {
-  console.log(relateds.length, section)
+export default function AmpRelated({ relateds, section }) {
+  const relatedsBefordAd = relateds.slice(0, 5)
+  const relatedsAfterAd = relateds.slice(5)
 
   return (
     <RelatedWrapper>
       <RelatedTitle>相關文章</RelatedTitle>
-      {relateds.map((relatedItem, index) => {
-        return (
-          <RelatedItem
-            href={`/story/${relatedItem.slug}`}
-            target="_blank"
-            key={index}
-            rel="noreferrer"
-          >
-            {relatedItem.title}
-          </RelatedItem>
-        )
-      })}
-      <StyledAmpGptAd section={section} position="E1" />
-      <AmpPopIn />
+
+      {relatedsBefordAd.map((relatedItem, index) => (
+        <RelatedItem
+          href={`/story/${relatedItem.slug}`}
+          target="_blank"
+          key={index}
+          rel="noreferrer"
+        >
+          {relatedItem.title}
+        </RelatedItem>
+      ))}
+
+      {relateds.length >= 5 && (
+        <>
+          <StyledAmpGptAd section={section} position="E1" />
+          {relatedsAfterAd.map((relatedItem, index) => (
+            <RelatedItem
+              href={`/story/${relatedItem.slug}`}
+              target="_blank"
+              key={index}
+              rel="noreferrer"
+            >
+              {relatedItem.title}
+            </RelatedItem>
+          ))}
+          <AmpPopIn />
+        </>
+      )}
+
+      {relateds.length === 4 && (
+        <>
+          <AmpPopIn />
+          <StyledAmpGptAd section={section} position="E1" />
+        </>
+      )}
+
+      {relateds.length < 4 && <AmpPopIn />}
     </RelatedWrapper>
   )
 }

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -130,7 +130,7 @@ function StoryAmpPage({ postData }) {
             </p>
 
             <AmpMain postData={postData} isMember={isMember} />
-            <AmpRelated relateds={relatedsWithOrdered} />
+            <AmpRelated relateds={relatedsWithOrdered} section={sectionSlot} />
             <Taboola title="你可能也喜歡這些文章" />
 
             <AmpGptAd section={sectionSlot} position="FT" />


### PR DESCRIPTION
- `if relateds.length<4`，不顯示 Amp-GPT-E1 廣告。
- `if relateds.length=4`，置於 Pop-In 廣告之後。
- `if relateds.length>=5`，置於第五則相關文章之後，Pop-In 廣告之前。
