### PR TITLE
feat(mm-next): add className for tracing gtm event

### DIFF
--- a/packages/mirror-media-next/components/section/videohub/subscribe-channel.js
+++ b/packages/mirror-media-next/components/section/videohub/subscribe-channel.js
@@ -63,10 +63,25 @@ export default function SubscribeChannel({ channel }) {
 
   return (
     <Wrapper>
-      <Icon src={channel.icon} alt={channel.name} onClick={onOpenChannel} />
+      <Icon
+        src={channel.icon}
+        alt={channel.name}
+        onClick={onOpenChannel}
+        className={`GTM-video-homepage-subscribe-channel_${channel.title}`}
+      />
       <DetailWrapper>
-        <Title onClick={onOpenChannel}>{channel.title}</Title>
-        <Subscribe onClick={onSubscribeChannel}>訂閱</Subscribe>
+        <Title
+          onClick={onOpenChannel}
+          className={`GTM-video-homepage-subscribe-channel_${channel.title}`}
+        >
+          {channel.title}
+        </Title>
+        <Subscribe
+          onClick={onSubscribeChannel}
+          className={`GTM-video-homepage-subscribe-channel_${channel.title}`}
+        >
+          訂閱
+        </Subscribe>
       </DetailWrapper>
     </Wrapper>
   )

--- a/packages/mirror-media-next/components/section/videohub/video-list.js
+++ b/packages/mirror-media-next/components/section/videohub/video-list.js
@@ -119,13 +119,18 @@ const VideoItemsWrapper = styled.div`
 `
 
 /**
+ * @typedef {import('../../shared/video-list-item').GtmClassName} GtmClassName
+ */
+
+/**
  * @param {Object} props
  * @param {import('../../../type/youtube').YoutubeVideo[]} props.videos
  * @param {string} props.name
  * @param {string} [props.slug]
+ * @param {GtmClassName} [props.gtmClassName]
  * @returns {React.ReactElement}
  */
-export default function VideoList({ videos, name, slug }) {
+export default function VideoList({ videos, name, slug, gtmClassName = '' }) {
   const hasSlug = !!slug
   return (
     <Wrapper hasSlug={hasSlug}>
@@ -141,7 +146,12 @@ export default function VideoList({ videos, name, slug }) {
 
       <VideoItemsWrapper>
         {videos.map((video) => (
-          <VideoListItem key={video.title} video={video} slug={slug} />
+          <VideoListItem
+            key={video.title}
+            video={video}
+            slug={slug}
+            gtmClassName={gtmClassName}
+          />
         ))}
       </VideoItemsWrapper>
     </Wrapper>

--- a/packages/mirror-media-next/components/shared/leading-video-item.js
+++ b/packages/mirror-media-next/components/shared/leading-video-item.js
@@ -218,13 +218,26 @@ const PlaylistTitle = styled.h2`
 `
 
 /**
+ * @typedef {Object} GtmClassName
+ * @property {string} title
+ * @property {import('./youtube-iframe').GtmYoutubeClassName} youtube
+ *
+ */
+
+/**
  * @param {Object} props
  * @param {import('../../type/youtube').YoutubeVideo} props.video
  * @param {string} [props.slug]
  * @param {string} [props.playlistTitle]
+ * @param {GtmClassName} [props.gtmClassName]
  * @returns {React.ReactElement}
  */
-export default function LeadingVideoItem({ video, slug, playlistTitle }) {
+export default function LeadingVideoItem({
+  video,
+  slug,
+  playlistTitle,
+  gtmClassName = { title: '', youtube: '' },
+}) {
   const hasSlug = !!slug
   return (
     <Wrapper hasSlug={hasSlug}>
@@ -232,13 +245,21 @@ export default function LeadingVideoItem({ video, slug, playlistTitle }) {
         <PlaylistTitle categorySlug={slug}>{playlistTitle}</PlaylistTitle>
       )}
       <Youtube hasSlug={hasSlug}>
-        <YoutubeIframe videoId={video.id} />
+        <YoutubeIframe
+          videoId={video.id}
+          gtmClassName={gtmClassName?.youtube}
+        />
         {hasSlug && <CategoryColorbox categorySlug={slug} />}
       </Youtube>
 
       <Title>
-        <a href={`/video/${video.id}`} target="_blank" rel="noreferrer">
-          {video.title}
+        <a
+          href={`/video/${video.id}`}
+          className={gtmClassName?.title}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <span>{video.title}</span>
         </a>
       </Title>
 

--- a/packages/mirror-media-next/components/shared/leading-video.js
+++ b/packages/mirror-media-next/components/shared/leading-video.js
@@ -66,18 +66,33 @@ const Title = styled.h2`
 `
 
 /**
+ * @typedef {import('./leading-video-item').GtmClassName} GtmClassName
+ */
+
+/**
  * @param {Object} props
  * @param {import('../../type/youtube').YoutubeVideo} props.video
  * @param {string} props.title
  * @param {string} [props.slug]
+ * @param {GtmClassName} [props.gtmClassName]
  * @returns {React.ReactElement}
  */
-export default function LeadingVideo({ video, title, slug }) {
+export default function LeadingVideo({
+  video,
+  title,
+  slug,
+  gtmClassName = { title: '', youtube: '' },
+}) {
   return (
     <Wrapper>
       {title && <Title categorySlug={slug}>{title}</Title>}
       {video && (
-        <LeadingVideoItem video={video} slug={slug} playlistTitle={title} />
+        <LeadingVideoItem
+          video={video}
+          slug={slug}
+          playlistTitle={title}
+          gtmClassName={gtmClassName}
+        />
       )}
       <YoutubePolicy />
     </Wrapper>

--- a/packages/mirror-media-next/components/shared/video-list-item.js
+++ b/packages/mirror-media-next/components/shared/video-list-item.js
@@ -78,17 +78,27 @@ const Title = styled.p`
 `
 
 /**
+ * @typedef {string} GtmClassName
+ */
+
+/**
  * @param {Object} props
  * @param {import('../../type/youtube').YoutubeVideo} props.video
  * @param {string} [props.slug]
+ * @param {GtmClassName} [props.gtmClassName]
  * @returns {React.ReactElement}
  */
-export default function VideoListItem({ video, slug }) {
+export default function VideoListItem({ video, slug, gtmClassName = '' }) {
   const hasSlug = !!slug
   return (
     <Wrapper>
       {hasSlug && <CategoryColorbox categorySlug={slug} />}
-      <a href={`/video/${video.id}`} target="_blank" rel="noreferrer">
+      <a
+        href={`/video/${video.id}`}
+        target="_blank"
+        rel="noreferrer"
+        className={gtmClassName}
+      >
         <ImageWrapper>
           <Image
             images={{ original: video.thumbnail }}
@@ -99,7 +109,12 @@ export default function VideoListItem({ video, slug }) {
         </ImageWrapper>
       </a>
       <Title>
-        <a href={`/video/${video.id}`} target="_blank" rel="noreferrer">
+        <a
+          href={`/video/${video.id}`}
+          target="_blank"
+          rel="noreferrer"
+          className={gtmClassName}
+        >
           {video.title}
         </a>
       </Title>

--- a/packages/mirror-media-next/components/shared/youtube-iframe.js
+++ b/packages/mirror-media-next/components/shared/youtube-iframe.js
@@ -17,20 +17,28 @@ const Iframe = styled.iframe`
 `
 
 /**
- *
+ * @typedef {string} GtmYoutubeClassName
+ */
+
+/**
+ * Why we add parameter `enablejsapi` in youtube iframe attribute `src`?
+ * Because we need to track gtm event when playing youtube video, the only way to achieve this is to add param.
+ * see [Youtube API](https://developers.google.com/youtube/player_parameters?hl=zh-tw#enablejsapi) to get more info.
  * @param {Object} props
  * @param {string} props.videoId
+ * @param {GtmYoutubeClassName} [props.gtmClassName]
  * @returns
  */
-export default function YoutubeIframe({ videoId }) {
+export default function YoutubeIframe({ videoId, gtmClassName = '' }) {
   return (
     <IframeWrapper>
       <Iframe
-        src={`https://www.youtube.com/embed/${videoId}`}
+        src={`https://www.youtube.com/embed/${videoId}?enablejsapi=1`}
         loading="lazy"
         frameBorder="0"
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
         allowFullScreen
+        className={gtmClassName}
       />
     </IframeWrapper>
   )

--- a/packages/mirror-media-next/components/story/normal/article-info.js
+++ b/packages/mirror-media-next/components/story/normal/article-info.js
@@ -150,8 +150,8 @@ export default function ArticleInfo({
           <ButtonCopyLink />
         </SocialMedia>
         <DonateSubscribeWrapper>
-          <DonateLink />
-          <SubscribeLink className="subscribe-btn" />
+          <DonateLink className="GTM-donate-link-top" />
+          <SubscribeLink className="subscribe-btn GTM-subscribe-link-top" />
         </DonateSubscribeWrapper>
       </SocialMediaAndDonateLink>
       <StyledTags tags={tags} />

--- a/packages/mirror-media-next/components/story/normal/aside-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/aside-article-list.js
@@ -1,3 +1,5 @@
+//REMINDER: DO NOT REMOVE className which has prefix `GTM-`, since it is used for collecting data of Google Analytics event.
+
 import { Fragment } from 'react'
 import Link from 'next/link'
 import styled from 'styled-components'
@@ -289,7 +291,10 @@ export default function AsideArticleList({
 
   const heading = listType === 'latestNews' ? '最新文章' : '熱門文章'
   const headingColor = listType === 'latestNews' ? 'gray' : 'darkBlue'
-
+  const gtmClassName =
+    listType === 'latestNews'
+      ? 'GTM-story-latest-list'
+      : 'GTM-story-popular-list'
   useEffect(() => {
     let callback = (entries, observer) => {
       entries.forEach((entry) => {
@@ -338,7 +343,7 @@ export default function AsideArticleList({
               <Link
                 href={articleHref}
                 target="_blank"
-                className="article-image"
+                className={`article-image ${gtmClassName}`}
               >
                 <Image
                   images={item?.heroImage?.resized}
@@ -351,7 +356,11 @@ export default function AsideArticleList({
 
               <FigureCaption>
                 <Label sectionTitle={sectionTitle}>{sectionName}</Label>
-                <Link href={articleHref} target="_blank">
+                <Link
+                  href={articleHref}
+                  target="_blank"
+                  className={gtmClassName}
+                >
                   <Title color={headingColor}>{item.title}</Title>
                 </Link>
               </FigureCaption>

--- a/packages/mirror-media-next/components/story/normal/related-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/related-article-list.js
@@ -1,4 +1,4 @@
-//TODO: insert real Advertisement, not just fake
+//REMINDER: DO NOT REMOVE className which has prefix `GTM-`, since it is used for collecting data of Google Analytics event.
 
 import styled from 'styled-components'
 import Image from '@readr-media/react-image'
@@ -174,7 +174,7 @@ export default function RelatedArticleList({
             <Link
               href={`/story/${related.slug}`}
               target="_blank"
-              className="article-image"
+              className="article-image GTM-story-related-list"
             >
               <Image
                 images={related.heroImage?.resized}
@@ -190,7 +190,11 @@ export default function RelatedArticleList({
             </Link>
 
             <figcaption className="article-title">
-              <Link href={`/story/${related.slug}`} target="_blank">
+              <Link
+                href={`/story/${related.slug}`}
+                className="GTM-story-related-list"
+                target="_blank"
+              >
                 {related.title}
               </Link>
             </figcaption>

--- a/packages/mirror-media-next/components/story/photography/photography-header.js
+++ b/packages/mirror-media-next/components/story/photography/photography-header.js
@@ -127,8 +127,8 @@ export default function Header() {
             height={32}
           />
         </a>
-        <DonateLink className="donate-btn-pc" />
-        <SubscribeLink className="subscribe-btn" />
+        <DonateLink className="donate-btn-pc GTM-donate-link-top" />
+        <SubscribeLink className="subscribe-btn GTM-subscribe-link-top" />
         {/* <PhotosIndexButton>
           <Image
             src="/images/photos-index-icon.svg"

--- a/packages/mirror-media-next/components/story/shared/button-copy-link.js
+++ b/packages/mirror-media-next/components/story/shared/button-copy-link.js
@@ -1,3 +1,5 @@
+//REMINDER: DO NOT REMOVE className which has prefix `GTM-`, since it is used for collecting data of Google Analytics event.
+
 import { useState } from 'react'
 
 import styled from 'styled-components'
@@ -77,6 +79,7 @@ export default function ButtonCopyLink({ width = 35, height = 35 }) {
           src={'/images/link-logo.svg'}
           width={width}
           height={height}
+          className="GTM-share-link"
           alt="copy link button"
         ></Image>
       </ClickButton>

--- a/packages/mirror-media-next/components/story/shared/button-social-network-share.js
+++ b/packages/mirror-media-next/components/story/shared/button-social-network-share.js
@@ -1,3 +1,5 @@
+//REMINDER: DO NOT REMOVE className which has prefix `GTM-`, since it is used for collecting data of Google Analytics event.
+
 import Link from 'next/link'
 import Image from 'next/image'
 import useSharedUrl from '../../../hooks/use-shared-url'
@@ -19,7 +21,6 @@ export default function ButtonSocialNetworkShare({
   url = '',
 }) {
   const sharedUrl = useSharedUrl(url)
-
   const getSocialNetWorkInfo = (type) => {
     switch (type) {
       case 'facebook':
@@ -27,12 +28,14 @@ export default function ButtonSocialNetworkShare({
           imageSrc: '/images/fb-logo.svg',
           imageAlt: 'facebook-share',
           link: `${FACEBOOK_SHARED_URL}${sharedUrl}`,
+          gtmClassName: 'GTM-share-facebook',
         }
       case 'line':
         return {
           imageSrc: '/images/line-logo.svg',
           imageAlt: 'line-share',
           link: `${LINE_SHARED_URL}${sharedUrl}`,
+          gtmClassName: 'GTM-share-line',
         }
 
       default:
@@ -40,12 +43,17 @@ export default function ButtonSocialNetworkShare({
           imageSrc: '/images/line-logo.svg',
           imageAlt: 'line-share',
           link: `${FACEBOOK_SHARED_URL}${sharedUrl}`,
+          gtmClassName: 'GTM-share-line',
         }
     }
   }
   const imageInfo = getSocialNetWorkInfo(type)
   return (
-    <Link href={imageInfo.link} target="_blank">
+    <Link
+      href={imageInfo.link}
+      target="_blank"
+      className={imageInfo.gtmClassName}
+    >
       <Image
         src={imageInfo.imageSrc}
         width={width}

--- a/packages/mirror-media-next/components/story/shared/magazine-invite-banner.js
+++ b/packages/mirror-media-next/components/story/shared/magazine-invite-banner.js
@@ -45,7 +45,7 @@ export default function MagazineInviteBanner({ className }) {
   return (
     <Wrapper className={className}>
       <p>月費、年費會員免費線上閱讀動態雜誌</p>
-      <Link href="/magazine" target="_blank">
+      <Link href="/magazine" className="GTM-story-magazine-box" target="_blank">
         線上閱讀
       </Link>
     </Wrapper>

--- a/packages/mirror-media-next/components/story/shared/support-mirrormedia-banner.js
+++ b/packages/mirror-media-next/components/story/shared/support-mirrormedia-banner.js
@@ -87,11 +87,11 @@ export default function SupportMirrorMediaBanner({ className }) {
       <InnerWrapper>
         <InnerBox>
           <p className="desc">小心意大意義，小額贊助鏡週刊！</p>
-          <DonateLink className="banner-button" />
+          <DonateLink className="banner-button GTM-donate-link-bottom" />
         </InnerBox>
         <InnerBox>
           <p className="desc">每月 $49 元全站看到飽，暢享無廣告閱讀體驗</p>
-          <SubscribeLink className="banner-button" />
+          <SubscribeLink className="banner-button GTM-subscribe-link-bottom" />
         </InnerBox>
       </InnerWrapper>
     </Container>

--- a/packages/mirror-media-next/components/story/shared/support-single-article-banner.js
+++ b/packages/mirror-media-next/components/story/shared/support-single-article-banner.js
@@ -61,12 +61,12 @@ const Container = styled.div`
  * @param {string} [props.className]
  * @returns {JSX.Element}
  */
-export default function SupportMirrorMediaBanner({ className }) {
+export default function SupportSingleArticleBanner({ className }) {
   return (
     <Container className={className}>
       <p className="title">小心意大意義，小額贊助鏡週刊！</p>
       {/* <p className="desc">目前已有 123,456 人贊助本文</p> */}
-      <DonateLink className="banner-button" />
+      <DonateLink className="banner-button GTM-donate-link-bottom" />
     </Container>
   )
 }

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -223,8 +223,8 @@ export default function StoryWideStyle({ postData, postContent }) {
               <StyledDate timeData={updatedAt} timeType="updatedDate" />
             </DateWrapper>
             <DonateSubscribeWrapper>
-              <DonateLink />
-              <SubscribeLink className="subscribe-btn" />
+              <DonateLink className="GTM-donate-link-top" />
+              <SubscribeLink className="subscribe-btn GTM-subscribe-link-top" />
             </DonateSubscribeWrapper>
             <section className="content">
               <DraftRenderBlock rawContentBlock={brief} contentLayout="wide" />

--- a/packages/mirror-media-next/components/video/video-list.js
+++ b/packages/mirror-media-next/components/video/video-list.js
@@ -67,9 +67,10 @@ const StyledGPTAd_R1 = styled(GPTAd)`
 /**
  * @param {Object} props
  * @param {import('../../type/youtube').YoutubeVideo[]} props.videos
+ * @param {string} [props.gtmClassName]
  * @returns {React.ReactElement}
  */
-export default function VideoList({ videos }) {
+export default function VideoList({ videos, gtmClassName = '' }) {
   const shouldShowAd = useDisplayAd()
 
   return (
@@ -79,7 +80,11 @@ export default function VideoList({ videos }) {
       <Title>最新影音</Title>
       <Videos>
         {videos.map((video) => (
-          <VideoListItem key={video.id} video={video} />
+          <VideoListItem
+            key={video.id}
+            video={video}
+            gtmClassName={gtmClassName}
+          />
         ))}
       </Videos>
     </Wrapper>

--- a/packages/mirror-media-next/components/video/youtube-article.js
+++ b/packages/mirror-media-next/components/video/youtube-article.js
@@ -1,9 +1,7 @@
 import styled from 'styled-components'
 import { transformTimeDataIntoSlashFormat } from '../../utils'
-import { useShareFbUrl } from '../../hooks/useShareFbUrl'
-import { useShareLineUrl } from '../../hooks/useShareLineUrl'
 import ButtonCopyLink from '../story/shared/button-copy-link'
-
+import ButtonSocialNetworkShare from '../story/shared/button-social-network-share'
 const Wrapper = styled.div`
   padding: 0 16px;
   ${({ theme }) => theme.breakpoint.md} {
@@ -62,9 +60,6 @@ const ShareIcons = styled.div`
     margin-top: 28px;
   }
 `
-const Icon = styled.img`
-  cursor: pointer;
-`
 
 /**
  * @param {Object} props
@@ -72,8 +67,6 @@ const Icon = styled.img`
  * @returns
  */
 export default function YoutubeArticle({ video }) {
-  const shareFbUrl = useShareFbUrl()
-  const shareLineUrl = useShareLineUrl()
   const description = video.description
     ?.replace(/(https?:\/\/[^\s]+)/g, '<a href="$1">$1</a>')
     .replace(/↵|\n/g, '<br>')
@@ -89,12 +82,8 @@ export default function YoutubeArticle({ video }) {
         <Description dangerouslySetInnerHTML={{ __html: description }} />
       )}
       <ShareIcons>
-        <a href={shareFbUrl} target="_blank" rel="noreferrer">
-          <Icon src="/images/video-share-fb.svg" alt="share to facebook" />
-        </a>
-        <a href={shareLineUrl} target="_blank" rel="noreferrer">
-          <Icon src="/images/video-share-line.svg" alt="share to facebook" />
-        </a>
+        <ButtonSocialNetworkShare width={40} height={40} type="facebook" />
+        <ButtonSocialNetworkShare width={40} height={40} type="line" />
         <ButtonCopyLink width={40} height={40} />
       </ShareIcons>
     </Wrapper>

--- a/packages/mirror-media-next/pages/section/videohub.js
+++ b/packages/mirror-media-next/pages/section/videohub.js
@@ -149,7 +149,14 @@ export default function SectionVideohub({
       <Wrapper>
         {shouldShowAd && <StyledGPTAd_PC_HD pageKey="videohub" adKey="PC_HD" />}
         {hasHVCVideo && (
-          <LeadingVideo video={highestViewCountVideo} title="熱門影片" />
+          <LeadingVideo
+            video={highestViewCountVideo}
+            title="熱門影片"
+            gtmClassName={{
+              title: 'GTM-video-homepage-popular-item',
+              youtube: 'GTM-video-homepage-popular-yt-play',
+            }}
+          />
         )}
         {shouldShowAd && <StyledGPTAd_MB_HD pageKey="videohub" adKey="MB_HD" />}
         {hasLatestVideo && <VideoList videos={latestVideos} name="最新影片" />}

--- a/packages/mirror-media-next/pages/section/videohub.js
+++ b/packages/mirror-media-next/pages/section/videohub.js
@@ -159,7 +159,13 @@ export default function SectionVideohub({
           />
         )}
         {shouldShowAd && <StyledGPTAd_MB_HD pageKey="videohub" adKey="MB_HD" />}
-        {hasLatestVideo && <VideoList videos={latestVideos} name="最新影片" />}
+        {hasLatestVideo && (
+          <VideoList
+            videos={latestVideos}
+            name="最新影片"
+            gtmClassName="GTM-video-homepage-latest-list"
+          />
+        )}
         <SubscribeChannels />
         {shouldShowAd && <StyledGPTAd_MB_FT pageKey="videohub" adKey="MB_FT" />}
         {playlistsVideos.map((playlistsVideo) => (

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -139,14 +139,19 @@ export default function Video({ video, latestVideos, headerData }) {
       footer={{ type: 'default' }}
     >
       <Wrapper>
-        <YoutubeIframe videoId={video.id} />
+        <YoutubeIframe videoId={video.id} gtmClassName="GTM-video-yt-play" />
 
         {shouldShowAd && <StyledGPTAd_HD pageKey="videohub" adKey="HD" />}
 
         <ContentWrapper>
           <YoutubeArticle video={video} />
           {shouldShowAd && <StyledGPTAd_E1 pageKey="videohub" adKey="E1" />}
-          {latestVideos.length > 0 && <VideoList videos={latestVideos} />}
+          {latestVideos.length > 0 && (
+            <VideoList
+              videos={latestVideos}
+              gtmClassName="GTM-video-latest-list"
+            />
+          )}
         </ContentWrapper>
 
         <YoutubePolicy />

--- a/packages/mirror-media-next/pages/video_category/[slug].js
+++ b/packages/mirror-media-next/pages/video_category/[slug].js
@@ -111,6 +111,10 @@ export default function VideoCategory({
           video={firstVideo}
           title={categoryName}
           slug={category.slug}
+          gtmClassName={{
+            title: 'GTM-leading-video-item',
+            youtube: 'GTM-leading-video-yt-play',
+          }}
         />
         {shouldShowAd && <StyledGPTAd_MB_HD pageKey="videohub" adKey="MB_HD" />}
         {hasMoreThanOneVideo && (


### PR DESCRIPTION
## Notable Change
1. 於多個頁面及元件中，新增前綴為`GTM-`的className，用於蒐集GTM事件
2. 詳細的gtm className，除可參考程式碼外，亦可參考[文件](https://paper.dropbox.com/doc/GA3-GA4-GTM--B8uWixlKVkEyy9ckKHi62606Ag-snTcSrWsAXzEcbCLG0hkw)。