### PR TITLE
feat(mm-next): add `.webp` image in `readr-media/readr-image` of multiple pages

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/magazine.js
+++ b/packages/mirror-media-next/apollo/fragments/magazine.js
@@ -13,6 +13,7 @@ import { gql } from '@apollo/client'
 /**
  * @typedef {Object} CoverPhoto
  * @property {Resized} resized
+ * @property {Resized} resizedWebp
  */
 
 /**
@@ -37,6 +38,14 @@ export const magazine = gql`
     urlOriginal
     coverPhoto {
       resized {
+        original
+        w480
+        w800
+        w1200
+        w1600
+        w2400
+      }
+      resizedWebp {
         original
         w480
         w800

--- a/packages/mirror-media-next/apollo/fragments/photo.js
+++ b/packages/mirror-media-next/apollo/fragments/photo.js
@@ -22,6 +22,7 @@ import { gql } from '@apollo/client'
  * @property {string} name
  * @property {ImageFile} imageFile
  * @property {Resized} resized
+ * @property {Resized} resizedWebp
  */
 
 /**
@@ -38,6 +39,14 @@ export const heroImage = gql`
       height
     }
     resized {
+      original
+      w480
+      w800
+      w1200
+      w1600
+      w2400
+    }
+    resizedWebp {
       original
       w480
       w800

--- a/packages/mirror-media-next/components/editor-choice.js
+++ b/packages/mirror-media-next/components/editor-choice.js
@@ -217,6 +217,7 @@ const editorChoiceImageJsx = (heroImage, title) => {
   return (
     <CustomImage
       images={heroImage?.resized}
+      imagesWebP={heroImage?.resizedWebp}
       defaultImage="/images/default-og-img.png"
       loadingImage="/images/loading.gif"
       rwd={{

--- a/packages/mirror-media-next/components/latest-news-item.js
+++ b/packages/mirror-media-next/components/latest-news-item.js
@@ -122,6 +122,16 @@ const Title = styled.div`
  */
 
 /**
+ * @typedef {string|MyObject} MyType
+ */
+
+/**
+ * @typedef {Object} MyObject
+ * @property {string} resized - The resized property description.
+ * @property {string} resizedWebp - The resizedWebp property description.
+ */
+
+/**
  * @param {Object} props
  * @param {Article} props.itemData
  * @returns {React.ReactElement}
@@ -130,17 +140,26 @@ export default function LatestNewsItem({ itemData }) {
   /**
    * If latest news is an external article, `itemData.heroImage` would be a url,
    * such as 'https://www-somewebsite.com/some-image.jpeg'.
-   * @returns {{} | Article['heroImage']['resized']}
+   * @param {string | Article['heroImage']} heroImage
+   * @returns {any}
    */
