### PR TITLE
fix(mm-next): modify `category` & `video_category` page error handling

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/category.js
+++ b/packages/mirror-media-next/apollo/fragments/category.js
@@ -7,6 +7,7 @@ import { section } from './section'
  * @property {string} name
  * @property {string} slug
  * @property {boolean} isMemberOnly
+ * @property {"active" | "inactive"} state
  * @property {import('./section').Section[]} sections it's singular but wrongly named as plural
  */
 
@@ -15,15 +16,17 @@ export const category = gql`
     id
     name
     slug
+    state
   }
 `
 
-export const categroyWithSection = gql`
+export const categoryWithSection = gql`
   ${section}
-  fragment categroyWithSection on Category {
+  fragment categoryWithSection on Category {
     id
     name
     slug
+    state
     isMemberOnly
     sections {
       ...section

--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -32,7 +32,7 @@ export const listingPost = gql`
     sections {
       ...section
     }
-    categories {
+    categories(where: { state: { equals: "active" } }) {
       ...category
     }
     heroImage {
@@ -124,7 +124,7 @@ export const asideListingPost = gql`
  * @property {boolean} isAdult - whether this post only adults can read
  * @property {Section[] | null } sections - which sections does this post belong to
  * @property {Section[] | null} sectionsInInputOrder - sections with adjusted order
- * @property {Pick<Category, 'id' | 'name'  | 'slug'>[] } categories - which categories does this post belong to
+ * @property {Pick<Category, 'id' | 'name'  | 'slug' | 'state'>[] } categories - which categories does this post belong to
  * @property {Contact[] | null} writers -  the field called '作者' in cms
  * @property {Contact[] | null} writersInInputOrder - writers with adjusted order
  * @property {Contact[] } photographers - the field called '攝影' in cms
@@ -173,7 +173,7 @@ export const post = gql`
     sectionsInInputOrder {
       ...section
     }
-    categories {
+    categories(where: { state: { equals: "active" } }) {
       ...category
     }
 

--- a/packages/mirror-media-next/apollo/fragments/section.js
+++ b/packages/mirror-media-next/apollo/fragments/section.js
@@ -29,7 +29,7 @@ export const sectionWithCategory = gql`
     id
     name
     slug
-    categories {
+    categories(where: { state: { equals: "active" } }) {
       name
       slug
     }

--- a/packages/mirror-media-next/apollo/query/categroies.js
+++ b/packages/mirror-media-next/apollo/query/categroies.js
@@ -4,7 +4,7 @@ import { category, categoryWithSection } from '../fragments/category'
 const fetchCategorySections = gql`
   ${categoryWithSection}
   query ($categorySlug: String) {
-    category(where: { slug: $categorySlug }) {
+    category(where: { slug: $categorySlug, state: { equals: "active" } }) {
       ...categoryWithSection
     }
   }
@@ -13,7 +13,7 @@ const fetchCategorySections = gql`
 const fetchCategory = gql`
   ${category}
   query ($categorySlug: String) {
-    category(where: { slug: $categorySlug }) {
+    category(where: { slug: $categorySlug, state: { equals: "active" } }) {
       ...category
     }
   }

--- a/packages/mirror-media-next/apollo/query/categroies.js
+++ b/packages/mirror-media-next/apollo/query/categroies.js
@@ -1,11 +1,11 @@
 import { gql } from '@apollo/client'
-import { category, categroyWithSection } from '../fragments/category'
+import { category, categoryWithSection } from '../fragments/category'
 
 const fetchCategorySections = gql`
-  ${categroyWithSection}
+  ${categoryWithSection}
   query ($categorySlug: String) {
     category(where: { slug: $categorySlug }) {
-      ...categroyWithSection
+      ...categoryWithSection
     }
   }
 `

--- a/packages/mirror-media-next/apollo/query/categroies.js
+++ b/packages/mirror-media-next/apollo/query/categroies.js
@@ -4,7 +4,7 @@ import { category, categoryWithSection } from '../fragments/category'
 const fetchCategorySections = gql`
   ${categoryWithSection}
   query ($categorySlug: String) {
-    category(where: { slug: $categorySlug, state: { equals: "active" } }) {
+    category(where: { slug: $categorySlug }) {
       ...categoryWithSection
     }
   }
@@ -13,7 +13,7 @@ const fetchCategorySections = gql`
 const fetchCategory = gql`
   ${category}
   query ($categorySlug: String) {
-    category(where: { slug: $categorySlug, state: { equals: "active" } }) {
+    category(where: { slug: $categorySlug }) {
       ...category
     }
   }

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -277,6 +277,7 @@ export async function getServerSideProps({ query, req, res }) {
     sections: [],
     slug: categorySlug,
     isMemberOnly: false,
+    state: 'inactive',
   }
   try {
     const { data } = await fetchCategoryByCategorySlug(categorySlug)
@@ -308,6 +309,18 @@ export async function getServerSideProps({ query, req, res }) {
         ...globalLogFields,
       })
     )
+  }
+
+  // handle category state, if `inactive` -> redirect to 404
+  if (category.state === 'inactive') {
+    console.log(
+      JSON.stringify({
+        severity: 'WARNING',
+        message: `categorySlug '${categorySlug}' is inactive, redirect to 404`,
+        globalLogFields,
+      })
+    )
+    return { notFound: true }
   }
 
   const isPremium = category.isMemberOnly

--- a/packages/mirror-media-next/pages/video_category/[slug].js
+++ b/packages/mirror-media-next/pages/video_category/[slug].js
@@ -93,7 +93,6 @@ export default function VideoCategory({
   headerData,
   category,
 }) {
-  console.log('category', category)
   const hasMoreThanOneVideo = videos.length > 1
   const firstVideo = videos[0]
   const remainingVideos = videos.slice(1)


### PR DESCRIPTION
## 需求說明
- `category` 列表頁：新增對於 `state` 的判斷，如 `state` 為 `inactive`，頁面導向 404。
- `video_category` 列表頁：新增對於 `state` 的判斷，如 `state` 為 `inactive`，頁面導向 404。

## Notable Changes
- 修改 `/apollo/fragments/category`： 新增 `state` property。[commits：d6334c](https://github.com/mirror-media/Adam/pull/495/commits/d6334cb6f4b4b62ee35bc5cd298b2a46f34f84a2)
- 修改 `/fragments` 和 `/query` 中對於 category state 為 `active` 的篩選條件判定。 [commits：3b353b0](3b353b0d7610bf9d8d32e05fa57dfea6ca136f05)
- 調整 `category` 、`video_category` 頁面 error handling：新增 category 為 `inactive` 導向 404 判斷。

<img width="768" alt="截圖 2023-08-23 下午7 38 30" src="https://github.com/mirror-media/Adam/assets/104489150/53a9ddff-55cd-4584-ab92-798e2e789469">
