### PR TITLE
feat(papermag): encrypt tradeInfo and send to newebpay

### DIFF
--- a/packages/mirror-media-next/components/papermag/form-detail/apply-discount.js
+++ b/packages/mirror-media-next/components/papermag/form-detail/apply-discount.js
@@ -154,17 +154,17 @@ const RemoveButton = styled.button`
 export default function ApplyDiscount({
   renewCouponApplied,
   setRenewCouponApplied,
+  loveCode,
+  setLoveCode,
 }) {
-  const [inputValue, setInputValue] = useState('')
-
   const handleInputChange = (event) => {
     const value = event.target.value
     if (/^[0-9]*$/.test(value) && value.length <= 8) {
-      setInputValue(value)
+      setLoveCode(value)
     }
   }
 
-  const isInputValid = inputValue.length === 8
+  const isInputValid = loveCode?.length === 8
 
   const handleConfirmClick = (e) => {
     e.preventDefault()
@@ -175,7 +175,7 @@ export default function ApplyDiscount({
 
   const handleRemoveClick = () => {
     setRenewCouponApplied(false)
-    setInputValue('')
+    setLoveCode('')
   }
 
   return (
@@ -190,7 +190,7 @@ export default function ApplyDiscount({
           <label>MR</label>
           <input
             placeholder="12345678"
-            value={inputValue}
+            value={loveCode}
             onChange={handleInputChange}
             disabled={renewCouponApplied}
           />

--- a/packages/mirror-media-next/components/papermag/form-detail/newebpay-form.js
+++ b/packages/mirror-media-next/components/papermag/form-detail/newebpay-form.js
@@ -1,0 +1,42 @@
+import styled from 'styled-components'
+
+const NewebpayFormContainer = styled.div`
+  h1 {
+    text-align: center;
+    font-size: 36px;
+  }
+
+  button {
+    display: none;
+  }
+`
+
+/**
+ * @param {Object} props
+ * @param {string} props.merchantId
+ * @param {string} props.tradeInfo
+ * @param {string} props.tradeSha
+ * @param {string} props.version
+ * @param {string} props.newebpayApiUrl
+ * @returns
+ */
+export default function NewebpayForm({
+  merchantId = '',
+  tradeInfo = '',
+  tradeSha = '',
+  version = '',
+  newebpayApiUrl = 'https://ccore.newebpay.com/MPG/mpg_gateway',
+}) {
+  return (
+    <NewebpayFormContainer>
+      <form id="data_set" name="newebpay" method="post" action={newebpayApiUrl}>
+        <input type="hidden" name="MerchantID" value={merchantId} />
+        <input type="hidden" name="TradeInfo" value={tradeInfo} />
+        <input type="hidden" name="TradeSha" value={tradeSha} />
+        <input type="hidden" name="Version" value={version} />
+
+        <button>Submit</button>
+      </form>
+    </NewebpayFormContainer>
+  )
+}

--- a/packages/mirror-media-next/components/papermag/form-detail/newebpay-form.js
+++ b/packages/mirror-media-next/components/papermag/form-detail/newebpay-form.js
@@ -18,7 +18,7 @@ const NewebpayFormContainer = styled.div`
  * @param {string} props.tradeSha
  * @param {string} props.version
  * @param {string} props.newebpayApiUrl
