### PR TITLE
fix(mm-next): unable select subtitle on story page

### DIFF
--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -84,6 +84,7 @@ const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
  * @typedef {Object} PostContent
  * @property {'fullContent' | 'trimmedContent'} type
  * @property {Pick<PostData,'content'>['content']} data
+ * @property {boolean} isLoaded
  */
 
 const sectionColor = css`

--- a/packages/mirror-media-next/components/story/photography/index.js
+++ b/packages/mirror-media-next/components/story/photography/index.js
@@ -133,6 +133,7 @@ const ArrowButton = styled.button`
  * @typedef {Object} PostContent
  * @property {'fullContent' | 'trimmedContent'} type
  * @property {Pick<PostData,'content'>['content']} data
+ * @property {boolean} isLoaded
  */
 
 /**

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -34,6 +34,7 @@ const { getContentBlocksH2H3 } = MirrorMedia
  * @typedef {Object} PostContent
  * @property {'fullContent' | 'trimmedContent'} type
  * @property {Pick<PostData,'content'>['content']} data
+ * @property {boolean} isLoaded
  */
 
 /**

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -29,6 +29,7 @@ import Aside from '../shared/aside'
  * @typedef {Object} PostContent
  * @property {'fullContent' | 'trimmedContent'} type
  * @property {Pick<PostData,'content'>['content']} data
+ * @property {boolean} isLoaded
  */
 
 /**


### PR DESCRIPTION
## 問題描述
在會員已登入且有權限閱讀會員文章的情況下，文章頁側欄索引會無法正確active的UI。
經過測試後，發現是元件`<NavSubtitleNavigator>`的[useEffect](https://github.com/mirror-media/Adam/blob/dev/packages/mirror-media-next/components/story/shared/nav-subtitle-navigator.js#L231-L305)無法正確透過`document.querySelector`，取得該頁面的h2與h3。

## 發生情境
錯誤只會發生在「文章類型為會員文章頁，會員已登入且有權限閱讀會員文章的情況」。
之所以只在該情況發生，是因為在文章頁server-side時，會同時抓取`trimmedContent`（截斷的內文）與`content`（完整內文）兩個欄位的資料，而如果是會員文章的話，這時拿到的`content`會是null。直到client-side時，才會取得會員的`accessToken`，並再次抓取`content`。而如果抓取成功，會透過useEffect更新state `postContent`（該state會用各個版型的內文draft-renderer）。

而在各個版型中，會以[`postContent`計算變數`h2AndH3Block`](https://github.com/mirror-media/Adam/blob/dev/packages/mirror-media-next/components/story/premium/index.js#L238)，並將`h2AndH3Block`傳入元件`<NavSubtitleNavigator>`，並執行該元件的useEffect，以`h2AndH3Block`的值透過[document.querySelector](https://github.com/mirror-media/Adam/blob/dev/packages/mirror-media-next/components/story/shared/nav-subtitle-navigator.js#L234-L238)取得h2與H3的html tag的位置。

而問題出在`h2AndH3Block`會順利更新，但是document.querySelector卻無法選到應有的html tag。

以這篇為例http://localhost:3000/story/20221214edi004 ：
一開始的`h2AndH3Block`會是兩個物件的陣列
```
[
    {
        "key": "ffn66",
        "text": "這是第一個h2",
        "type": "header-two"
    },
    {
        "key": "26oej",
        "text": "這是第一個h2底下的h3",
        "type": "header-three"
    }
]
```
而當postContent更新後，`h2AndH3Block`會變成含有所有h2與h3的陣列
```
[
    {
        "key": "ffn66",
        "text": "這是第一個h2",
        "type": "header-two"
    },
    {
        "key": "26oej",
        "text": "這是第一個h2底下的h3",
        "type": "header-three"
    },
    {
        "key": "abgbe",
        "text": "這是第一個h2底下的第二個h3",
        "type": "header-three"
    },
    {
        "key": "cu1li",
        "text": "這是第二個h2",
        "type": "header-two"
    },
    {
        "key": "5oeb7",
        "text": "這是第二個h2底下的第一個h3",
        "type": "header-three"
    },
    {
        "key": "fqamo",
        "text": "這是第二個h2底下的第二個h3",
        "type": "header-three"
    },
    {
        "key": "cuqvj",
        "text": "這是第二個h2底下的第三個h3",
        "type": "header-three"
    }
]
```
但是在元件<NavSubtitleNavigator>的useEffect中，卻只能透過document.querySelector選到一開始的h2跟h3（只有兩個物件的那個），而無法選到所有h2跟h3的，也就是：
`[h2, h3, null, null, null, null, null, null, null]`


## 解法
目前是直接於story頁的useEffect中，透過[set state強制額外render一次](https://github.com/mirror-media/Adam/pull/455/commits/942e41c2d6bf6a2a657451281b53f40143733b0a#diff-c4571d1420434b7f40e35c4a05ba57718b59d9f06465082815cf6fcc0da4e47aR154-R169)，但這樣有兩個問題：
1. 會增加re-render次數
2. 其實算是我誤打誤撞解開的，不太知道確切的原因，以及跟react哪些機制有關。


