### PR TITLE
feat(mm-next/amp): not to show AMP GPT ST Ad if the category contains wine

### DIFF
--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -154,7 +154,8 @@ function StoryAmpPage({ postData }) {
               <AmpGptAd section={sectionSlot} position="FT" />
 
               <AmpFooter />
-              <AmpGptStickyAd />
+              {/* If there are wine categories (length greater than 0), AmpGptStickyAd will not be shown. */}
+              {categoryOfWineSlug.length === 0 && <AmpGptStickyAd />}
             </section>
             <AdultOnlyWarning isAdult={isAdult} />
             <WineWarning categories={categories} />


### PR DESCRIPTION
- `<AmpGptStickyAd />` will only be rendered if the length of the `categoryOfWineSlug` is 0. If there are wine categories (length greater than 0), the component will not be shown.