- * @returns
+ * @returns {JSX.Element}
  */
 export default function NewebpayForm({
   merchantId = '',

--- a/packages/mirror-media-next/components/papermag/subscribe-papermag-form.js
+++ b/packages/mirror-media-next/components/papermag/subscribe-papermag-form.js
@@ -14,7 +14,6 @@ import NewebpayForm from './form-detail/newebpay-form'
 
 import { NEWEBPAY_PAPERMAG_API_URL } from '../../config/index.mjs'
 import { useRouter } from 'next/router'
-import { nextTick } from 'process'
 
 const Form = styled.form`
   display: flex;

--- a/packages/mirror-media-next/components/papermag/subscribe-papermag-form.js
+++ b/packages/mirror-media-next/components/papermag/subscribe-papermag-form.js
@@ -14,6 +14,7 @@ import NewebpayForm from './form-detail/newebpay-form'
 
 import { NEWEBPAY_PAPERMAG_API_URL } from '../../config/index.mjs'
 import { useRouter } from 'next/router'
+import { nextTick } from 'process'
 
 const Form = styled.form`
   display: flex;
@@ -125,6 +126,7 @@ export default function SubscribePaperMagForm({ plan }) {
         receiveMobile: recipientValues.cellphone,
         loveCode,
         carrierType: receiptData,
+        returnUrl: `${window.location.origin}/papermag/return`,
       },
     }
 
@@ -139,13 +141,12 @@ export default function SubscribePaperMagForm({ plan }) {
     }
 
     setPaymentPlayload(data.data)
+    // 為了確保資料先填入 form 中而使用 setTimeout
+    setTimeout(() => {
+      const formDOM = document.forms.newebpay
+      formDOM.submit()
+    }, 0)
   }
