### PR TITLE
fix(mm-next/category): if no related-section, use 'other' ad units

### DIFF
--- a/packages/mirror-media-next/components/shared/article-list.js
+++ b/packages/mirror-media-next/components/shared/article-list.js
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useRef } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 import ArticleListItem from './article-list-item'
@@ -59,23 +59,24 @@ const StyledGPTAd = styled(GPTAd)`
  * @returns {React.ReactElement}
  */
 export default function ArticleList({ renderList, section }) {
+  const [GptPageKey, setGptPageKey] = useState('other')
   const shouldShowAd = useDisplayAd()
-  const GPT_PAGE_KEY = useRef('other')
 
+  /**
+   * 這個元件會被共用於 author/tag/category/section 列表頁
+   * 在 author/tag 列表頁時，GPT 廣告的 PageKey 固定為 'other'
+   * 在 section/category 列表頁時，GPT 廣告的 PageKey 設定為 'section.slug'
+   * 若 category 無所屬的 section (related-Section)，則 PageKey 一律為 'other'
+   */
   useEffect(() => {
-    const urlElements = window.location.pathname.split('/')
-    const pageType = urlElements[urlElements.length - 2]
-
-    switch (pageType) {
-      case 'author':
-      case 'tag':
-        GPT_PAGE_KEY.current = 'other'
-        break
-      case 'section':
-      case 'category':
-        GPT_PAGE_KEY.current = getSectionGPTPageKey(section.slug)
-        break
+    /**
+     * When the component is used on `author` or `tag` listing pages, there won't be a "section" parameter.
+     * As a result, it will return and directly use the default GptPageKey value: "other".
+     */
+    if (!section?.slug) {
+      return
     }
+    setGptPageKey(getSectionGPTPageKey(section.slug))
   }, [section])
 
   const renderListWithAd = shouldShowAd
@@ -102,9 +103,7 @@ export default function ArticleList({ renderList, section }) {
         ))}
       </ItemContainer>
 
-      {shouldShowAd && (
-        <StyledGPTAd pageKey={GPT_PAGE_KEY.current} adKey="FT" />
-      )}
+      {shouldShowAd && <StyledGPTAd pageKey={GptPageKey} adKey="FT" />}
 
       <ItemContainer>
         {renderListWithoutAd.map((item) => (

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -23,6 +23,7 @@ import WineWarning from '../../components/shared/wine-warning'
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
 })
+import FullScreenAds from '../../components/ads/full-screen-ads'
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -238,6 +239,7 @@ export default function Category({
           <StickyGPTAd pageKey={GptPageKey} adKey="MB_ST" />
         ) : null}
         <WineWarning categories={[category]} />
+        {isNotWineCategory && <FullScreenAds />}
       </CategoryContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -23,7 +23,6 @@ import WineWarning from '../../components/shared/wine-warning'
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
 })
-import FullScreenAds from '../../components/ads/full-screen-ads'
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -204,7 +203,9 @@ export default function Category({
   const isNotWineCategory = getCategoryOfWineSlug([category]).length === 0
 
   //The type of GPT ad to display depends on which category the section belongs to.
+  //If category not have related-section, use `other` ad units
   const sectionSlug = category?.sections?.[0]?.slug ?? ''
+  const GptPageKey = getSectionGPTPageKey(sectionSlug) ?? 'other'
 
   return (
     <Layout
@@ -213,9 +214,7 @@ export default function Category({
       footer={{ type: 'default' }}
     >
       <CategoryContainer isPremium={isPremium}>
-        {shouldShowAd && (
-          <StyledGPTAd pageKey={getSectionGPTPageKey(sectionSlug)} adKey="HD" />
-        )}
+        {shouldShowAd && <StyledGPTAd pageKey={GptPageKey} adKey="HD" />}
 
         {isPremium ? (
           <PremiumCategoryTitle sectionName={sectionSlug}>
@@ -236,13 +235,9 @@ export default function Category({
         />
 
         {shouldShowAd && isNotWineCategory ? (
-          <StickyGPTAd
-            pageKey={getSectionGPTPageKey(sectionSlug)}
-            adKey="MB_ST"
-          />
+          <StickyGPTAd pageKey={GptPageKey} adKey="MB_ST" />
         ) : null}
         <WineWarning categories={[category]} />
-        {isNotWineCategory && <FullScreenAds />}
       </CategoryContainer>
     </Layout>
   )

--- a/packages/mirror-media-next/utils/ad.js
+++ b/packages/mirror-media-next/utils/ad.js
@@ -77,16 +77,18 @@ const getSectionGPTPageKey = (sectionSlug) => {
     return
   }
 
-  let GptPageKey = 'other'
+  let GptPageKey
 
   //if sectionSlug is `論壇(mirrorcolumn)` or `新聞深探(timesquare)`, use the `culture` ad unit.
   const invalidSections = ['mirrorcolumn', 'timesquare']
 
   if (invalidSections.includes(sectionSlug)) {
     GptPageKey = SECTION_IDS['culture']
+  } else if (SECTION_IDS.hasOwnProperty(sectionSlug)) {
+    GptPageKey = SECTION_IDS[sectionSlug]
   } else {
     //if SECTION_IDS doesn't include `sectionSlug` ad units, use `other` ad units
-    GptPageKey = SECTION_IDS[sectionSlug] ?? 'other'
+    GptPageKey = 'other'
   }
 
   return GptPageKey

--- a/packages/mirror-media-next/utils/ad.js
+++ b/packages/mirror-media-next/utils/ad.js
@@ -72,23 +72,26 @@ function getPageKeyByPartnerSlug(partnerSlug = '') {
  * @param {string} sectionSlug
  * @returns {string | undefined}
  */
-const getSectionGPTPageKey = (sectionSlug = '') => {
-  if (typeof sectionSlug !== 'string') {
-    console.error(
-      `The value for 'sectionSlug' is not of the correct data type 'string'. Please check the data type of the value being passed.`
-    )
-    return undefined
+const getSectionGPTPageKey = (sectionSlug) => {
+  if (!sectionSlug || typeof sectionSlug !== 'string') {
+    return
   }
+
+  let GptPageKey = 'other'
 
   //if sectionSlug is `論壇(mirrorcolumn)` or `新聞深探(timesquare)`, use the `culture` ad unit.
   const invalidSections = ['mirrorcolumn', 'timesquare']
 
   if (invalidSections.includes(sectionSlug)) {
-    return SECTION_IDS['culture']
+    GptPageKey = SECTION_IDS['culture']
   } else {
-    return SECTION_IDS[sectionSlug]
+    //if SECTION_IDS doesn't include `sectionSlug` ad units, use `other` ad units
+    GptPageKey = SECTION_IDS[sectionSlug] ?? 'other'
   }
+
+  return GptPageKey
 }
+
 
 /**
  * Determining whether to insert a `PopIn` advertisement after a specific post index.


### PR DESCRIPTION
### Notable Changes 



- 調整 category 列表頁 GPT 廣告單元：

   - 若該 category 有所屬 section：廣告單元用 section.slug 
   - 有 section.slug，但該 slug 未在 `SECTION_IDS` 內有建檔，改用 `other` 廣告單元。
   - 若該 category 無所屬 section：廣告單元用 `other`

- 調整 `getSectionGPTPageKey` utils：
   - 當無 `sectionSlug` 傳入或類型不符合，回傳 undefined，不顯示廣告。
   - 當 `sectionSlug` 是 `論壇(mirrorcolumn)` or `新聞深探(timesquare)`， 改用 `culture` 廣告單元。
   - 當有 `sectionSlug` ，但該 slug 未在 `SECTION_IDS` 內有建檔，改用 `other` 廣告單元。