### PR TITLE
chore(mm-next): bump Dep version

### DIFF
--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",
-    "@mirrormedia/lilith-draft-renderer": "^1.2.0-alpha.36",
+    "@mirrormedia/lilith-draft-renderer": "^1.3.0-alpha.2",
     "@next/font": "^13.1.2",
-    "@readr-media/react-image": "^2.1.2",
+    "@readr-media/react-image": "^2.1.3",
     "@readr-media/share-button": "^1.0.3",
     "@svgr/webpack": "^6.3.1",
     "@twreporter/errors": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1682,12 +1682,12 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@mirrormedia/lilith-draft-renderer@^1.2.0-alpha.36":
-  version "1.2.0-alpha.36"
-  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.36.tgz#cb48a034c0618a40f40b5af949e96e9233bb2869"
-  integrity sha512-mgtVLhGafEmwqxSJN30MXOrJp+vjqnyep60NbteY8T3LSuUjW83BQm58OAHdNGbAKoJ3Ay9JlVFF9kCpTYXaDA==
+"@mirrormedia/lilith-draft-renderer@^1.3.0-alpha.2":
+  version "1.3.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.3.0-alpha.2.tgz#7817063bb1aa61fff5927feab643d82a4dff837b"
+  integrity sha512-Xank+tbnDF1YcHWTjiY9gxaN98WI+N9dKxlTNhL7HzBmBkyVYVI7u7OkK4s/VVEclGau89pb9stFug4sZiqLqQ==
   dependencies:
-    "@readr-media/react-image" "1.6.0"
+    "@readr-media/react-image" "2.1.3"
     body-scroll-lock "3.1.5"
     draft-js "^0.11.7"
     node-html-parser "^6.1.5"
@@ -1858,20 +1858,15 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@readr-media/react-image@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-1.6.0.tgz#1bff81cdaa8b14f255c22b2504df1d09fc783223"
-  integrity sha512-k4FOxVlAdvsFY5zP7nczs11LrJ3mA2T6Y7rwoTjpA9GMhlf3wtLWD84/XwcsGXNvHg0gbxQtmOcNvKE1LsZxwg==
+"@readr-media/react-image@2.1.3", "@readr-media/react-image@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.1.3.tgz#97834255b39f42d15b93449637131d28a3aca168"
+  integrity sha512-XAuKKSqRNSvH/CJAfbBhVE7Ezkaetc0pM3AEKUPydYJP51N6fp8mWfPR0HUSw/7QLElHSGXVKCvyuOpVIXa5eQ==
 
 "@readr-media/react-image@^1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-1.5.1.tgz#d04b809416be6a1432a0a3154f2641292d7b6b8d"
   integrity sha512-BExGQWO158vtfox2mkwjT8khZp00KOwAObnZsQVzO4JNO4RlTog/5u7ccw7WuBd1OR07rlh/jKm4ts+qt78saw==
-
-"@readr-media/react-image@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.1.2.tgz#b479e0a5668ca7ab13d0d6326e6832899700c9f4"
-  integrity sha512-nE/+uLupLIfwUi96RxM1WzLGIrdvEMVxGAUKdimFdIT+ChsymZaxlkDHrC7sUQqJ7FqYGbUF5PNaF2nDNj07vw==
 
 "@readr-media/share-button@^1.0.3":
   version "1.0.3"


### PR DESCRIPTION
## Notable Change
dependencies `@mirrormedia/lilith-draft-renderer` 升版，該版本實作了react-image的webp圖片載入。
dependencies `@readr-media/react-image` 升版，該版本處理了非預期資料結構的錯誤處理。