### PR TITLE
feat(mm-next): slice story content based on special business logic

### DIFF
--- a/packages/mirror-media-next/components/amp/amp-main.js
+++ b/packages/mirror-media-next/components/amp/amp-main.js
@@ -9,7 +9,10 @@ import ArticleBrief from '../story/shared/brief'
 import DraftRenderBlock from '../story/shared/draft-renderer-block'
 import useSharedUrl from '../../hooks/use-shared-url'
 import AmpGptAd from '../../components/amp/amp-ads/amp-gpt-ad'
-import { copyAndSliceDraftBlock, getBlocksCount } from '../../utils/story'
+import {
+  copyAndSliceDraftBlock,
+  getSlicedIndexAndUnstyledBlocksCount,
+} from '../../utils/story'
 import { getAmpGptDataSlotSection } from '../../utils/ad'
 
 const MainWrapper = styled.div`
@@ -171,8 +174,8 @@ export default function AmpMain({ postData, isMember }) {
   ]
 
   const sectionSlot = getAmpGptDataSlotSection(section)
-  const blocksLength = getBlocksCount(postContent)
-
+  const { slicedIndex, unstyledBlocksCount } =
+    getSlicedIndexAndUnstyledBlocksCount(content)
   return (
     <MainWrapper>
       <AmpInfo
@@ -217,25 +220,36 @@ export default function AmpMain({ postData, isMember }) {
 
       <AmpContentContainer>
         <DraftRenderBlock
-          rawContentBlock={copyAndSliceDraftBlock(postContent, 0, 1)}
+          rawContentBlock={copyAndSliceDraftBlock(
+            postContent,
+            0,
+            slicedIndex.mb[0]
+          )}
           contentLayout="amp"
         />
 
-        {blocksLength > 1 && (
+        {unstyledBlocksCount > 1 && (
           <>
             <StyledAmpGptAd section={sectionSlot} position="AT1" />
-            <DraftRenderBlock
-              rawContentBlock={copyAndSliceDraftBlock(postContent, 1, 5)}
-              contentLayout="amp"
-            />
           </>
         )}
+        <DraftRenderBlock
+          rawContentBlock={copyAndSliceDraftBlock(
+            postContent,
+            slicedIndex.mb[0],
+            slicedIndex.mb[1]
+          )}
+          contentLayout="amp"
+        />
 
-        {blocksLength > 5 && (
+        {unstyledBlocksCount > 5 && (
           <>
             <StyledAmpGptAd section={sectionSlot} position="AT2" />
             <DraftRenderBlock
-              rawContentBlock={copyAndSliceDraftBlock(postContent, 5)}
+              rawContentBlock={copyAndSliceDraftBlock(
+                postContent,
+                slicedIndex.mb[1]
+              )}
               contentLayout="amp"
             />
           </>

--- a/packages/mirror-media-next/components/story/normal/article-content.js
+++ b/packages/mirror-media-next/components/story/normal/article-content.js
@@ -1,6 +1,9 @@
 import styled from 'styled-components'
 import DraftRenderBlock from '../shared/draft-renderer-block'
-import { copyAndSliceDraftBlock, getBlocksCount } from '../../../utils/story'
+import {
+  copyAndSliceDraftBlock,
+  getSlicedIndexAndUnstyledBlocksCount,
+} from '../../../utils/story'
 import dynamic from 'next/dynamic'
 import useWindowDimensions from '../../../hooks/use-window-dimensions'
 import { useDisplayAd } from '../../../hooks/useDisplayAd'
@@ -60,48 +63,47 @@ export default function ArticleContent({
   const shouldShowAd = useDisplayAd(hiddenAdvertised)
   const windowDimensions = useWindowDimensions()
 
-  const blocksLength = getBlocksCount(content)
+  const { slicedIndex, unstyledBlocksCount } =
+    getSlicedIndexAndUnstyledBlocksCount(content)
 
   //The GPT advertisement for the `mobile` version includes `AT1` & `AT2`
   const MB_contentJsx = (
     <Wrapper>
       <DraftRenderBlock
-        rawContentBlock={copyAndSliceDraftBlock(content, 0, 1)}
+        rawContentBlock={copyAndSliceDraftBlock(content, 0, slicedIndex.mb[0])}
         contentLayout="normal"
         wrapper={(children) => <ContentContainer>{children}</ContentContainer>}
       />
 
-      {blocksLength > 1 && (
+      {unstyledBlocksCount > 1 && (
         <>
           {shouldShowAd && (
             <StyledGPTAd pageKey={pageKeyForGptAd} adKey="MB_AT1" />
           )}
-
-          <DraftRenderBlock
-            rawContentBlock={copyAndSliceDraftBlock(content, 1, 5)}
-            contentLayout="normal"
-            wrapper={(children) => (
-              <ContentContainer>{children}</ContentContainer>
-            )}
-          />
         </>
       )}
+      <DraftRenderBlock
+        rawContentBlock={copyAndSliceDraftBlock(
+          content,
+          slicedIndex.mb[0],
+          slicedIndex.mb[1]
+        )}
+        contentLayout="normal"
+        wrapper={(children) => <ContentContainer>{children}</ContentContainer>}
+      />
 
-      {blocksLength > 5 && (
+      {unstyledBlocksCount > 5 && (
         <>
           {shouldShowAd && (
             <StyledGPTAd pageKey={pageKeyForGptAd} adKey="MB_AT2" />
           )}
-
-          <DraftRenderBlock
-            rawContentBlock={copyAndSliceDraftBlock(content, 5)}
-            contentLayout="normal"
-            wrapper={(children) => (
-              <ContentContainer>{children}</ContentContainer>
-            )}
-          />
         </>
       )}
+      <DraftRenderBlock
+        rawContentBlock={copyAndSliceDraftBlock(content, slicedIndex.mb[1])}
+        contentLayout="normal"
+        wrapper={(children) => <ContentContainer>{children}</ContentContainer>}
+      />
     </Wrapper>
   )
 
@@ -109,26 +111,23 @@ export default function ArticleContent({
   const PC_contentJsx = (
     <Wrapper>
       <DraftRenderBlock
-        rawContentBlock={copyAndSliceDraftBlock(content, 0, 3)}
+        rawContentBlock={copyAndSliceDraftBlock(content, 0, slicedIndex.pc[0])}
         contentLayout="normal"
         wrapper={(children) => <ContentContainer>{children}</ContentContainer>}
       />
 
-      {blocksLength > 3 && (
+      {unstyledBlocksCount > 3 && (
         <>
           {shouldShowAd && (
             <StyledGPTAd pageKey={pageKeyForGptAd} adKey="PC_AT1" />
           )}
-
-          <DraftRenderBlock
-            rawContentBlock={copyAndSliceDraftBlock(content, 3)}
-            contentLayout="normal"
-            wrapper={(children) => (
-              <ContentContainer>{children}</ContentContainer>
-            )}
-          />
         </>
       )}
+      <DraftRenderBlock
+        rawContentBlock={copyAndSliceDraftBlock(content, slicedIndex.pc[0])}
+        contentLayout="normal"
+        wrapper={(children) => <ContentContainer>{children}</ContentContainer>}
+      />
     </Wrapper>
   )
 

--- a/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
+++ b/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
@@ -101,7 +101,6 @@ export default function HeroImageAndVideo({
             imagesWebP={heroImage.resizedWebp}
             loadingImage={'/images/loading@4x.gif'}
             defaultImage={'/images/default-og-img.png'}
-            debugMode={true}
             alt={heroCaption ? heroCaption : title}
             objectFit={'cover'}
             priority={true}

--- a/packages/mirror-media-next/components/story/normal/related-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/related-article-list.js
@@ -168,7 +168,6 @@ export default function RelatedArticleList({
               <Image
                 images={related.heroImage?.resized}
                 imagesWebP={related.heroImage?.resizedWebp}
-                debugMode={true}
                 alt={related.title}
                 rwd={{
                   mobile: '500px',

--- a/packages/mirror-media-next/components/story/premium/article-content.js
+++ b/packages/mirror-media-next/components/story/premium/article-content.js
@@ -1,7 +1,10 @@
 import styled from 'styled-components'
 import DraftRenderBlock from '../shared/draft-renderer-block'
 import dynamic from 'next/dynamic'
-import { copyAndSliceDraftBlock, getBlocksCount } from '../../../utils/story'
+import {
+  copyAndSliceDraftBlock,
+  getSlicedIndexAndUnstyledBlocksCount,
+} from '../../../utils/story'
 import useWindowDimensions from '../../../hooks/use-window-dimensions'
 import { useDisplayAd } from '../../../hooks/useDisplayAd'
 import { SECTION_IDS } from '../../../constants'
@@ -48,32 +51,30 @@ export default function PremiumArticleContent({
 }) {
   const shouldShowAd = useDisplayAd(hiddenAdvertised)
   const windowDimensions = useWindowDimensions()
-  const blocksLength = getBlocksCount(content)
+  const { slicedIndex, unstyledBlocksCount } =
+    getSlicedIndexAndUnstyledBlocksCount(content, { mb: [0], pc: [] })
 
   //The GPT advertisement for the `mobile` version includes `AT1`
   const MB_contentJsx = (
     <section className={className}>
       <DraftRenderBlock
-        rawContentBlock={copyAndSliceDraftBlock(content, 0, 1)}
+        rawContentBlock={copyAndSliceDraftBlock(content, 0, slicedIndex.mb[0])}
         contentLayout="premium"
         wrapper={(children) => <ContentContainer>{children}</ContentContainer>}
       />
 
-      {blocksLength > 1 && (
+      {unstyledBlocksCount > 1 && (
         <>
           {shouldShowAd && (
             <StyledGPTAd pageKey={pageKeyForGptAd} adKey="MB_AT1" />
           )}
-
-          <DraftRenderBlock
-            rawContentBlock={copyAndSliceDraftBlock(content, 1)}
-            contentLayout="premium"
-            wrapper={(children) => (
-              <ContentContainer>{children}</ContentContainer>
-            )}
-          />
         </>
       )}
+      <DraftRenderBlock
+        rawContentBlock={copyAndSliceDraftBlock(content, slicedIndex.mb[0])}
+        contentLayout="premium"
+        wrapper={(children) => <ContentContainer>{children}</ContentContainer>}
+      />
     </section>
   )
 


### PR DESCRIPTION
## Notable Change
1. 調整切分文章content邏輯：使用本次PR新增的函式`getSlicedIndexAndUnstyledBlocksCount`，計算並回傳切分文章content的斷點，並以該斷點作為參數傳入既有函數`copyAndSliceDraftBlock`。

## Implement Detail

依據先前討論結果，原本打算調整既有函數`copyAndSliceDraftBlock`，概略的調整方向有兩個：
1. 使用`Array.filter`，將content.blocks中 type 為`unstyled` 的元素取出並另存為一個陣列（以下簡稱陣列A）。並將陣列A透過`Array.slice(startIndex, endIndex)`，取得切分後首個跟最後一個的key，再將key使用`Array.findIndex`，計算該key在content.blocks中的index為何。
2. 新增一個變數`_startIndex`、`_endIndex`，並使用for loop 比對參數`content.blocks`中每個元素的type，如果不為`unstyled` 的話，則跳過，反之，則將變數`_startIndex`、`_endIndex` +1，直到`_startIndex`、`_endIndex`的值，分別與startIndex、endIndex相等。

但兩種做法都遇到一個問題：當`startIndex`不為零時，content.blocks.slice()的首個參數會計算錯誤。
以下方陣列為例，假如1為`unstyled`，0為非`unstyled`：
`[1, 0, 0, 1, 1, 1, 0, 0]`
當我執行`copyAndSliceDraftBlock(content, 0 , 1)`，會回傳`[1]`，這是正確的，但如果執行`copyAndSliceDraftBlock(content, 1 , 2)`的話，照理說會回傳`[0,0,1]`，但是方法一會回傳[1,1]，原因在於陣列A中的key是unstyled的，以該item透過findIndex尋找`content.blocks`的index的話，自然會尋找到`1` 而非 0。
方法二則會正確回傳`[0,0,1]`。

為了解決方法一的錯誤，曾經將方法一中的`content.blocks.slice()`的第一個參數start，改為使用參數`startIndex`，是可以解決原本的問題，但是如果content.blocks改為以下陣列，則會發生錯誤：
`[1, 1, 1, 0, 0, 1, 1, 0]`
方法一：`copyAndSliceDraftBlock(content, 0 , 1)`會回傳`[1,1,1,0]`，這是正確的，但是`copyAndSliceDraftBlock(content, 1, 2)` 則會回傳`[1,1,0,0]`，但照理是要回傳`[0,0]`。
方法二：如果以`[1, 1, 1, 0, 0, 0, 1, 0]`試驗方法二的話，`copyAndSliceDraftBlock(content, 0 , 1)` 會回傳`[1,1,1,0]`，但`copyAndSliceDraftBlock(content, 1, 2)`卻會回傳`[1,1,0,0]`，但應回傳[0,0]。

而兩個的原因都出在，我們一個頁面會執行多次函式`copyAndSliceDraftBlock()`，但首次切分的endIndex，應該也是第二次切分的startIndex，但是現在的方法一與方法二都無法做到這件事（另一方面，方法一與方法二的計算方式都過於複雜且冗長，方法二甚至要跑兩個for loop，恐有效能問題）。

而這次的解法，則是不改函式`copyAndSliceDraftBlock()`，而是另外新增一個函式`getSlicedIndexAndUnstyledBlocksCount`，以此來計算需要切分的斷點為何。
與方法一、方法二相比，這個方法可以知道每次切分的斷點為何，進而達到「首次切分的endIndex，應該也是第二次切分的startIndex」這件事情。

另外，這個函式也會回傳另一屬性`unstyledBlocksCount`，其用途在於，原本決定要切分多次是透過變數[`blockLength`](https://github.com/mirror-media/Adam/pull/517/commits/723ef01b7ebc0d5c6daed809ec7e639ba849885a#diff-f52b084774873699ae31613574a65bce226bf341cf9a08d043f243dcade17bbbL74)決定，而該變數的計算基礎為扣除空行、空白的段落數量，這個計算與原始的切分斷點計算基礎相同（比如說story頁normal版型的mb: 1跟5）。但是隨著切分斷點改變以`getSlicedIndexAndUnstyledBlocksCount`所回傳的數值為基礎，而該回傳數值又是以content.blocks中unstyled的數量為基礎。
舉例來說，假設content.blocks為`[1, 0, 0, 0, 0, 0, 0, 0]`，`blockLength`為8，但是其中unstyled的`blockLength`為1，原本的業務邏輯，手機版會將其拆分為`[1] , [0, 0, 0, 0], [0, 0, 0]`，但是新的業務邏輯只會拆分成為`[1] , [0, 0, 0, 0, 0, 0, 0]`。依據新的業務邏輯，需要改為使用`unstyledBlocksCount`來決定其中是否要插入廣告，否則會變成`[1] ,(廣告A) [0, 0, 0, 0, 0, 0, 0] (廣告B),[]`，但實際上只需要廣告A即可。

## Ref
1. [Asana card](https://app.asana.com/0/1181156545719626/1205321495078422/f)
2. 方法一可參考此[branch](https://github.com/dyfu95/Adam/tree/0906-content-slice-1)，不過寫得較為凌亂。
3. 方法二可參考此[branch](https://github.com/dyfu95/Adam/tree/0906-content-slice-2)，不過寫得較為凌亂。

## Note
該PR會先merge供PM與需求方驗收，若有調整建議，會另開PR修正。

