### PR TITLE
refactor: set img of list-articles-item and related-article rwd 500px

### DIFF
--- a/packages/mirror-media-next/components/story/normal/related-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/related-article-list.js
@@ -180,9 +180,9 @@ export default function RelatedArticleList({
                 images={related.heroImage?.resized}
                 alt={related.title}
                 rwd={{
-                  mobile: '280px',
-                  tablet: '87px',
-                  laptop: '135px',
+                  mobile: '500px',
+                  tablet: '500px',
+                  laptop: '500px',
                 }}
                 defaultImage={'/images/default-og-img.png'}
                 loadingImage={'/images/loading.gif'}

--- a/packages/mirror-media-next/components/story/shared/related-article-list.js
+++ b/packages/mirror-media-next/components/story/shared/related-article-list.js
@@ -157,9 +157,9 @@ export default function RelatedArticleList({ relateds }) {
                 images={related.heroImage?.resized}
                 alt={related.title}
                 rwd={{
-                  mobile: '280px',
-                  tablet: '87px',
-                  laptop: '276px',
+                  mobile: '500px',
+                  tablet: '500px',
+                  laptop: '500px',
                 }}
                 width={'100%'}
                 height={'100%'}

--- a/packages/mirror-media-next/components/topic/list/list-articles-item.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles-item.js
@@ -141,7 +141,7 @@ export default function ListArticlesItem({ item }) {
           alt={item.title}
           loadingImage="/images/loading.gif"
           defaultImage="/images/default-og-img.png"
-          rwd={{ tablet: '500px', desktop: '500px' }}
+          rwd={{ mobile: '500px', tablet: '500px', desktop: '500px' }}
         />
         {itemSection && (
           <ItemSection sectionName={itemSection?.slug}>

--- a/packages/mirror-media-next/components/topic/list/list-articles-item.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles-item.js
@@ -141,7 +141,7 @@ export default function ListArticlesItem({ item }) {
           alt={item.title}
           loadingImage="/images/loading.gif"
           defaultImage="/images/default-og-img.png"
-          rwd={{ tablet: '320px', desktop: '220px' }}
+          rwd={{ tablet: '500px', desktop: '500px' }}
         />
         {itemSection && (
           <ItemSection sectionName={itemSection?.slug}>


### PR DESCRIPTION
### 參考卡片
- [debug topic 文章卡片圖片為糊的](https://app.asana.com/0/1205254559800623/1205254407716913/f)
- [延伸閱讀圖片為糊的（改抓w800）](https://app.asana.com/0/1205254559800623/1205254407716904/f)

### 原因和解法
目前不知為何 480w 的圖片只有 150px，這部分已通知 PM 等後端處理。
暫時性解法為直接跳過 480w 的，將 rwd 設定為 500px，拿取 800w 圖片。