### PR TITLE
feat(mm-next/amp-main): insert GPT ads AT1 and AT2 into amp articles

### DIFF
--- a/packages/mirror-media-next/components/amp/amp-main.js
+++ b/packages/mirror-media-next/components/amp/amp-main.js
@@ -8,6 +8,9 @@ import AmpInfo from './amp-info'
 import ArticleBrief from '../story/shared/brief'
 import DraftRenderBlock from '../story/shared/draft-renderer-block'
 import useSharedUrl from '../../hooks/use-shared-url'
+import AmpGptAd from '../../components/amp/amp-ads/amp-gpt-ad'
+import { copyAndSliceDraftBlock, getBlocksCount } from '../../utils/story'
+import { getAmpGptDataSlotSection } from '../../utils/ad'
 
 const MainWrapper = styled.div`
   margin-top: 24px;
@@ -103,6 +106,10 @@ const AmpContentContainer = styled.section`
   margin-top: 36px;
 `
 
+const StyledAmpGptAd = styled(AmpGptAd)`
+  margin: 32px 0;
+`
+
 /**
  * @typedef {import('../../apollo/fragments/post').Post} PostData
  */
@@ -160,6 +167,9 @@ export default function AmpMain({ postData, isMember }) {
     { extend_byline: extend_byline },
   ]
 
+  const sectionSlot = getAmpGptDataSlotSection(section)
+  const blocksLength = getBlocksCount(content)
+
   return (
     <MainWrapper>
       <AmpInfo
@@ -201,8 +211,35 @@ export default function AmpMain({ postData, isMember }) {
           contentLayout="amp"
         ></ArticleBrief>
       </AmpBriefContainer>
+
       <AmpContentContainer>
-        <DraftRenderBlock rawContentBlock={content} contentLayout="amp" />
+        <DraftRenderBlock
+          rawContentBlock={copyAndSliceDraftBlock(content, 0, 1)}
+          contentLayout="amp"
+        />
+
+        {blocksLength > 1 && (
+          <>
+            <StyledAmpGptAd section={sectionSlot} position="AT1" />
+            <DraftRenderBlock
+              rawContentBlock={copyAndSliceDraftBlock(content, 1, 5)}
+              contentLayout="amp"
+            />
+          </>
+        )}
+
+        {blocksLength > 5 && (
+          <>
+            <StyledAmpGptAd section={sectionSlot} position="AT2" />
+            <DraftRenderBlock
+              rawContentBlock={copyAndSliceDraftBlock(content, 5)}
+              contentLayout="amp"
+            />
+          </>
+        )}
+
+        {/* <DraftRenderBlock rawContentBlock={content} contentLayout="amp" /> */}
+
         {isMember && (
           <Link href={sharedUrl.replace('/amp/', '/')}>
             【 加入鏡週刊會員，觀看全文 】

--- a/packages/mirror-media-next/components/amp/amp-main.js
+++ b/packages/mirror-media-next/components/amp/amp-main.js
@@ -238,8 +238,6 @@ export default function AmpMain({ postData, isMember }) {
           </>
         )}
 
-        {/* <DraftRenderBlock rawContentBlock={content} contentLayout="amp" /> */}
-
         {isMember && (
           <Link href={sharedUrl.replace('/amp/', '/')}>
             【 加入鏡週刊會員，觀看全文 】


### PR DESCRIPTION
Use the `copyAndSliceDraftBlock` utility to divide the content into sections for rendering `AT1` and `AT2` GPT ads. Insert AT1 if `blocksLength` is greater than **1**, and AT2 if `blocksLength` is greater than **5**.