### PR TITLE
refactor(gptAd): change adKeyST to MB_ST that will hide before scrolled

### DIFF
--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -111,7 +111,7 @@ export default function Author({ postsCount, posts, author, headerData }) {
           authorId={author.id}
           renderPageSize={RENDER_PAGE_SIZE}
         />
-        {shouldShowAd && <StickyGPTAd pageKey="other" adKey="ST" />}
+        {shouldShowAd && <StickyGPTAd pageKey="other" adKey="MB_ST" />}
       </AuthorContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -235,7 +235,10 @@ export default function Category({
         />
 
         {shouldShowAd && isNotWineCategory ? (
-          <StickyGPTAd pageKey={getSectionGPTPageKey(sectionSlug)} adKey="ST" />
+          <StickyGPTAd
+            pageKey={getSectionGPTPageKey(sectionSlug)}
+            adKey="MB_ST"
+          />
         ) : null}
         <WineWarning categories={[category]} />
       </CategoryContainer>

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -144,7 +144,7 @@ export default function ExternalPartner({
         {shouldShowAd && (
           <StickyGPTAd
             pageKey={getPageKeyByPartnerSlug(partner.slug)}
-            adKey="ST"
+            adKey="MB_ST"
           />
         )}
       </PartnerContainer>

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -120,7 +120,7 @@ export default function WarmLife({ warmLifeData, headerData }) {
           renderPageSize={RENDER_PAGE_SIZE}
         />
         {shouldShowAd && (
-          <StickyGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} adKey="ST" />
+          <StickyGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} adKey="MB_ST" />
         )}
       </WarmLifeContainer>
     </Layout>

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -139,7 +139,7 @@ export default function Section({ postsCount, posts, section, headerData }) {
         {shouldShowAd && (
           <StickyGPTAd
             pageKey={getSectionGPTPageKey(section.slug)}
-            adKey="ST"
+            adKey="MB_ST"
           />
         )}
       </SectionContainer>

--- a/packages/mirror-media-next/pages/section/topic.js
+++ b/packages/mirror-media-next/pages/section/topic.js
@@ -114,7 +114,7 @@ export default function Topics({ topics, topicsCount, headerData }) {
           topics={topics}
           renderPageSize={RENDER_PAGE_SIZE}
         />
-        {shouldShowAd && <StickyGPTAd pageKey="other" adKey="ST" />}
+        {shouldShowAd && <StickyGPTAd pageKey="other" adKey="MB_ST" />}
       </TopicsContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -136,7 +136,7 @@ export default function Tag({ postsCount, posts, tag, headerData }) {
           renderPageSize={RENDER_PAGE_SIZE}
         />
 
-        {shouldShowAd && <StickyGPTAd pageKey="other" adKey="ST" />}
+        {shouldShowAd && <StickyGPTAd pageKey="other" adKey="MB_ST" />}
       </TagContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -159,7 +159,7 @@ export default function Video({ video, latestVideos, headerData }) {
         {shouldShowAd && (
           <>
             <StyledGPTAd_FT pageKey="videohub" adKey="FT" />
-            <StickyGPTAd pageKey="videohub" adKey="ST" />
+            <StickyGPTAd pageKey="videohub" adKey="MB_ST" />
           </>
         )}
       </Wrapper>


### PR DESCRIPTION
### 描述
需求為「只要有 MB_ST」出現的地方都要使用者滑一下才出現。
發現目前廣告欄位並沒有 PC_ST，也就是說所有的 ST 最終都會被 device 轉變成 MB_ST。加上判斷標準是 adKey === 'MB_ST'，不如統一讓相關廣告的 adKey 都變成 `MB_ST`。