### PR TITLE
feat(mm-next): add new header data, adjust related component

### DIFF
--- a/packages/mirror-media-next/components/header.js
+++ b/packages/mirror-media-next/components/header.js
@@ -9,70 +9,157 @@ import {
   SOCIAL_MEDIA_LINKS,
 } from '../constants'
 
-const DISPLAY_PARTNERS = [{ name: '生活暖流', href: '/externals/warmlife' }]
-
 const DEFAULT_NORMAL_SECTIONS_DATA = [
   {
-    id: '42',
+    order: 1,
+    type: 'section',
     slug: 'member',
     name: '會員專區',
     categories: [
-      { id: '11', slug: 'food', name: '美食焦點', isMemberOnly: true },
-      { id: '12', slug: 'traveltaiwan', name: '旅行台灣', isMemberOnly: true },
-      { id: '17', slug: 'seetheworld', name: '看見世界', isMemberOnly: true },
-      { id: '18', slug: 'kitchenplay', name: '廚房密技', isMemberOnly: true },
-      { id: '29', slug: 'money', name: '理財', isMemberOnly: true },
-      { id: '35', slug: 'celebrity', name: '鏡大咖', isMemberOnly: true },
-      { id: '37', slug: 'column', name: '影劇專欄', isMemberOnly: true },
-      { id: '45', slug: 'wine', name: '好酒情報', isMemberOnly: true },
-      { id: '59', slug: 'somebody', name: '一鏡到底', isMemberOnly: true },
-      { id: '60', slug: 'world', name: '鏡相人間', isMemberOnly: true },
-      { id: '61', slug: 'truth', name: '心內話', isMemberOnly: true },
-      { id: '62', slug: 'mogul', name: '財經人物', isMemberOnly: true },
-      { id: '104', slug: 'timesquare', name: '時代現場', isMemberOnly: true },
-      { id: '122', slug: 'mg', name: '完整全文', isMemberOnly: false },
-      { id: '123', slug: 'dig', name: '新聞深探', isMemberOnly: true },
+      {
+        id: '1',
+        slug: 'food',
+        name: '美食焦點',
+        isMemberOnly: true,
+      },
+      {
+        id: '2',
+        slug: 'traveltaiwan',
+        name: '旅行台灣',
+        isMemberOnly: true,
+      },
+      {
+        id: '7',
+        slug: 'seetheworld',
+        name: '看見世界',
+        isMemberOnly: true,
+      },
+      {
+        id: '8',
+        slug: 'kitchenplay',
+        name: '廚房密技',
+        isMemberOnly: true,
+      },
+      {
+        id: '19',
+        slug: 'money',
+        name: '理財',
+        isMemberOnly: true,
+      },
+      {
+        id: '25',
+        slug: 'celebrity',
+        name: '鏡大咖',
+        isMemberOnly: true,
+      },
+      {
+        id: '27',
+        slug: 'column',
+        name: '影劇專欄',
+        isMemberOnly: true,
+      },
+      {
+        id: '35',
+        slug: 'wine',
+        name: '好酒情報',
+        isMemberOnly: true,
+      },
+      {
+        id: '49',
+        slug: 'somebody',
+        name: '一鏡到底',
+        isMemberOnly: true,
+      },
+      {
+        id: '50',
+        slug: 'world',
+        name: '鏡相人間',
+        isMemberOnly: true,
+      },
+      {
+        id: '51',
+        slug: 'truth',
+        name: '心內話',
+        isMemberOnly: true,
+      },
+      {
+        id: '52',
+        slug: 'mogul',
+        name: '財經人物',
+        isMemberOnly: true,
+      },
+      {
+        id: '94',
+        slug: 'timesquare',
+        name: '時代現場',
+        isMemberOnly: true,
+      },
+      {
+        id: '112',
+        slug: 'mg',
+        name: '完整全文',
+        isMemberOnly: false,
+      },
+      {
+        id: '113',
+        slug: 'dig',
+        name: '新聞深探',
+        isMemberOnly: true,
+      },
     ],
   },
   {
-    id: '32',
+    order: 2,
+    type: 'category',
     slug: 'news',
-    name: '時事',
-    categories: [
-      { id: '19', slug: 'shopping', name: '消費', isMemberOnly: false },
-      { id: '27', slug: 'news', name: '焦點', isMemberOnly: false },
-      { id: '55', slug: 'political', name: '政治', isMemberOnly: false },
-      { id: '56', slug: 'life', name: '生活', isMemberOnly: false },
-      { id: '57', slug: 'city-news', name: '社會', isMemberOnly: false },
-      { id: '108', slug: 'boom', name: '鏡爆', isMemberOnly: false },
-      { id: '109', slug: 'global', name: '國際要聞', isMemberOnly: false },
-      { id: '118', slug: 'wine1', name: '微醺酩品', isMemberOnly: false },
-    ],
+    name: '焦點',
+    isMemberOnly: false,
+    sections: ['news'],
   },
   {
-    id: '37',
-    slug: 'businessmoney',
-    name: '財經理財',
-    categories: [
-      { id: '28', slug: 'business', name: '財經', isMemberOnly: false },
-      { id: '29', slug: 'money', name: '理財', isMemberOnly: true },
-    ],
-  },
-  {
-    id: '33',
+    order: 3,
+    type: 'section',
     slug: 'entertainment',
     name: '娛樂',
     categories: [
-      { id: '34', slug: 'latestnews', name: '娛樂頭條', isMemberOnly: false },
-      { id: '35', slug: 'celebrity', name: '鏡大咖', isMemberOnly: true },
-      { id: '37', slug: 'column', name: '影劇專欄', isMemberOnly: true },
-      { id: '46', slug: 'insight', name: '娛樂透視', isMemberOnly: false },
-      { id: '58', slug: 'comic', name: '動漫遊戲', isMemberOnly: false },
-      { id: '71', slug: 'rookie', name: '試鏡間', isMemberOnly: false },
-      { id: '72', slug: 'fashion', name: '穿衣鏡', isMemberOnly: false },
-      { id: '73', slug: 'madam', name: '蘭蘭夫人', isMemberOnly: false },
       {
-        id: '74',
+        id: '24',
+        slug: 'latestnews',
+        name: '娛樂頭條',
+        isMemberOnly: false,
+      },
+      {
+        id: '36',
+        slug: 'insight',
+        name: '娛樂透視',
+        isMemberOnly: false,
+      },
+      {
+        id: '48',
+        slug: 'comic',
+        name: '動漫遊戲',
+        isMemberOnly: false,
+      },
+      {
+        id: '61',
+        slug: 'rookie',
+        name: '試鏡間',
+        isMemberOnly: false,
+      },
+      {
+        id: '62',
+        slug: 'fashion',
+        name: '穿衣鏡',
+        isMemberOnly: false,
+      },
+      {
+        id: '63',
+        slug: 'madam',
+        name: '蘭蘭夫人',
+        isMemberOnly: false,
+      },
+      {
+        id: '64',
         slug: 'superstar',
         name: '我眼中的大明星',
         isMemberOnly: false,
@@ -80,114 +167,168 @@ const DEFAULT_NORMAL_SECTIONS_DATA = [
     ],
   },
   {
-    id: '39',
-    slug: 'videohub',
-    name: '影音',
-    categories: [
-      {
-        id: '75',
-        slug: 'video_coverstory',
-        name: '鏡封面',
-        isMemberOnly: false,
-      },
-      {
-        id: '76',
-        slug: 'video_entertainment',
-        name: '鏡娛樂',
-        isMemberOnly: false,
-      },
-      { id: '77', slug: 'video_society', name: '鏡社會', isMemberOnly: false },
-      {
-        id: '78',
-        slug: 'video_investigation',
-        name: '鏡調查',
-        isMemberOnly: false,
-      },
-      {
-        id: '79',
-        slug: 'video_finance',
-        name: '財經理財',
-        isMemberOnly: false,
-      },
-      { id: '80', slug: 'video_people', name: '鏡人物', isMemberOnly: false },
-      {
-        id: '81',
-        slug: 'video_foodtravel',
-        name: '鏡食旅',
-        isMemberOnly: false,
-      },
-      {
-        id: '82',
-        slug: 'video_ent_perspective',
-        name: '娛樂透視',
-        isMemberOnly: false,
-      },
-      {
-        id: '83',
-        slug: 'video_carandwatch',
-        name: '汽車鐘錶',
-        isMemberOnly: false,
-      },
-    ],
+    order: 4,
+    type: 'category',
+    slug: 'political',
+    name: '政治',
+    isMemberOnly: false,
+    sections: ['news'],
   },
   {
-    id: '44',
-    slug: 'mirrorcolumn',
-    name: '論壇',
+    order: 5,
+    type: 'category',
+    slug: 'business',
+    name: '財經',
+    isMemberOnly: false,
+    sections: ['businessmoney'],
+  },
+  {
+    order: 6,
+    type: 'category',
+    slug: 'city-news',
+    name: '社會',
+    isMemberOnly: false,
+    sections: ['news'],
+  },
+  {
+    order: 7,
+    type: 'section',
+    slug: 'life',
+    name: '生活',
     categories: [
       {
-        id: '116',
-        slug: 'mirrorcolumn',
-        name: '名家專欄',
+        id: '46',
+        slug: 'life',
+        name: '萬象',
         isMemberOnly: false,
       },
-    ],
-  },
-  { id: '38', slug: 'mafalda', name: '瑪法達', categories: [] },
-  {
-    id: '36',
-    slug: 'culture',
-    name: '文化',
-    categories: [
       {
-        id: '84',
+        id: '74',
         slug: 'knowledgeprogram',
         name: '知識好好玩',
         isMemberOnly: false,
       },
-      { id: '85', slug: 'bookreview', name: '書評', isMemberOnly: false },
-      { id: '86', slug: 'culture-column', name: '專欄', isMemberOnly: false },
-      { id: '87', slug: 'poem', name: '詩', isMemberOnly: false },
-      { id: '105', slug: 'booksummary', name: '鏡書摘', isMemberOnly: false },
-      { id: '120', slug: 'voice', name: '好聽人物', isMemberOnly: false },
+      {
+        id: '75',
+        slug: 'bookreview',
+        name: '書評',
+        isMemberOnly: false,
+      },
+      {
+        id: '76',
+        slug: 'culture-column',
+        name: '專欄',
+        isMemberOnly: false,
+      },
+      {
+        id: '77',
+        slug: 'poem',
+        name: '詩',
+        isMemberOnly: false,
+      },
+      {
+        id: '95',
+        slug: 'booksummary',
+        name: '鏡書摘',
+        isMemberOnly: false,
+      },
+      {
+        id: '109',
+        slug: 'vioce',
+        name: '好聽人物',
+        isMemberOnly: false,
+      },
     ],
   },
   {
-    id: '30',
+    order: 8,
+    type: 'category',
+    slug: 'global',
+    name: '國際要聞',
+    isMemberOnly: false,
+    sections: ['news', 'international'],
+  },
+  {
+    order: 9,
+    type: 'section',
     slug: 'carandwatch',
     name: '汽車鐘錶',
     categories: [
-      { id: '21', slug: 'watchfocus', name: '錶壇焦點', isMemberOnly: false },
-      { id: '22', slug: 'watchfeature', name: '鐘錶專題', isMemberOnly: false },
-      { id: '25', slug: 'blog', name: '編輯幕後', isMemberOnly: false },
-      { id: '66', slug: 'car_focus', name: '車壇焦點', isMemberOnly: false },
-      { id: '67', slug: 'car_features', name: '鏡車專題', isMemberOnly: false },
-      { id: '68', slug: 'test_drives', name: '靚俥試駕', isMemberOnly: false },
-      { id: '69', slug: 'pit_zone', name: '鏡車經', isMemberOnly: false },
       {
-        id: '117',
+        id: '11',
+        slug: 'watchfocus',
+        name: '錶壇焦點',
+        isMemberOnly: false,
+      },
+      {
+        id: '12',
+        slug: 'watchfeature',
+        name: '鐘錶專題',
+        isMemberOnly: false,
+      },
+      {
+        id: '15',
+        slug: 'blog',
+        name: '編輯幕後',
+        isMemberOnly: false,
+      },
+      {
+        id: '56',
+        slug: 'car_focus',
+        name: '車壇焦點',
+        isMemberOnly: false,
+      },
+      {
+        id: '57',
+        slug: 'car_features',
+        name: '鏡車專題',
+        isMemberOnly: false,
+      },
+      {
+        id: '58',
+        slug: 'test_drives',
+        name: '靚俥試駕',
+        isMemberOnly: false,
+      },
+      {
+        id: '59',
+        slug: 'pit_zone',
+        name: '鏡車經',
+        isMemberOnly: false,
+      },
+      {
+        id: '107',
         slug: 'newwatches2021',
         name: '新錶2021',
         isMemberOnly: false,
       },
-      { id: '121', slug: 'luxury', name: '奢華誌', isMemberOnly: false },
       {
-        id: '124',
+        id: '111',
+        slug: 'luxury',
+        name: '奢華誌',
+        isMemberOnly: false,
+      },
+      {
+        id: '114',
         slug: 'newwatches2022',
         name: '新錶2022',
         isMemberOnly: false,
       },
+      {
+        id: '115',
+        slug: 'newwatches2023',
+        name: '新錶2023',
+        isMemberOnly: false,
+      },
     ],
+  },
+  {
+    order: 10,
+    type: 'category',
+    slug: 'mafalda-1',
+    name: '瑪法達',
+    isMemberOnly: false,
+    sections: [],
   },
 ]
 
@@ -210,12 +351,11 @@ const GPTAd = dynamic(() => import('../components/ads/gpt/gpt-ad'), {
 })
 
 /**
- *
- *  @typedef {import('../apollo/fragments/section').Section[]} Sections
- */
-
-/**
- * @typedef {import('./nav-sections').SectionWithHrefTemp} SectionWithHrefTemp
+ * @typedef {import('./nav-sections').HeadersDataSection} HeadersDataSection
+ * @typedef {import('./nav-sections').HeadersDataCategory} HeadersDataCategory
+ * @typedef {import('./nav-sections').HeadersDataCategoryWithHref} HeadersDataCategoryWithHref
+ * @typedef {import('./nav-sections').HeadersDataSectionWithHref} HeadersDataSectionWithHref
+ * @typedef {import('./nav-sections').SectionsAndCategoriesWithHref} SectionsAndCategoriesWithHref
  */
 
 /**
@@ -344,101 +484,163 @@ const StyledGPTAd = styled(GPTAd)`
   }
 `
 
-/**
- * Remove item from array `categories` if which is member only category.
- * @param {import('../apollo/fragments/section').Section} section
- * @returns {import('../apollo/fragments/section').Section}
- */
-function filterOutIsMemberOnlyCategoriesInNormalSection(section) {
-  return {
-    ...section,
-    categories:
-      section.slug === 'member'
-        ? section.categories
-        : section.categories.filter((category) => !category.isMemberOnly),
+const formatSectionItem = (section) => {
+  const sectionWithInsertedCategory = insertCategoryIntoCertainSection(section)
+  const sectionAndItsCategoriesWithHref = getSectionAndCategoryHref(
+    sectionWithInsertedCategory
+  )
+  return sectionAndItsCategoriesWithHref
+
+  /**
+   * @param {HeadersDataSection} section
+   * @returns {HeadersDataSection}
+   */
+  function insertCategoryIntoCertainSection(section) {
+    if (section.slug === 'member') {
+      return {
+        ...section,
+        categories: [
+          {
+            id: '7a7482edb739242537f11e24760d2c79', //hash for ensure it is unique from other category, no other usage.
+            slug: 'magazine',
+            name: '動態雜誌',
+            isMemberOnly: false,
+          },
+          ...section.categories,
+        ],
+      }
+    } else if (section.slug === 'life') {
+      return {
+        ...section,
+        categories: [
+          ...section.categories,
+          {
+            id: '306dac073da6dc1ddb4e34c228035915', //hash for ensure it is unique from other category, no other usage.
+            slug: 'warmlife',
+            name: '暖流',
+            isMemberOnly: false,
+          },
+        ],
+      }
+    }
+    return { ...section }
+  }
+  /**
+   * @param {HeadersDataSection} section
+   * @returns {HeadersDataSectionWithHref}
+   */
+  function getSectionAndCategoryHref(section) {
+    return {
+      ...section,
+      href: getSectionHref(section.slug),
+      categories: getCategoryInSectionWithHref(section),
+    }
+
+    /**
+     * @param {HeadersDataSection['slug']} sectionSlug
+     * @returns {HeadersDataCategoryWithHref['href']}
+     */
+    function getSectionHref(sectionSlug) {
+      if (sectionSlug === 'member') {
+        return `/premiumsection/${sectionSlug}`
+      } else {
+        return `/section/${sectionSlug}`
+      }
+    }
+
+    /**
+     * @param {HeadersDataSection} section
+     * @returns {HeadersDataSectionWithHref['categories']}
+     */
+    function getCategoryInSectionWithHref(section) {
+      const { categories = [] } = section
+      return categories.map((category) => {
+        return {
+          ...category,
+          href: getCategoryHref(section.slug, category.slug),
+        }
+      })
+      /**
+       * @param {HeadersDataSection['slug']} sectionSlug
+       * @param {import('./nav-sections').CategoryInHeadersDataSection['slug']} categorySlug
+       * @returns {string}
+       */
+      function getCategoryHref(sectionSlug, categorySlug) {
+        if (sectionSlug === 'videohub') {
+          return `/video_category/${categorySlug}`
+        }
+        if (categorySlug === 'magazine') {
+          return '/magazine/'
+        }
+        if (sectionSlug === 'life' && categorySlug === 'warmlife') {
+          return '/externals/warmlife'
+        }
+        return `/category/${categorySlug}`
+      }
+    }
   }
 }
 
-/**
- *
- * @param {import('../apollo/fragments/section').Section} section
- * @return {SectionWithHrefTemp}
- */
-function getSectionAndCategoryHref(section) {
-  const getCategoryHref = (sectionSlug, categorySlug) => {
-    if (sectionSlug === 'videohub') {
-      return `/video_category/${categorySlug}`
-    }
-    if (categorySlug === 'magazine') {
-      return '/magazine/'
-    }
-    return `/category/${categorySlug}`
-  }
+const formatCategoryItem = (category) => {
+  return getSectionAndCategoryHref(category)
 
   /**
    *
-   * @param {string} sectionSlug
-   * @returns {string}
+   * @param {HeadersDataCategory} section
+   * @return {HeadersDataCategoryWithHref}
    */
-  const getSectionHref = (sectionSlug) => {
-    if (sectionSlug === 'member') {
-      return `/premiumsection/${sectionSlug}`
-    } else {
-      return `/section/${sectionSlug}`
-    }
-  }
-  const getCategoryWithHref = (section, categories) => {
-    return categories.map((category) => {
-      return { ...category, href: getCategoryHref(section.slug, category.slug) }
-    })
-  }
-  const newSection = {
-    ...section,
-    href: getSectionHref(section.slug),
-    categories: getCategoryWithHref(section, section.categories),
-  }
-  return newSection
-}
-
-const insertMagazineIntoSections = (section) => {
-  if (section.slug === 'member') {
+  function getSectionAndCategoryHref(section) {
     return {
       ...section,
-      categories: [
-        {
-          id: '7a7482edb739242537f11e24760d2c79', //hash for ensure it is unique from other category, no other usage.
-          slug: 'magazine',
-          name: '動態雜誌',
-          isMemberOnly: false,
-        },
-        ...section.categories,
-      ],
+      href: getCategoryHref(section.sections, section.slug),
+    }
+
+    /**
+     *
+     * @param {HeadersDataCategory['sections']} sections
+     * @param {HeadersDataCategory['slug']} categorySlug
+     * @returns {string}
+     */
+    function getCategoryHref(sections, categorySlug) {
+      if (
+        sections &&
+        sections.length &&
+        sections.some((section) => section === 'videohub')
+      ) {
+        return `/video_category/${categorySlug}`
+      }
+      return `/category/${categorySlug}`
     }
   }
-  return { ...section }
 }
 /**
  *
- * @param {Sections} sectionsData
- * @returns {SectionWithHrefTemp[]}
+ * @param {(HeadersDataSection | HeadersDataCategory)[] } sectionsData
+ * @returns {SectionsAndCategoriesWithHref}
  */
 const formatSections = (sectionsData) => {
   const _sectionsData =
     sectionsData && sectionsData.length
       ? sectionsData
       : DEFAULT_NORMAL_SECTIONS_DATA
-  return (
-    _sectionsData
-      .map(insertMagazineIntoSections)
-      .map(filterOutIsMemberOnlyCategoriesInNormalSection)
-      .map(getSectionAndCategoryHref) ?? []
-  )
+  const formattedSectionData = _sectionsData.map((item) => {
+    switch (item.type) {
+      case 'section':
+        return formatSectionItem(item)
+      case 'category':
+        return formatCategoryItem(item)
+      default:
+        return null
+    }
+  })
+
+  return formattedSectionData
 }
 /**
  * TODO: use typedef in `../apollo/fragments/section` and  `../apollo/fragments/topic`
  * Should be done after fetch header data from new json file
  * @param {Object} props
- * @param {Sections} props.sectionsData
+ * @param {SectionsAndCategoriesWithHref} props.sectionsData
  * @param {Topics} props.topicsData
  * @param {JSX.Element} [props.children]
  * @returns {React.ReactElement}
@@ -516,8 +718,7 @@ export default function Header({
           <PromotionLinks links={PROMOTION_LINKS} />
           <MobileSidebar
             topics={topics}
-            sections={sections}
-            displayedPartners={DISPLAY_PARTNERS}
+            sectionsAndCategories={sections}
             subBrands={SUB_BRAND_LINKS}
             promotions={PROMOTION_LINKS}
             socialMedia={SOCIAL_MEDIA_LINKS}
@@ -547,7 +748,7 @@ export default function Header({
             }
           />
         </SearchInputWrapper>
-        <NavSections sections={sections} displayedPartners={DISPLAY_PARTNERS} />
+        <NavSections sectionsAndCategories={sections} />
         <TopicsAndFlashNews>
           {children}
           <TopicsAndSubscribe>

--- a/packages/mirror-media-next/components/header.js
+++ b/packages/mirror-media-next/components/header.js
@@ -808,15 +808,15 @@ const SkeletonBlockBottomDown = styled(SkeletonBlock)`
 `
 const HeaderSkeleton = () => {
   const elementInBottomUp = []
-  const numberOfElementsInBottomUp = 9
+  const numberOfElementsInBottomUp = 10
 
   for (let i = 0; i < numberOfElementsInBottomUp; i++) {
     elementInBottomUp.push(
       <SkeletonBlock
         key={i}
-        mobile={{ width: '105px', height: '32px' }}
-        tablet={{ width: '105px', height: '32px' }}
-        desktop={{ width: '105px', height: '32px' }}
+        mobile={{ width: '90px', height: '32px' }}
+        tablet={{ width: '90px', height: '32px' }}
+        desktop={{ width: '90px', height: '32px' }}
       />
     )
   }

--- a/packages/mirror-media-next/components/nav-sections.js
+++ b/packages/mirror-media-next/components/nav-sections.js
@@ -1,9 +1,9 @@
 //TODO: When user at certain section, at category which belongs to certain section, at story which belongs to certain section
 //component <Section> will change color of title to section color defined at /styles/sections-color.
-//TODO: Replace <a> to <Link> for Single Page Application
 import styled, { css } from 'styled-components'
 import { minWidth } from '../styles/media'
 import Logo from './logo'
+import Link from 'next/link'
 /**
  * @typedef {import('../type/theme').Theme} Theme
  */
@@ -21,22 +21,32 @@ const colorCss = css`
       } else if (sectionSlug && theme.color.sectionsColor[sectionSlug]) {
         return theme.color.sectionsColor[sectionSlug]
       } else {
-        return '#fff'
+        return '#000'
       }
     }
   };
 `
 
 /**
- * @typedef {import('../apollo/fragments/section').Section} Section
+ * @typedef {import('../utils/api/index').HeadersDataSection} HeadersDataSection
+ */
+/**
+ * @typedef {import('../utils/api/index').CategoryInHeadersDataSection} CategoryInHeadersDataSection
  */
 
 /**
- * @typedef {import('../apollo/fragments/section').SectionWithCategory} SectionWithCategory
+ * @typedef {import('../utils/api/index').HeadersDataCategory} HeadersDataCategory
  */
 
 /**
- * @typedef {Omit<Section, 'categories' > & {href: string, categories: Array.<SectionWithCategory & { href: string }> }} SectionWithHrefTemp
+ * @typedef {Omit<HeadersDataSection, 'categories' > & {href: string, categories: Array.<CategoryInHeadersDataSection & { href: string }> }}HeadersDataSectionWithHref
+ */
+/**
+ * @typedef {HeadersDataCategory & {href: string }} HeadersDataCategoryWithHref
+ */
+
+/**
+ * @typedef { (HeadersDataCategoryWithHref | HeadersDataSectionWithHref )[]} SectionsAndCategoriesWithHref
  */
 const SectionsWrapper = styled.nav`
   font-size: 14px;
@@ -91,7 +101,7 @@ const Section = styled.li`
     line-height: 150%;
     flex-shrink: 1;
     width: 100%;
-    min-width: calc(100% / 11);
+    min-width: calc(100% / 12);
     &.member {
       color: #fff;
       background-color: #000000;
@@ -113,7 +123,7 @@ const SectionLink = styled.a`
   font-weight: 700;
   padding: 7px 6px 5px 6px;
   ${({ theme }) => theme.breakpoint.xl} {
-    padding: 9px 16px 9px 16px;
+    padding: 9px 12px 9px 12px;
   }
 `
 
@@ -161,31 +171,25 @@ const CategoryLink = styled.a`
     }
   }
   ${({ theme }) => theme.breakpoint.xl} {
-    padding: 8px 14px 8px 14px;
+    padding: 8px 12px 8px 12px;
   }
 `
 
 /**
  * @param {Object} props
- * @param {SectionWithHrefTemp[]} props.sections
- * @param {{name: string, href:string}[]} props.displayedPartners
+ * @param {SectionsAndCategoriesWithHref} props.sectionsAndCategories
  * @returns {React.ReactElement}
  */
-export default function NavSections({ sections = [], displayedPartners = [] }) {
-  return (
-    <SectionsWrapper>
-      <SectionLogo>
-        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-        <a href="/">
-          <LogoIcon />
-        </a>
-      </SectionLogo>
-      <Sections>
-        {sections.map((section) => (
-          <Section key={section.id} sectionSlug={section?.slug}>
+export default function NavSections({ sectionsAndCategories = [] }) {
+  const sectionsAndCategoriesJsx = sectionsAndCategories.map((section) => {
+    switch (section?.type) {
+      case 'section':
+        return (
+          <Section key={section.order} sectionSlug={section?.slug}>
             <SectionLink href={section.href}>
               <h2>{section.name}</h2>
             </SectionLink>
+
             <SectionDropDown>
               {section.categories.map((category) => (
                 <CategoryLink
@@ -198,17 +202,29 @@ export default function NavSections({ sections = [], displayedPartners = [] }) {
               ))}
             </SectionDropDown>
           </Section>
-        ))}
-        <>
-          {displayedPartners.map((partner) => (
-            <Section key={partner.name}>
-              <SectionLink href={partner.href}>
-                <h2>{partner.name}</h2>
-              </SectionLink>
-            </Section>
-          ))}
-        </>
-      </Sections>
+        )
+      case 'category':
+        const renderSectionSlug = section.sections?.[0]
+
+        return (
+          <Section key={section.order} sectionSlug={renderSectionSlug}>
+            <SectionLink href={section.href}>
+              <h2>{section.name}</h2>
+            </SectionLink>
+          </Section>
+        )
+      default:
+        return null
+    }
+  })
+  return (
+    <SectionsWrapper>
+      <SectionLogo>
+        <Link href="/">
+          <LogoIcon />
+        </Link>
+      </SectionLogo>
+      <Sections>{sectionsAndCategoriesJsx}</Sections>
     </SectionsWrapper>
   )
 }

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -16,6 +16,7 @@ let URL_STATIC_NORMAL_SECTIONS = ''
 let URL_STATIC_TOPICS = ''
 let URL_STATIC_POST_FLASH_NEWS = ''
 let URL_STATIC_POST_EXTERNAL = ''
+let URL_STATIC_HEADER_HEADERS = ''
 let DONATION_PAGE_URL = ''
 let GA_MEASUREMENT_ID = ''
 let GTM_ID = ''
@@ -42,6 +43,7 @@ switch (ENV) {
     URL_STATIC_POST_EXTERNAL = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/post_external`
     URL_STATIC_POPULAR_NEWS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/popular.json`
     URL_STATIC_404_POPULAR_NEWS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/404_popular.json`
+    URL_STATIC_HEADER_HEADERS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/header_headers.json`
 
     DONATION_PAGE_URL = 'https://mirrormedia.oen.tw/'
     GA_MEASUREMENT_ID = 'G-341XFN0675'
@@ -75,6 +77,7 @@ switch (ENV) {
     URL_STATIC_POST_EXTERNAL = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/post_external`
     URL_STATIC_POPULAR_NEWS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/popular.json`
     URL_STATIC_404_POPULAR_NEWS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/404_popular.json`
+    URL_STATIC_HEADER_HEADERS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/header_headers.json`
 
     DONATION_PAGE_URL = 'https://mirrormedia.oen.tw/'
     GA_MEASUREMENT_ID = 'G-32D7P3MJ8B'
@@ -107,6 +110,7 @@ switch (ENV) {
     URL_STATIC_POST_EXTERNAL = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/post_external`
     URL_STATIC_POPULAR_NEWS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/popular.json`
     URL_STATIC_404_POPULAR_NEWS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/404_popular.json`
+    URL_STATIC_HEADER_HEADERS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/header_headers.json`
 
     DONATION_PAGE_URL = 'https://mirrormedia.testing.oen.tw/'
     GA_MEASUREMENT_ID = 'G-36HYH6NF6P'
@@ -141,7 +145,7 @@ switch (ENV) {
     URL_STATIC_POST_EXTERNAL = `http://localhost:8080/json/post_external`
     URL_STATIC_POPULAR_NEWS = `http://localhost:8080/json/popular.json`
     URL_STATIC_404_POPULAR_NEWS = `http://localhost:8080/json/404_popular.json`
-
+    URL_STATIC_HEADER_HEADERS = `http://localhost:8080/json/header_headers.json`
     DONATION_PAGE_URL = 'https://mirrormedia.testing.oen.tw/'
     GA_MEASUREMENT_ID = 'G-36HYH6NF6P'
     GTM_ID = 'GTM-PBNLSMX'
@@ -179,4 +183,5 @@ export {
   URL_STATIC_404_POPULAR_NEWS,
   GPT_MODE,
   FIREBASE_CONFIG,
+  URL_STATIC_HEADER_HEADERS,
 }

--- a/packages/mirror-media-next/mocks/json/header_headers.json
+++ b/packages/mirror-media-next/mocks/json/header_headers.json
@@ -1,0 +1,335 @@
+{
+    "headers": [
+        {
+            "order": 1,
+            "type": "section",
+            "slug": "member",
+            "name": "會員專區",
+            "categories": [
+                {
+                    "id": "1",
+                    "slug": "food",
+                    "name": "美食焦點",
+                    "isMemberOnly": true
+                },
+                {
+                    "id": "2",
+                    "slug": "traveltaiwan",
+                    "name": "旅行台灣",
+                    "isMemberOnly": true
+                },
+                {
+                    "id": "7",
+                    "slug": "seetheworld",
+                    "name": "看見世界",
+                    "isMemberOnly": true
+                },
+                {
+                    "id": "8",
+                    "slug": "kitchenplay",
+                    "name": "廚房密技",
+                    "isMemberOnly": true
+                },
+                {
+                    "id": "19",
+                    "slug": "money",
+                    "name": "理財",
+                    "isMemberOnly": true
+                },
+                {
+                    "id": "25",
+                    "slug": "celebrity",
+                    "name": "鏡大咖",
+                    "isMemberOnly": true
+                },
+                {
+                    "id": "27",
+                    "slug": "column",
+                    "name": "影劇專欄",
+                    "isMemberOnly": true
+                },
+                {
+                    "id": "35",
+                    "slug": "wine",
+                    "name": "好酒情報",
+                    "isMemberOnly": true
+                },
+                {
+                    "id": "49",
+                    "slug": "somebody",
+                    "name": "一鏡到底",
+                    "isMemberOnly": true
+                },
+                {
+                    "id": "50",
+                    "slug": "world",
+                    "name": "鏡相人間",
+                    "isMemberOnly": true
+                },
+                {
+                    "id": "51",
+                    "slug": "truth",
+                    "name": "心內話",
+                    "isMemberOnly": true
+                },
+                {
+                    "id": "52",
+                    "slug": "mogul",
+                    "name": "財經人物",
+                    "isMemberOnly": true
+                },
+                {
+                    "id": "94",
+                    "slug": "timesquare",
+                    "name": "時代現場",
+                    "isMemberOnly": true
+                },
+                {
+                    "id": "112",
+                    "slug": "mg",
+                    "name": "完整全文",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "113",
+                    "slug": "dig",
+                    "name": "新聞深探",
+                    "isMemberOnly": true
+                }
+            ]
+        },
+        {
+            "order": 2,
+            "type": "category",
+            "slug": "news",
+            "name": "焦點",
+            "isMemberOnly": false,
+            "sections": [
+                "news"
+            ]
+        },
+        {
+            "order": 3,
+            "type": "section",
+            "slug": "entertainment",
+            "name": "娛樂",
+            "categories": [
+                {
+                    "id": "24",
+                    "slug": "latestnews",
+                    "name": "娛樂頭條",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "36",
+                    "slug": "insight",
+                    "name": "娛樂透視",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "48",
+                    "slug": "comic",
+                    "name": "動漫遊戲",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "61",
+                    "slug": "rookie",
+                    "name": "試鏡間",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "62",
+                    "slug": "fashion",
+                    "name": "穿衣鏡",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "63",
+                    "slug": "madam",
+                    "name": "蘭蘭夫人",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "64",
+                    "slug": "superstar",
+                    "name": "我眼中的大明星",
+                    "isMemberOnly": false
+                }
+            ]
+        },
+        {
+            "order": 4,
+            "type": "category",
+            "slug": "political",
+            "name": "政治",
+            "isMemberOnly": false,
+            "sections": [
+                "news"
+            ]
+        },
+        {
+            "order": 5,
+            "type": "category",
+            "slug": "business",
+            "name": "財經",
+            "isMemberOnly": false,
+            "sections": [
+                "businessmoney"
+            ]
+        },
+        {
+            "order": 6,
+            "type": "category",
+            "slug": "city-news",
+            "name": "社會",
+            "isMemberOnly": false,
+            "sections": [
+                "news"
+            ]
+        },
+        {
+            "order": 7,
+            "type": "section",
+            "slug": "life",
+            "name": "生活",
+            "categories": [
+                {
+                    "id": "46",
+                    "slug": "life",
+                    "name": "萬象",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "74",
+                    "slug": "knowledgeprogram",
+                    "name": "知識好好玩",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "75",
+                    "slug": "bookreview",
+                    "name": "書評",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "76",
+                    "slug": "culture-column",
+                    "name": "專欄",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "77",
+                    "slug": "poem",
+                    "name": "詩",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "95",
+                    "slug": "booksummary",
+                    "name": "鏡書摘",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "109",
+                    "slug": "vioce",
+                    "name": "好聽人物",
+                    "isMemberOnly": false
+                }
+            ]
+        },
+        {
+            "order": 8,
+            "type": "category",
+            "slug": "global",
+            "name": "國際要聞",
+            "isMemberOnly": false,
+            "sections": [
+                "news",
+                "international"
+            ]
+        },
+        {
+            "order": 9,
+            "type": "section",
+            "slug": "carandwatch",
+            "name": "汽車鐘錶",
+            "categories": [
+                {
+                    "id": "11",
+                    "slug": "watchfocus",
+                    "name": "錶壇焦點",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "12",
+                    "slug": "watchfeature",
+                    "name": "鐘錶專題",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "15",
+                    "slug": "blog",
+                    "name": "編輯幕後",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "56",
+                    "slug": "car_focus",
+                    "name": "車壇焦點",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "57",
+                    "slug": "car_features",
+                    "name": "鏡車專題",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "58",
+                    "slug": "test_drives",
+                    "name": "靚俥試駕",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "59",
+                    "slug": "pit_zone",
+                    "name": "鏡車經",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "107",
+                    "slug": "newwatches2021",
+                    "name": "新錶2021",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "111",
+                    "slug": "luxury",
+                    "name": "奢華誌",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "114",
+                    "slug": "newwatches2022",
+                    "name": "新錶2022",
+                    "isMemberOnly": false
+                },
+                {
+                    "id": "115",
+                    "slug": "newwatches2023",
+                    "name": "新錶2023",
+                    "isMemberOnly": false
+                }
+            ]
+        },
+        {
+            "order": 10,
+            "type": "category",
+            "slug": "mafalda-1",
+            "name": "瑪法達",
+            "isMemberOnly": false,
+            "sections": []
+        }
+    ]
+}

--- a/packages/mirror-media-next/styles/theme/color.js
+++ b/packages/mirror-media-next/styles/theme/color.js
@@ -19,6 +19,7 @@ const sectionsColor = {
   carandwatch: '#1877F2',
   external: '#2ECDA7',
   mirrorcolumn: '#B79479',
+  life: '#2ECDA7',
 }
 const videoCategoryColor = {
   video_coverstory: '#30bac8',

--- a/packages/mirror-media-next/type/theme.js
+++ b/packages/mirror-media-next/type/theme.js
@@ -33,6 +33,7 @@ export default {}
  * @property {String} sectionsColor.carandwatch
  * @property {String} sectionsColor.external
  * @property {String} sectionsColor.mirrorcolumn
+ * @property {String} sectionsColor.life
  *
  * @property {Object} videoCategoryColor
  * @property {String} videoCategoryColor.video_coverstory

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -1,18 +1,53 @@
 import errors from '@twreporter/errors'
 import {
-  URL_STATIC_NORMAL_SECTIONS,
   URL_STATIC_PREMIUM_SECTIONS,
   URL_STATIC_TOPICS,
+  URL_STATIC_HEADER_HEADERS,
 } from '../../config/index.mjs'
 import axiosInstance from '../../axios/index.js'
 
 /**
- * @typedef {import('../../apollo/fragments/section.js').Section[]} Sections
+ * @typedef {Object} Category
+ * @property {string} id
+ * @property {string} slug
+ * @property {string} name
+ * @property {boolean} isMemberOnly
  */
 /**
  * @typedef {import('../../apollo/fragments/topic.js').Topic[]} Topics
  */
 
+/**
+ * @typedef {Object} CategoryInHeadersDataSection
+ * @property {string} id
+ * @property {string} slug
+ * @property {string} name
+ * @property {boolean} isMemberOnly
+ */
+
+/**
+ * @typedef {Object} HeadersDataSection
+ * @property {number} order
+ * @property {'section'} type
+ * @property {string} slug
+ * @property {string} name
+ * @property {CategoryInHeadersDataSection[]} categories
+ */
+
+/**
+ * @typedef {Object} HeadersDataCategory
+ * @property {number} order
+ * @property {'category'} type
+ * @property {string} slug
+ * @property {string} name
+ * @property {boolean} isMemberOnly
+ * @property {string[]} sections
+ *
+ */
+
+/**
+ * @typedef { (HeadersDataSection | HeadersDataCategory)[]} HeadersData
+ */
 /**
  * Creates an Axios request function that sends a GET request to the specified URL with a timeout.
  * @param {string} requestUrl - The URL to send the request to.
@@ -26,8 +61,8 @@ const errorLogger = (errorMessage) => {
   throw annotatingAxiosError
 }
 
-/** @type {() => Promise<import('axios').AxiosResponse<{sections: Sections}>>} */
-const fetchNormalSections = createAxiosRequest(URL_STATIC_NORMAL_SECTIONS)
+/** @type {() => Promise<import('axios').AxiosResponse<{headers: HeadersData}>>} */
+const fetchNormalSections = createAxiosRequest(URL_STATIC_HEADER_HEADERS)
 
 /** @type {() => Promise<import('axios').AxiosResponse<{topics: Topics}>>} */
 const fetchTopics = createAxiosRequest(URL_STATIC_TOPICS)
@@ -35,7 +70,7 @@ const fetchTopics = createAxiosRequest(URL_STATIC_TOPICS)
 const fetchPremiumSections = createAxiosRequest(URL_STATIC_PREMIUM_SECTIONS)
 
 const fetchHeaderDataInDefaultPageLayout = async () => {
-  /** @type {Sections} */
+  /** @type {HeadersData} */
   let sectionsData = []
   /** @type {Topics} */
   let topicsData = []
@@ -46,8 +81,8 @@ const fetchHeaderDataInDefaultPageLayout = async () => {
     ])
 
     const sectionsResponse = responses[0].status === 'fulfilled' && responses[0]
-    sectionsData = Array.isArray(sectionsResponse?.value?.data?.sections)
-      ? sectionsResponse?.value?.data?.sections
+    sectionsData = Array.isArray(sectionsResponse?.value?.data?.headers)
+      ? sectionsResponse?.value?.data?.headers
       : []
 
     const topicsResponse = responses[1].status === 'fulfilled' && responses[1]
@@ -55,7 +90,7 @@ const fetchHeaderDataInDefaultPageLayout = async () => {
       ? topicsResponse?.value?.data?.topics
       : []
 
-    return { sectionsData: sectionsData, topicsData }
+    return { sectionsData, topicsData }
   } catch (err) {
     errorLogger(err)
   }


### PR DESCRIPTION
## Notable Change
1. 抓取新的header data json檔，並調整對應的元件結構。

## Todos
原本想在元件MobileSidebar中，使用next/link取代`<a>`，提升跳轉後初載入速度。但發現如果是section -> section, category -> category的話，會無法正確顯示跳轉後的頁面資料。經debug後，發現是需要在無限滾動的元件中加入`key`，但實際原因仍待釐清，故先使用`<a>`。將於之後另開PR修復。