### PR TITLE
refactor(mm-next): replace `<a>` by `next/link` in header, add `key` in listing page

### DIFF
--- a/packages/mirror-media-next/components/mobile-sidebar.js
+++ b/packages/mirror-media-next/components/mobile-sidebar.js
@@ -4,7 +4,7 @@ import useClickOutside from '../hooks/useClickOutside'
 import Link from 'next/link'
 import HamburgerButton from './shared/hamburger-button'
 import CloseButton from './shared/close-button'
-
+import { useRouter } from 'next/router'
 /**
  * @typedef {import('../apollo/fragments/section').Section} Section
  */
@@ -277,22 +277,32 @@ export default function MobileSidebar({
   promotions,
   socialMedia,
 }) {
+  const router = useRouter()
+
   const [openSidebar, setOpenSidebar] = useState(false)
   const [openSection, setOpenSection] = useState('')
   const sideBarRef = useRef(null)
   useClickOutside(sideBarRef, () => {
     setOpenSidebar(false)
   })
-
+  const handleOnClick = (e, href) => {
+    e.preventDefault()
+    setOpenSidebar(false)
+    router.push(href)
+  }
   const sectionsAndCategoriesJsx = sectionsAndCategories.map((item) => {
     switch (item.type) {
       case 'section':
         return (
           <Fragment key={item.order}>
             <Section sectionSlug={item.slug}>
-              <a style={{ width: '50%' }} href={item.href}>
+              <Link
+                style={{ width: '50%' }}
+                href={item.href}
+                onClick={(e) => handleOnClick(e, item.href)}
+              >
                 <h3>{item.name}</h3>
-              </a>
+              </Link>
               <SectionToggle
                 onClick={() => setOpenSection(item.slug)}
                 shouldOpen={item.slug === openSection}
@@ -304,9 +314,13 @@ export default function MobileSidebar({
               sectionSlug={item.slug}
             >
               {item.categories.map((category) => (
-                <a key={category.id} href={category.href}>
+                <Link
+                  key={category.id}
+                  href={category.href}
+                  onClick={(e) => handleOnClick(e, category.href)}
+                >
                   {category.name}
-                </a>
+                </Link>
               ))}
             </Categories>
           </Fragment>
@@ -316,9 +330,13 @@ export default function MobileSidebar({
 
         return (
           <Section key={item.order} sectionSlug={renderSectionSlug}>
-            <a style={{ width: '100%' }} href={item.href}>
+            <Link
+              style={{ width: '100%' }}
+              href={item.href}
+              onClick={(e) => handleOnClick(e, item.href)}
+            >
               <h3>{item.name}</h3>
-            </a>
+            </Link>
           </Section>
         )
       default:
@@ -348,7 +366,7 @@ export default function MobileSidebar({
           <SubBrandList>
             {subBrands.map((brand) => (
               <li key={brand.name}>
-                <a
+                <Link
                   href={brand.href}
                   target="_blank"
                   rel="noopener noreferer noreferrer"
@@ -358,7 +376,7 @@ export default function MobileSidebar({
                     src={`/images/${brand.name}-colorless.png`}
                     alt={brand.title}
                   />
-                </a>
+                </Link>
               </li>
             ))}
           </SubBrandList>
@@ -374,7 +392,7 @@ export default function MobileSidebar({
         </SideBarBottom>
         <SocialMediaList>
           {socialMedia.map(({ name, href }) => (
-            <a
+            <Link
               key={name}
               href={href}
               target="_blank"
@@ -386,7 +404,7 @@ export default function MobileSidebar({
                 src="/images/transperent.png"
                 alt={name}
               ></img>
-            </a>
+            </Link>
           ))}
         </SocialMediaList>
       </SideBar>

--- a/packages/mirror-media-next/components/nav-sections.js
+++ b/packages/mirror-media-next/components/nav-sections.js
@@ -126,7 +126,7 @@ const Section = styled.li`
     }
   }
 `
-const SectionLink = styled.a`
+const SectionLink = styled(Link)`
   display: block;
   width: 100%;
   font-weight: 700;
@@ -168,7 +168,7 @@ const SectionDropDown = styled.div`
     }
   }
 `
-const CategoryLink = styled.a`
+const CategoryLink = styled(Link)`
   display: block;
   &:hover {
     ${

--- a/packages/mirror-media-next/components/nav-topics.js
+++ b/packages/mirror-media-next/components/nav-topics.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-
+import Link from 'next/link'
 /**
  * @typedef {Pick<import('../apollo/fragments/topic').Topic, 'id' | 'slug' | 'name'>[]} Topics
  */
@@ -16,7 +16,7 @@ const TopicsWrapper = styled.section`
   }
 `
 
-const Topic = styled.a`
+const Topic = styled(Link)`
   font-size: 16px;
   line-height: 29px;
   height: 100%;

--- a/packages/mirror-media-next/components/premium-header.js
+++ b/packages/mirror-media-next/components/premium-header.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react'
 import styled from 'styled-components'
-
+import Link from 'next/link'
 import SearchBarDesktop from './search-bar-desktop'
 import { Z_INDEX } from '../constants'
 import { DEFAULT_PREMIUM_SECTIONS_DATA } from '../constants/header'
@@ -230,10 +230,9 @@ export default function PremiumHeader({
   return (
     <HeaderWrapper shouldSticky={shouldShowSubtitleNavigator}>
       <HeaderTop>
-        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-        <a href="/">
+        <Link href="/">
           <HeaderLogo />
-        </a>
+        </Link>
         <ActionWrapper>
           <SearchBarDesktop
             searchTerms={searchTerms}

--- a/packages/mirror-media-next/components/premium-mobile-sidebar.js
+++ b/packages/mirror-media-next/components/premium-mobile-sidebar.js
@@ -2,7 +2,8 @@ import styled, { css } from 'styled-components'
 import React, { Fragment, useState, useRef } from 'react'
 import useClickOutside from '../hooks/useClickOutside'
 import NavSubtitleNavigator from './story/shared/nav-subtitle-navigator'
-
+import Link from 'next/link'
+import { useRouter } from 'next/router'
 /**
  * @typedef {import('../type/theme').Theme} Theme
  */
@@ -235,13 +236,18 @@ export default function PremiumMobileSidebar({
   shouldShowSubtitleNavigator = false,
   h2AndH3Block = [],
 }) {
+  const router = useRouter()
   const [openSidebar, setOpenSidebar] = useState(false)
   const [openSection, setOpenSection] = useState('')
   const sideBarRef = useRef(null)
   useClickOutside(sideBarRef, () => {
     setOpenSidebar(false)
   })
-
+  const handleOnClick = (e, href) => {
+    e.preventDefault()
+    setOpenSidebar(false)
+    router.push(href)
+  }
   return (
     <>
       <SideBarButton onClick={() => setOpenSidebar((val) => !val)}>
@@ -266,9 +272,13 @@ export default function PremiumMobileSidebar({
           {sections.map(({ id, name, categories, slug }) => (
             <Fragment key={id}>
               <Section>
-                <a style={{ width: '50%' }} href={`/premiumsection/${slug}`}>
+                <Link
+                  style={{ width: '50%' }}
+                  href={`/premiumsection/${slug}`}
+                  onClick={(e) => handleOnClick(e, `/premiumsection/${slug}`)}
+                >
                   <h3>{name}</h3>
-                </a>
+                </Link>
                 <SectionToggle
                   onClick={() => setOpenSection(slug)}
                   shouldOpen={slug === openSection}
@@ -280,9 +290,15 @@ export default function PremiumMobileSidebar({
                 sectionSlug={slug}
               >
                 {categories.map((category) => (
-                  <a key={category.id} href={`/category/${category.slug}`}>
+                  <Link
+                    key={category.id}
+                    href={`/category/${category.slug}`}
+                    onClick={(e) =>
+                      handleOnClick(e, `/category/${category.slug}`)
+                    }
+                  >
                     {category.name}
-                  </a>
+                  </Link>
                 ))}
               </Categories>
             </Fragment>

--- a/packages/mirror-media-next/components/premium-nav-sections.js
+++ b/packages/mirror-media-next/components/premium-nav-sections.js
@@ -1,7 +1,7 @@
 //TODO: When user at certain section, at category which belongs to certain section, at story which belongs to certain section
 //component <Section> will change color of title to section color defined at /styles/sections-color.
-//TODO: Replace <a> to <Link> for Single Page Application
 import styled, { css } from 'styled-components'
+import Link from 'next/link'
 /**
  * @typedef {import('../type/theme').Theme} Theme
  */
@@ -112,7 +112,7 @@ const Section = styled.li`
   }
 `
 
-const SectionLink = styled.a`
+const SectionLink = styled(Link)`
   display: block;
   width: 100%;
   font-weight: 700;
@@ -138,7 +138,7 @@ const SectionDropDown = styled.div`
     }
   }
 `
-const CategoryLink = styled.a`
+const CategoryLink = styled(Link)`
   display: block;
   &:hover {
     color: ${({ sectionSlug }) => (sectionSlug ? colorCss : ' #fff')};

--- a/packages/mirror-media-next/components/section/videohub/video-list.js
+++ b/packages/mirror-media-next/components/section/videohub/video-list.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import VideoListItem from '../../shared/video-list-item'
-
+import Link from 'next/link'
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
  */
@@ -136,9 +136,9 @@ export default function VideoList({ videos, name, slug, gtmClassName = '' }) {
     <Wrapper hasSlug={hasSlug}>
       <Title categorySlug={slug}>
         {hasSlug ? (
-          <a href={`/video_category/${slug}`} target="_blank" rel="noreferrer">
+          <Link href={`/video_category/${slug}`} rel="noreferrer">
             {name}
-          </a>
+          </Link>
         ) : (
           <>{name}</>
         )}

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -97,13 +97,20 @@ const RENDER_PAGE_SIZE = 12
 export default function Author({ postsCount, posts, author, headerData }) {
   const authorName = author.name || ''
   const shouldShowAd = useDisplayAd()
+  /**
+   * The reason why component `<AuthorContainer>` need to add `key`:
+   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
+   * we need to use key to tell React "this is an another page components".
+   * Otherwise, page will not render correct data in components.
+   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
+   */
   return (
     <Layout
       head={{ title: `${authorName}相關報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <AuthorContainer>
+      <AuthorContainer key={author.id}>
         {shouldShowAd && <StyledGPTAd pageKey="other" adKey="HD" />}
         {authorName && <AuthorTitle>{authorName}</AuthorTitle>}
         <AuthorArticles

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -207,14 +207,20 @@ export default function Category({
   //If category not have related-section, use `other` ad units
   const sectionSlug = category?.sections?.[0]?.slug ?? ''
   const GptPageKey = getSectionGPTPageKey(sectionSlug) ?? 'other'
-
+  /**
+   * The reason why component `<CategoryContainer>` need to add `key`:
+   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
+   * we need to use key to tell React "this is an another page components".
+   * Otherwise, page will not render correct data in components.
+   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
+   */
   return (
     <Layout
       head={{ title: `${categoryName}分類報導` }}
       header={{ type: isPremium ? 'premium' : 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <CategoryContainer isPremium={isPremium}>
+      <CategoryContainer key={category.id} isPremium={isPremium}>
         {shouldShowAd && <StyledGPTAd pageKey={GptPageKey} adKey="HD" />}
 
         {isPremium ? (

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -118,14 +118,20 @@ export default function ExternalPartner({
   headerData,
 }) {
   const shouldShowAd = useDisplayAd()
-
+  /**
+   * The reason why component `<PartnerContainer>` need to add `key`:
+   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
+   * we need to use key to tell React "this is an another page components".
+   * Otherwise, page will not render correct data in components.
+   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
+   */
   return (
     <Layout
       head={{ title: `${partner?.name}相關報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <PartnerContainer>
+      <PartnerContainer key={partner.id}>
         {shouldShowAd && (
           <StyledGPTAd
             pageKey={getPageKeyByPartnerSlug(partner.slug)}

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -108,14 +108,20 @@ export default function WarmLife({
   headerData,
 }) {
   const shouldShowAd = useDisplayAd()
-
+  /**
+   * The reason why component `<WarmLifeContainer>` need to add `key`:
+   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
+   * we need to use key to tell React "this is an another page components".
+   * Otherwise, page will not render correct data in components.
+   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
+   */
   return (
     <Layout
       head={{ title: `${WARMLIFE_DEFAULT_TITLE}相關報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <WarmLifeContainer>
+      <WarmLifeContainer key={'externals/warmlife'}>
         {shouldShowAd && (
           <StyledGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} adKey="HD" />
         )}

--- a/packages/mirror-media-next/pages/premiumsection/[slug].js
+++ b/packages/mirror-media-next/pages/premiumsection/[slug].js
@@ -130,14 +130,20 @@ export default function Section({ postsCount, posts, section, headerData }) {
   const sectionName = section.name || ''
 
   const shouldShowAd = useDisplayAd()
-
+  /**
+   * The reason why component `<SectionContainer>` need to add `key`:
+   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
+   * we need to use key to tell React "this is an another page components".
+   * Otherwise, page will not render correct data in components.
+   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
+   */
   return (
     <Layout
       head={{ title: `${sectionName}分類報導` }}
       header={{ type: 'premium', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <SectionContainer>
+      <SectionContainer key={section.id}>
         {shouldShowAd && (
           <StyledGPTAd_HD pageKey={SECTION_IDS['member']} adKey="HD" />
         )}

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -111,14 +111,20 @@ const RENDER_PAGE_SIZE = 12
 export default function Section({ postsCount, posts, section, headerData }) {
   const sectionName = section.name || ''
   const shouldShowAd = useDisplayAd()
-
+  /**
+   * The reason why component `<SectionContainer>` need to add `key`:
+   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
+   * we need to use key to tell React "this is an another page components".
+   * Otherwise, page will not render correct data in components.
+   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
+   */
   return (
     <Layout
       head={{ title: `${sectionName}分類報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <SectionContainer>
+      <SectionContainer key={section.id}>
         {shouldShowAd && (
           <StyledGPTAd
             pageKey={getSectionGPTPageKey(section.slug)}

--- a/packages/mirror-media-next/pages/section/topic.js
+++ b/packages/mirror-media-next/pages/section/topic.js
@@ -92,6 +92,8 @@ const RENDER_PAGE_SIZE = 12
  */
 
 /**
+ *
+ *
  * @param {Object} props
  * @param {Topic[]} props.topics
  * @param {number} props.topicsCount
@@ -100,14 +102,20 @@ const RENDER_PAGE_SIZE = 12
  */
 export default function Topics({ topics, topicsCount, headerData }) {
   const shouldShowAd = useDisplayAd()
-
+  /**
+   * The reason why component `<TopicsContainer>` need to add `key`:
+   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
+   * we need to use key to tell React "this is an another page components".
+   * Otherwise, page will not render correct data in components.
+   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
+   */
   return (
     <Layout
       head={{ title: `精選專區` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <TopicsContainer>
+      <TopicsContainer key={'topics'}>
         {shouldShowAd && <StyledGPTAd pageKey="other" adKey="HD" />}
         <TopicsTitle>精選專區</TopicsTitle>
         <SectionTopics

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -114,14 +114,20 @@ const RENDER_PAGE_SIZE = 12
 export default function Tag({ postsCount, posts, tag, headerData }) {
   const tagName = tag.name || ''
   const shouldShowAd = useDisplayAd()
-
+  /**
+   * The reason why component `<TagContainer>` need to add `key`:
+   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
+   * we need to use key to tell React "this is an another page components".
+   * Otherwise, page will not render correct data in components.
+   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
+   */
   return (
     <Layout
       head={{ title: `${tagName}相關報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <TagContainer>
+      <TagContainer key={tag.id}>
         {shouldShowAd && <StyledGPTAd pageKey="other" adKey="HD" />}
 
         {tagName && (

--- a/packages/mirror-media-next/pages/topic/[slug].js
+++ b/packages/mirror-media-next/pages/topic/[slug].js
@@ -13,6 +13,7 @@ import {
   sortArrayWithOtherArrayId,
 } from '../../utils/index'
 import { fetchTopicByTopicSlug } from '../../utils/api/topic'
+import { Fragment } from 'react'
 
 const RENDER_PAGE_SIZE = 12
 
@@ -61,7 +62,13 @@ export default function Topic({ topic, slideshowImages, headerData }) {
         </>
       )
   }
-
+  /**
+   * The reason why component `<Fragment>` need to add `key`:
+   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
+   * we need to use key to tell React "this is an another page components".
+   * Otherwise, page will not render correct data in components.
+   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
+   */
   return (
     <Layout
       head={{
@@ -77,7 +84,7 @@ export default function Topic({ topic, slideshowImages, headerData }) {
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      {topicJSX}
+      <Fragment key={topic.id}>{topicJSX}</Fragment>
     </Layout>
   )
 }

--- a/packages/mirror-media-next/pages/video_category/[slug].js
+++ b/packages/mirror-media-next/pages/video_category/[slug].js
@@ -1,6 +1,6 @@
 import errors from '@twreporter/errors'
 import dynamic from 'next/dynamic'
-
+import Link from 'next/link'
 import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import CategoryVideos from '../../components/video_category/category-videos.js'
 import { VIDEOHUB_CATEGORIES_PLAYLIST_MAPPING } from '../../constants/index.js'
@@ -99,14 +99,20 @@ export default function VideoCategory({
   const categoryName = category.name || ''
 
   const shouldShowAd = useDisplayAd()
-
+  /**
+   * The reason why component `<Wrapper>` need to add `key`:
+   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
+   * we need to use key to tell React "this is an another page components".
+   * Otherwise, page will not render correct data in components.
+   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
+   */
   return (
     <Layout
       head={{ title: `${categoryName}影音` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <Wrapper>
+      <Wrapper key={category.id}>
         {shouldShowAd && <StyledGPTAd_PC_HD pageKey="videohub" adKey="PC_HD" />}
         <LeadingVideo
           video={firstVideo}


### PR DESCRIPTION
## Notable Change
1. 使用`next/link` 取代`<a>`，以提升routing速度。
2. 於listing頁元件加入`key`，避免client side navigation後造成的錯誤。目前story頁、external頁都為另開分頁，所以暫時不實作。