-  const getRenderImages = () => {
-    if (itemData.heroImage?.resized) {
-      return itemData.heroImage?.resized
-    } else if (typeof itemData.heroImage === 'string') {
-      return { original: itemData.heroImage }
+  const getRenderImages = (heroImage) => {
+    /**
+     * @type {string | { original:string }}
+     */
+    let images = { original: '' }
+    let imagesWebp = null
+    if (typeof heroImage === 'string') {
+      images = { original: heroImage }
+      imagesWebp = null
+    } else if (heroImage?.resized) {
+      images = heroImage.resized
+    } else if (heroImage?.resizedWebp) {
+      imagesWebp = heroImage?.resizedWebp
     }
-    return {}
+    return { images, imagesWebp }
   }
-  const renderImages = getRenderImages()
+  const { images, imagesWebP } = getRenderImages(itemData.heroImage)
   return (
     <Link
       href={itemData.articleHref}
@@ -153,7 +172,8 @@ export default function LatestNewsItem({ itemData }) {
           <CustomImage
             defaultImage="/images/default-og-img.png"
             loadingImage="images/loading.gif"
-            images={renderImages}
+            images={images}
+            imagesWebP={imagesWebP}
             objectFit="cover"
             rwd={{
               mobile: '488px',

--- a/packages/mirror-media-next/components/magazine/magazine-specials.js
+++ b/packages/mirror-media-next/components/magazine/magazine-specials.js
@@ -168,6 +168,7 @@ export default function MagazineSpecials({ specials }) {
             <ImageWrapper>
               <Image
                 images={magazine.coverPhoto?.resized}
+                imagesWebP={magazine.coverPhoto?.resizedWebp}
                 loadingImage="/images/loading.gif"
                 defaultImage="/images/default-og-img.png"
                 alt={magazine.title}

--- a/packages/mirror-media-next/components/magazine/magazine-weeklys.js
+++ b/packages/mirror-media-next/components/magazine/magazine-weeklys.js
@@ -196,6 +196,7 @@ export default function MagazineWeeklys({ weeklys }) {
             <ImageWrapper>
               <Image
                 images={magazine.coverPhoto?.resized}
+                imagesWebP={magazine.coverPhoto?.resizedWebp}
                 loadingImage="/images/loading.gif"
                 defaultImage="/images/default-og-img.png"
                 alt={magazine.title}

--- a/packages/mirror-media-next/components/shared/article-list-item.js
+++ b/packages/mirror-media-next/components/shared/article-list-item.js
@@ -113,6 +113,7 @@ export default function ArticleListItem({ item, section }) {
       <ImageContainer>
         <Image
           images={item.heroImage?.resized}
+          imagesWebP={item.heroImage?.resizedWebp}
           alt={item.title}
           loadingImage="/images/loading.gif"
           defaultImage="/images/default-og-img.png"

--- a/packages/mirror-media-next/components/shared/premium-article-list-item.js
+++ b/packages/mirror-media-next/components/shared/premium-article-list-item.js
@@ -125,6 +125,7 @@ export default function PremiumArticleListItem({ item, section }) {
       <ImageContainer>
         <Image
           images={item.heroImage?.resized}
+          imagesWebP={item.heroImage?.resizedWebp}
           alt={item.title}
           loadingImage="/images/loading.gif"
           defaultImage="/images/default-og-img.png"

--- a/packages/mirror-media-next/components/story/normal/aside-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/aside-article-list.js
@@ -347,6 +347,7 @@ export default function AsideArticleList({
               >
                 <Image
                   images={item?.heroImage?.resized}
+                  imagesWebP={item?.heroImage?.resizedWebp}
                   alt={item.title}
                   loadingImage={'/images/loading.gif'}
                   defaultImage={'/images/default-og-img.png'}

--- a/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
+++ b/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
@@ -3,18 +3,7 @@ import styled from 'styled-components'
 import Image from 'next/image'
 import defaultImage from '../../../public/images/default-og-img.png'
 /**
- * @typedef {import('../../../apollo/fragments/post').HeroImage &
- * {
- *  id: string,
- *  resized: {
- *    original: string,
- *    w480: string,
- *    w800: string,
- *    w1200: string,
- *    w1600: string,
- *    w2400: string
- *  }
- * } } HeroImage
+ * @typedef {Pick<import('../../../apollo/fragments/post').HeroImage ,'id' | 'resized' | 'resizedWebp'>} HeroImage
  */
 
 /**
@@ -91,6 +80,7 @@ export default function HeroImageAndVideo({
 }) {
   const shouldShowHeroVideo = Boolean(heroVideo)
   const shouldShowHeroImage = Boolean(!shouldShowHeroVideo && heroImage)
+
   const heroJsx = () => {
     if (shouldShowHeroVideo) {
       return (
@@ -108,8 +98,10 @@ export default function HeroImageAndVideo({
         <HeroImage>
           <CustomImage
             images={heroImage.resized}
+            imagesWebP={heroImage.resizedWebp}
             loadingImage={'/images/loading@4x.gif'}
             defaultImage={'/images/default-og-img.png'}
+            debugMode={true}
             alt={heroCaption ? heroCaption : title}
             objectFit={'cover'}
             priority={true}

--- a/packages/mirror-media-next/components/story/normal/related-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/related-article-list.js
@@ -24,18 +24,7 @@ const StyledPopInAdRelated = dynamic(
 )
 
 /**
- * @typedef {import('../../../apollo/fragments/post').HeroImage &
- * {
- *  id: string,
- *  resized: {
- *    original: string,
- *    w480: string,
- *    w800: string,
- *    w1200: string,
- *    w1600: string,
- *    w2400: string
- *  }
- * } } HeroImage
+ * @typedef {Pick<import('../../../apollo/fragments/post').HeroImage ,'id' | 'resized' | 'resizedWebp'>} HeroImage
  */
 
 /**
@@ -178,6 +167,8 @@ export default function RelatedArticleList({
             >
               <Image
                 images={related.heroImage?.resized}
+                imagesWebP={related.heroImage?.resizedWebp}
+                debugMode={true}
                 alt={related.title}
                 rwd={{
                   mobile: '500px',

--- a/packages/mirror-media-next/components/story/photography/related-posts.js
+++ b/packages/mirror-media-next/components/story/photography/related-posts.js
@@ -3,18 +3,7 @@ import Image from '@readr-media/react-image'
 import Link from 'next/link'
 
 /**
- * @typedef {import('../../../apollo/fragments/post').HeroImage &
- * {
- *  id: string,
- *  resized: {
- *    original: string,
- *    w480: string,
- *    w800: string,
- *    w1200: string,
- *    w1600: string,
- *    w2400: string
- *  }
- * } } HeroImage
+ * @typedef {Pick<import('../../../apollo/fragments/post').HeroImage ,'id' | 'resized' | 'resizedWebp'>} HeroImage
  */
 
 /**
@@ -116,6 +105,7 @@ export default function RelatedPosts({ relateds = [] }) {
                 <ImageWrapper>
                   <Image
                     images={related.heroImage?.resized}
+                    imagesWebP={related.heroImage?.resizedWebp}
                     alt={related.title}
                     rwd={{
                       mobile: '280px',

--- a/packages/mirror-media-next/components/story/shared/aside-article-list.js
+++ b/packages/mirror-media-next/components/story/shared/aside-article-list.js
@@ -295,6 +295,7 @@ export default function AsideArticleList({
             <Link href={articleHref} target="_blank" className="article-image">
               <Image
                 images={item?.heroImage?.resized}
+                imagesWebP={item?.heroImage?.resizedWebp}
                 alt={item.title}
                 loadingImage={'/images/loading.gif'}
                 defaultImage={'/images/default-og-img.png'}

--- a/packages/mirror-media-next/components/story/shared/hero-image-and-video.js
+++ b/packages/mirror-media-next/components/story/shared/hero-image-and-video.js
@@ -1,18 +1,8 @@
 import styled, { css } from 'styled-components'
 import CustomImage from '@readr-media/react-image'
+
 /**
- * @typedef {import('../../../apollo/fragments/post').HeroImage &
- * {
- *  id: string,
- *  resized: {
- *    original: string,
- *    w480: string,
- *    w800: string,
- *    w1200: string,
- *    w1600: string,
- *    w2400: string
- *  }
- * } } HeroImage
+ * @typedef {Pick<import('../../../apollo/fragments/post').HeroImage ,'id' | 'resized' | 'resizedWebp'>} HeroImage
  */
 
 /**
@@ -173,6 +163,7 @@ export default function HeroImageAndVideo({
       return (
         <CustomImage
           images={heroImage.resized}
+          imagesWebP={heroImage.resizedWebp}
           loadingImage={'/images/loading@4x.gif'}
           defaultImage={'/images/default-og-img.png'}
           alt={heroCaption ? heroCaption : title}

--- a/packages/mirror-media-next/components/story/shared/related-article-list.js
+++ b/packages/mirror-media-next/components/story/shared/related-article-list.js
@@ -5,18 +5,7 @@ import Image from '@readr-media/react-image'
 import Link from 'next/link'
 
 /**
- * @typedef {import('../../../apollo/fragments/post').HeroImage &
- * {
- *  id: string,
- *  resized: {
- *    original: string,
- *    w480: string,
- *    w800: string,
- *    w1200: string,
- *    w1600: string,
- *    w2400: string
- *  }
- * } } HeroImage
+ * @typedef {Pick<import('../../../apollo/fragments/post').HeroImage ,'id' | 'resized' | 'resizedWebp'>} HeroImage
  */
 
 /**
@@ -155,6 +144,7 @@ export default function RelatedArticleList({ relateds }) {
             >
               <Image
                 images={related.heroImage?.resized}
+                imagesWebP={related?.heroImage?.resizedWebp}
                 alt={related.title}
                 rwd={{
                   mobile: '500px',

--- a/packages/mirror-media-next/components/topic/group/group-articles-item.js
+++ b/packages/mirror-media-next/components/topic/group/group-articles-item.js
@@ -129,6 +129,7 @@ export default function GroupArticlesItem({ item }) {
       <ImageContainer>
         <Image
           images={item.heroImage?.resized}
+          imagesWebP={item.heroImage?.resizedWebp}
           alt={item.title}
           loadingImage="/images/loading.gif"
           defaultImage="/images/default-og-img.png"

--- a/packages/mirror-media-next/components/topic/list/list-articles-item.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles-item.js
@@ -106,12 +106,8 @@ const ItemBrief = styled.div`
  *  slug: string,
  * }} Category
  *
- * @typedef {import('../../../apollo/fragments/photo').Photo & {
- *  id: String,
- *  name: String,
- *  imageFile: import('../../../apollo/fragments/photo').ImageFile,
- *  resized: import('../../../apollo/fragments/photo').Resized
- * }} HeroImage
+ *
+ * @typedef {Pick<import('../../../apollo/fragments/post').HeroImage ,'id' | 'resized' | 'resizedWebp'>} HeroImage
  *
  * @typedef {import('../../../apollo/fragments/post').Post & {
  *  id: string,
@@ -138,6 +134,7 @@ export default function ListArticlesItem({ item }) {
       <ImageContainer>
         <Image
           images={item.heroImage?.resized}
+          imagesWebP={item.heroImage?.resizedWebp}
           alt={item.title}
           loadingImage="/images/loading.gif"
           defaultImage="/images/default-og-img.png"

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -16,7 +16,7 @@
     "@apollo/client": "^3.7.3",
     "@mirrormedia/lilith-draft-renderer": "^1.2.0-alpha.36",
     "@next/font": "^13.1.2",
-    "@readr-media/react-image": "^1.6.0",
+    "@readr-media/react-image": "^2.1.2",
     "@readr-media/share-button": "^1.0.3",
     "@svgr/webpack": "^6.3.1",
     "@twreporter/errors": "^1.1.2",

--- a/packages/mirror-media-next/pages/404.js
+++ b/packages/mirror-media-next/pages/404.js
@@ -250,6 +250,7 @@ export default function Custom404() {
                     loadingImage="/images/loading.gif"
                     defaultImage="/images/default-og-img.png"
                     images={post.heroImage?.resized}
+                    imagesWebP={post.heroImage?.resizedWebp}
                     rwd={{
                       mobile: '284px',
                       tablet: '284px',

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -106,7 +106,7 @@ export default function Story({ postData, headerData, storyLayoutType }) {
    * If it didn't obtain the full content, and the user is logged in, story page will try to get the full content again by using the user's access token as the request payload.
    * If successful, the full content will be displayed; if not, the truncated content will still be shown.
    */
-  console.log('re-render')
+
   const { isLoggedIn, accessToken, isLogInProcessFinished } = useMembership()
   /** @type { [PostContent, React.Dispatch<React.SetStateAction<PostContent>> ]} */
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1858,7 +1858,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@readr-media/react-image@1.6.0", "@readr-media/react-image@^1.6.0":
+"@readr-media/react-image@1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-1.6.0.tgz#1bff81cdaa8b14f255c22b2504df1d09fc783223"
   integrity sha512-k4FOxVlAdvsFY5zP7nczs11LrJ3mA2T6Y7rwoTjpA9GMhlf3wtLWD84/XwcsGXNvHg0gbxQtmOcNvKE1LsZxwg==
@@ -1867,6 +1867,11 @@
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-1.5.1.tgz#d04b809416be6a1432a0a3154f2641292d7b6b8d"
   integrity sha512-BExGQWO158vtfox2mkwjT8khZp00KOwAObnZsQVzO4JNO4RlTog/5u7ccw7WuBd1OR07rlh/jKm4ts+qt78saw==
+
+"@readr-media/react-image@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.1.2.tgz#b479e0a5668ca7ab13d0d6326e6832899700c9f4"
+  integrity sha512-nE/+uLupLIfwUi96RxM1WzLGIrdvEMVxGAUKdimFdIT+ChsymZaxlkDHrC7sUQqJ7FqYGbUF5PNaF2nDNj07vw==
 
 "@readr-media/share-button@^1.0.3":
   version "1.0.3"


### PR DESCRIPTION
## Notable Change
因應套件 `@readr-media/react-image`更新，可支援載入webp圖片，該PR將相關頁面，皆傳入參數`imagesWebp`。
有調整的頁面如下：
1. 文章頁
2. 列表頁：包含一般列表頁、premium列表頁
3. topics group/list 列表頁
4. 404頁
5. 首頁
6. magazine頁

尚未調整頁面如下：
1. 文章頁內文圖片：需調整套件[@mirrormedia/lilith-draft-renderer](https://www.npmjs.com/package/@mirrormedia/lilith-draft-renderer)內容。
2. external頁、externals列表頁（包含暖流頁）：因該頁面的圖片來源為外部合作夥伴提供之圖片檔，不包含webp圖片。
3. section/topic頁：該頁的圖片相關業務邏輯較複雜，日後再確認業務邏輯與可修改的部份。