-
-  useEffect(() => {
-    if (!paymentPayload.MerchantID) return
-    const formDOM = document.forms.newebpay
-    formDOM.submit()
-  }, [paymentPayload])
 
   return (
     <>

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -3,6 +3,10 @@ const GCP_PROJECT_ID = 'mirrormedia-1470651750304'
 // The following variables are from environment variables
 
 const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
+const NEWEBPAY_PAPERMAG_KEY =
+  process.env.NEWEBPAY_PAPERMAG_KEY || 'newebpay-papermag-key'
+const NEWEBPAY_PAPERMAG_IV =
+  process.env.NEWEBPAY_PAPERMAG_IV || 'newebpay-papermag-iv'
 
 // The following variables are given values according to different `ENV`
 
@@ -23,6 +27,7 @@ let GTM_ID = ''
 let SEARCH_URL = 'search-url/search'
 let URL_STATIC_POPULAR_NEWS = ''
 let URL_STATIC_404_POPULAR_NEWS = ''
+let NEWEBPAY_PAPERMAG_API_URL = ''
 
 let GPT_MODE = ''
 // It is safe to expose the configuration of Firebase.
@@ -44,6 +49,10 @@ switch (ENV) {
     URL_STATIC_POPULAR_NEWS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/popular.json`
     URL_STATIC_404_POPULAR_NEWS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/404_popular.json`
     URL_STATIC_HEADER_HEADERS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/header_headers.json`
+
+    NEWEBPAY_PAPERMAG_API_URL =
+      process.env.NEWEBPAY_PAPERMAG_API_URL ||
+      'https://core.newebpay.com/MPG/mpg_gateway'
 
     DONATION_PAGE_URL = 'https://mirrormedia.oen.tw/'
     GA_MEASUREMENT_ID = 'G-341XFN0675'
@@ -79,6 +88,10 @@ switch (ENV) {
     URL_STATIC_404_POPULAR_NEWS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/404_popular.json`
     URL_STATIC_HEADER_HEADERS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/header_headers.json`
 
+    NEWEBPAY_PAPERMAG_API_URL =
+      process.env.NEWEBPAY_PAPERMAG_API_URL ||
+      'https://ccore.newebpay.com/MPG/mpg_gateway'
+
     DONATION_PAGE_URL = 'https://mirrormedia.oen.tw/'
     GA_MEASUREMENT_ID = 'G-32D7P3MJ8B'
     GTM_ID = 'GTM-KVDZ27K'
@@ -112,6 +125,10 @@ switch (ENV) {
     URL_STATIC_404_POPULAR_NEWS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/404_popular.json`
     URL_STATIC_HEADER_HEADERS = `https://${WEEKLY_API_SERVER_ORIGIN}/gcs/files/json/header_headers.json`
 
+    NEWEBPAY_PAPERMAG_API_URL =
+      process.env.NEWEBPAY_PAPERMAG_API_URL ||
+      'https://ccore.newebpay.com/MPG/mpg_gateway'
+
     DONATION_PAGE_URL = 'https://mirrormedia.testing.oen.tw/'
     GA_MEASUREMENT_ID = 'G-36HYH6NF6P'
     GTM_ID = 'GTM-PBNLSMX'
@@ -137,6 +154,10 @@ switch (ENV) {
     WEEKLY_API_SERVER_ORIGIN =
       'adam-weekly-api-server-dev-ufaummkd5q-de.a.run.app'
     WEEKLY_API_SERVER_YOUTUBE_ENDPOINT = `https://${WEEKLY_API_SERVER_ORIGIN}/youtube`
+
+    NEWEBPAY_PAPERMAG_API_URL =
+      process.env.NEWEBPAY_PAPERMAG_API_URL ||
+      'https://ccore.newebpay.com/MPG/mpg_gateway'
 
     URL_STATIC_PREMIUM_SECTIONS = `http://localhost:8080/json/header_member.json`
     URL_STATIC_NORMAL_SECTIONS = `http://localhost:8080/json/header_sections.json`
@@ -184,4 +205,7 @@ export {
   GPT_MODE,
   FIREBASE_CONFIG,
   URL_STATIC_HEADER_HEADERS,
+  NEWEBPAY_PAPERMAG_API_URL,
+  NEWEBPAY_PAPERMAG_KEY,
+  NEWEBPAY_PAPERMAG_IV,
 }

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.3",
     "@mirrormedia/lilith-draft-renderer": "^1.3.0-alpha.2",
+    "@mirrormedia/newebpay-node": "^1.0.8",
     "@next/font": "^13.1.2",
     "@readr-media/react-image": "^2.1.3",
     "@readr-media/share-button": "^1.0.3",

--- a/packages/mirror-media-next/pages/api/papermag.js
+++ b/packages/mirror-media-next/pages/api/papermag.js
@@ -4,7 +4,7 @@ import {
   NEWEBPAY_PAPERMAG_IV,
 } from '../../config/index.mjs'
 
-async function getPaymentDataOfPapermagSubscription(gateWayPayload, origin) {
+async function getPaymentDataOfPapermagSubscription(gateWayPayload) {
   const data = {
     MerchantID: 'MS323443601',
     RespondType: 'JSON',
@@ -19,17 +19,14 @@ async function getPaymentDataOfPapermagSubscription(gateWayPayload, origin) {
     NotifyURL:
       'https://mm-subscription-webhooks-publishers-dev-ufaummkd5q-de.a.run.app/newebpay/magazine',
   }
-  data.ReturnURL = `${origin}/papermag/return`
   return data
 }
 
 export default async function EncryptInfo(req, res) {
   const tradeInfo = req.body
-  const { origin } = req.headers
   try {
     const infoForNewebpay = await getPaymentDataOfPapermagSubscription(
-      tradeInfo,
-      origin
+      tradeInfo
     )
 
     const newebpay = new NewebPay(NEWEBPAY_PAPERMAG_KEY, NEWEBPAY_PAPERMAG_IV)

--- a/packages/mirror-media-next/pages/api/papermag.js
+++ b/packages/mirror-media-next/pages/api/papermag.js
@@ -4,13 +4,20 @@ import {
   NEWEBPAY_PAPERMAG_IV,
 } from '../../config/index.mjs'
 
+function getRandomMerchantOrderNo() {
+  const min = 1000000000
+  const max = 9999999999
+  const randomTenDigitNumber = Math.floor(Math.random() * (max - min + 1)) + min
+  return 'P' + randomTenDigitNumber
+}
+
 async function getPaymentDataOfPapermagSubscription(gateWayPayload) {
   const data = {
     MerchantID: 'MS323443601',
     RespondType: 'JSON',
     TimeStamp: '1694018103',
     Version: '1.6',
-    MerchantOrderNo: 'P2309070697',
+    MerchantOrderNo: getRandomMerchantOrderNo(),
     Amt: 7280,
     ItemDesc: '一年鏡週刊 52 期加掛號運費',
     LoginType: 0,

--- a/packages/mirror-media-next/pages/api/papermag.js
+++ b/packages/mirror-media-next/pages/api/papermag.js
@@ -1,0 +1,61 @@
+import NewebPay from '@mirrormedia/newebpay-node'
+import {
+  NEWEBPAY_PAPERMAG_KEY,
+  NEWEBPAY_PAPERMAG_IV,
+} from '../../config/index.mjs'
+
+async function getPaymentDataOfPapermagSubscription(gateWayPayload, origin) {
+  const data = {
+    MerchantID: 'MS323443601',
+    RespondType: 'JSON',
+    TimeStamp: '1694018103',
+    Version: '1.6',
+    MerchantOrderNo: 'P2309070697',
+    Amt: 7280,
+    ItemDesc: '一年鏡週刊 52 期加掛號運費',
+    LoginType: 0,
+    Email: 'test@ww.ww',
+    TradeLimit: 900,
+    NotifyURL:
+      'https://mm-subscription-webhooks-publishers-dev-ufaummkd5q-de.a.run.app/newebpay/magazine',
+  }
+  data.ReturnURL = `${origin}/papermag/return`
+  return data
+}
+
+export default async function EncryptInfo(req, res) {
+  const tradeInfo = req.body
+  const { origin } = req.headers
+  try {
+    const infoForNewebpay = await getPaymentDataOfPapermagSubscription(
+      tradeInfo,
+      origin
+    )
+
+    const newebpay = new NewebPay(NEWEBPAY_PAPERMAG_KEY, NEWEBPAY_PAPERMAG_IV)
+    const encryptPostData = await newebpay.getEncryptedFormPostData(
+      infoForNewebpay
+    )
+
+    console.log(
+      JSON.stringify({
+        message: `papermag payload:`,
+        debugPayload: {
+          'req.body': req.body,
+        },
+        'logging.googleapis.com/trace': `projects/mirrormedia-1470651750304/traces/papermag`,
+      })
+    )
+
+    res.send({
+      status: 'success',
+      data: encryptPostData,
+    })
+  } catch (e) {
+    console.log(e)
+    res.status(500).send({
+      status: 'error',
+      message: e.message,
+    })
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1692,6 +1692,14 @@
     draft-js "^0.11.7"
     node-html-parser "^6.1.5"
 
+"@mirrormedia/newebpay-node@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/newebpay-node/-/newebpay-node-1.0.8.tgz#b7925edf92c4c3b67989c871c3f6ae0ca10b0105"
+  integrity sha512-yl8lEraQMKJkvElzEX64ZCG/rtTKT+hg6nJxokzYI7Xb/fA1f5SA2e+4AXZkDf4mwxdHZXjlwJsEvBUHRU9H3A==
+  dependencies:
+    crypto "^1.0.1"
+    querystring "^0.2.1"
+
 "@next/env@13.0.7":
   version "13.0.7"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-13.0.7.tgz#7b6ccd9006d3fb57c369e3fb62b28e15324141e9"
@@ -2870,6 +2878,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
+  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
 
 css-color-keywords@^1.0.0:
   version "1.0.0"
@@ -5518,6 +5531,11 @@ qs@6.11.0:
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
+
+querystring@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"
+  integrity sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
 
 queue-microtask@^1.2.2:
   version "1.2.3"


### PR DESCRIPTION
### 描述
- 點擊「確認訂購」後，先將資料存入 db，並將拿回來的資料加密，最後送給藍新。
- 因為目前新的 db 還沒好，因此在 `getPaymentDataOfPapermagSubscription` 中先寫了一個假資料，方便測試以及之後後端建立 api 參考。
- 因為要存入 db，將優惠碼 `loveCode` 從 `ApplyDiscount` 抽出。