### PR TITLE
revert(mm-next): revert commit about client-side navigation on header

### DIFF
--- a/packages/mirror-media-next/components/mobile-sidebar.js
+++ b/packages/mirror-media-next/components/mobile-sidebar.js
@@ -4,7 +4,7 @@ import useClickOutside from '../hooks/useClickOutside'
 import Link from 'next/link'
 import HamburgerButton from './shared/hamburger-button'
 import CloseButton from './shared/close-button'
-import { useRouter } from 'next/router'
+
 /**
  * @typedef {import('../apollo/fragments/section').Section} Section
  */
@@ -277,32 +277,22 @@ export default function MobileSidebar({
   promotions,
   socialMedia,
 }) {
-  const router = useRouter()
-
   const [openSidebar, setOpenSidebar] = useState(false)
   const [openSection, setOpenSection] = useState('')
   const sideBarRef = useRef(null)
   useClickOutside(sideBarRef, () => {
     setOpenSidebar(false)
   })
-  const handleOnClick = (e, href) => {
-    e.preventDefault()
-    setOpenSidebar(false)
-    router.push(href)
-  }
+
   const sectionsAndCategoriesJsx = sectionsAndCategories.map((item) => {
     switch (item.type) {
       case 'section':
         return (
           <Fragment key={item.order}>
             <Section sectionSlug={item.slug}>
-              <Link
-                style={{ width: '50%' }}
-                href={item.href}
-                onClick={(e) => handleOnClick(e, item.href)}
-              >
+              <a style={{ width: '50%' }} href={item.href}>
                 <h3>{item.name}</h3>
-              </Link>
+              </a>
               <SectionToggle
                 onClick={() => setOpenSection(item.slug)}
                 shouldOpen={item.slug === openSection}
@@ -314,13 +304,9 @@ export default function MobileSidebar({
               sectionSlug={item.slug}
             >
               {item.categories.map((category) => (
-                <Link
-                  key={category.id}
-                  href={category.href}
-                  onClick={(e) => handleOnClick(e, category.href)}
-                >
+                <a key={category.id} href={category.href}>
                   {category.name}
-                </Link>
+                </a>
               ))}
             </Categories>
           </Fragment>
@@ -330,13 +316,9 @@ export default function MobileSidebar({
 
         return (
           <Section key={item.order} sectionSlug={renderSectionSlug}>
-            <Link
-              style={{ width: '100%' }}
-              href={item.href}
-              onClick={(e) => handleOnClick(e, item.href)}
-            >
+            <a style={{ width: '100%' }} href={item.href}>
               <h3>{item.name}</h3>
-            </Link>
+            </a>
           </Section>
         )
       default:
@@ -366,7 +348,7 @@ export default function MobileSidebar({
           <SubBrandList>
             {subBrands.map((brand) => (
               <li key={brand.name}>
-                <Link
+                <a
                   href={brand.href}
                   target="_blank"
                   rel="noopener noreferer noreferrer"
@@ -376,7 +358,7 @@ export default function MobileSidebar({
                     src={`/images/${brand.name}-colorless.png`}
                     alt={brand.title}
                   />
-                </Link>
+                </a>
               </li>
             ))}
           </SubBrandList>
@@ -392,7 +374,7 @@ export default function MobileSidebar({
         </SideBarBottom>
         <SocialMediaList>
           {socialMedia.map(({ name, href }) => (
-            <Link
+            <a
               key={name}
               href={href}
               target="_blank"
@@ -404,7 +386,7 @@ export default function MobileSidebar({
                 src="/images/transperent.png"
                 alt={name}
               ></img>
-            </Link>
+            </a>
           ))}
         </SocialMediaList>
       </SideBar>

--- a/packages/mirror-media-next/components/nav-sections.js
+++ b/packages/mirror-media-next/components/nav-sections.js
@@ -126,7 +126,7 @@ const Section = styled.li`
     }
   }
 `
-const SectionLink = styled(Link)`
+const SectionLink = styled.a`
   display: block;
   width: 100%;
   font-weight: 700;
@@ -168,7 +168,7 @@ const SectionDropDown = styled.div`
     }
   }
 `
-const CategoryLink = styled(Link)`
+const CategoryLink = styled.a`
   display: block;
   &:hover {
     ${

--- a/packages/mirror-media-next/components/nav-topics.js
+++ b/packages/mirror-media-next/components/nav-topics.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from 'styled-components'
-import Link from 'next/link'
+
 /**
  * @typedef {Pick<import('../apollo/fragments/topic').Topic, 'id' | 'slug' | 'name'>[]} Topics
  */
@@ -16,7 +16,7 @@ const TopicsWrapper = styled.section`
   }
 `
 
-const Topic = styled(Link)`
+const Topic = styled.a`
   font-size: 16px;
   line-height: 29px;
   height: 100%;

--- a/packages/mirror-media-next/components/premium-header.js
+++ b/packages/mirror-media-next/components/premium-header.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react'
 import styled from 'styled-components'
-import Link from 'next/link'
+
 import SearchBarDesktop from './search-bar-desktop'
 import { Z_INDEX } from '../constants'
 import { DEFAULT_PREMIUM_SECTIONS_DATA } from '../constants/header'
@@ -230,9 +230,10 @@ export default function PremiumHeader({
   return (
     <HeaderWrapper shouldSticky={shouldShowSubtitleNavigator}>
       <HeaderTop>
-        <Link href="/">
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+        <a href="/">
           <HeaderLogo />
-        </Link>
+        </a>
         <ActionWrapper>
           <SearchBarDesktop
             searchTerms={searchTerms}

--- a/packages/mirror-media-next/components/premium-mobile-sidebar.js
+++ b/packages/mirror-media-next/components/premium-mobile-sidebar.js
@@ -2,8 +2,7 @@ import styled, { css } from 'styled-components'
 import React, { Fragment, useState, useRef } from 'react'
 import useClickOutside from '../hooks/useClickOutside'
 import NavSubtitleNavigator from './story/shared/nav-subtitle-navigator'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
+
 /**
  * @typedef {import('../type/theme').Theme} Theme
  */
@@ -236,18 +235,13 @@ export default function PremiumMobileSidebar({
   shouldShowSubtitleNavigator = false,
   h2AndH3Block = [],
 }) {
-  const router = useRouter()
   const [openSidebar, setOpenSidebar] = useState(false)
   const [openSection, setOpenSection] = useState('')
   const sideBarRef = useRef(null)
   useClickOutside(sideBarRef, () => {
     setOpenSidebar(false)
   })
-  const handleOnClick = (e, href) => {
-    e.preventDefault()
-    setOpenSidebar(false)
-    router.push(href)
-  }
+
   return (
     <>
       <SideBarButton onClick={() => setOpenSidebar((val) => !val)}>
@@ -272,13 +266,9 @@ export default function PremiumMobileSidebar({
           {sections.map(({ id, name, categories, slug }) => (
             <Fragment key={id}>
               <Section>
-                <Link
-                  style={{ width: '50%' }}
-                  href={`/premiumsection/${slug}`}
-                  onClick={(e) => handleOnClick(e, `/premiumsection/${slug}`)}
-                >
+                <a style={{ width: '50%' }} href={`/premiumsection/${slug}`}>
                   <h3>{name}</h3>
-                </Link>
+                </a>
                 <SectionToggle
                   onClick={() => setOpenSection(slug)}
                   shouldOpen={slug === openSection}
@@ -290,15 +280,9 @@ export default function PremiumMobileSidebar({
                 sectionSlug={slug}
               >
                 {categories.map((category) => (
-                  <Link
-                    key={category.id}
-                    href={`/category/${category.slug}`}
-                    onClick={(e) =>
-                      handleOnClick(e, `/category/${category.slug}`)
-                    }
-                  >
+                  <a key={category.id} href={`/category/${category.slug}`}>
                     {category.name}
-                  </Link>
+                  </a>
                 ))}
               </Categories>
             </Fragment>

--- a/packages/mirror-media-next/components/premium-nav-sections.js
+++ b/packages/mirror-media-next/components/premium-nav-sections.js
@@ -1,7 +1,7 @@
 //TODO: When user at certain section, at category which belongs to certain section, at story which belongs to certain section
 //component <Section> will change color of title to section color defined at /styles/sections-color.
+//TODO: Replace <a> to <Link> for Single Page Application
 import styled, { css } from 'styled-components'
-import Link from 'next/link'
 /**
  * @typedef {import('../type/theme').Theme} Theme
  */
@@ -112,7 +112,7 @@ const Section = styled.li`
   }
 `
 
-const SectionLink = styled(Link)`
+const SectionLink = styled.a`
   display: block;
   width: 100%;
   font-weight: 700;
@@ -138,7 +138,7 @@ const SectionDropDown = styled.div`
     }
   }
 `
-const CategoryLink = styled(Link)`
+const CategoryLink = styled.a`
   display: block;
   &:hover {
     color: ${({ sectionSlug }) => (sectionSlug ? colorCss : ' #fff')};

--- a/packages/mirror-media-next/components/section/videohub/video-list.js
+++ b/packages/mirror-media-next/components/section/videohub/video-list.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import VideoListItem from '../../shared/video-list-item'
-import Link from 'next/link'
+
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
  */
@@ -136,9 +136,9 @@ export default function VideoList({ videos, name, slug, gtmClassName = '' }) {
     <Wrapper hasSlug={hasSlug}>
       <Title categorySlug={slug}>
         {hasSlug ? (
-          <Link href={`/video_category/${slug}`} rel="noreferrer">
+          <a href={`/video_category/${slug}`} target="_blank" rel="noreferrer">
             {name}
-          </Link>
+          </a>
         ) : (
           <>{name}</>
         )}

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -97,20 +97,13 @@ const RENDER_PAGE_SIZE = 12
 export default function Author({ postsCount, posts, author, headerData }) {
   const authorName = author.name || ''
   const shouldShowAd = useDisplayAd()
-  /**
-   * The reason why component `<AuthorContainer>` need to add `key`:
-   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
-   * we need to use key to tell React "this is an another page components".
-   * Otherwise, page will not render correct data in components.
-   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
-   */
   return (
     <Layout
       head={{ title: `${authorName}相關報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <AuthorContainer key={author.id}>
+      <AuthorContainer>
         {shouldShowAd && <StyledGPTAd pageKey="other" adKey="HD" />}
         {authorName && <AuthorTitle>{authorName}</AuthorTitle>}
         <AuthorArticles

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -207,20 +207,14 @@ export default function Category({
   //If category not have related-section, use `other` ad units
   const sectionSlug = category?.sections?.[0]?.slug ?? ''
   const GptPageKey = getSectionGPTPageKey(sectionSlug) ?? 'other'
-  /**
-   * The reason why component `<CategoryContainer>` need to add `key`:
-   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
-   * we need to use key to tell React "this is an another page components".
-   * Otherwise, page will not render correct data in components.
-   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
-   */
+
   return (
     <Layout
       head={{ title: `${categoryName}分類報導` }}
       header={{ type: isPremium ? 'premium' : 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <CategoryContainer key={category.id} isPremium={isPremium}>
+      <CategoryContainer isPremium={isPremium}>
         {shouldShowAd && <StyledGPTAd pageKey={GptPageKey} adKey="HD" />}
 
         {isPremium ? (

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -118,20 +118,14 @@ export default function ExternalPartner({
   headerData,
 }) {
   const shouldShowAd = useDisplayAd()
-  /**
-   * The reason why component `<PartnerContainer>` need to add `key`:
-   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
-   * we need to use key to tell React "this is an another page components".
-   * Otherwise, page will not render correct data in components.
-   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
-   */
+
   return (
     <Layout
       head={{ title: `${partner?.name}相關報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <PartnerContainer key={partner.id}>
+      <PartnerContainer>
         {shouldShowAd && (
           <StyledGPTAd
             pageKey={getPageKeyByPartnerSlug(partner.slug)}

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -108,20 +108,14 @@ export default function WarmLife({
   headerData,
 }) {
   const shouldShowAd = useDisplayAd()
-  /**
-   * The reason why component `<WarmLifeContainer>` need to add `key`:
-   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
-   * we need to use key to tell React "this is an another page components".
-   * Otherwise, page will not render correct data in components.
-   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
-   */
+
   return (
     <Layout
       head={{ title: `${WARMLIFE_DEFAULT_TITLE}相關報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <WarmLifeContainer key={'externals/warmlife'}>
+      <WarmLifeContainer>
         {shouldShowAd && (
           <StyledGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} adKey="HD" />
         )}

--- a/packages/mirror-media-next/pages/premiumsection/[slug].js
+++ b/packages/mirror-media-next/pages/premiumsection/[slug].js
@@ -130,20 +130,14 @@ export default function Section({ postsCount, posts, section, headerData }) {
   const sectionName = section.name || ''
 
   const shouldShowAd = useDisplayAd()
-  /**
-   * The reason why component `<SectionContainer>` need to add `key`:
-   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
-   * we need to use key to tell React "this is an another page components".
-   * Otherwise, page will not render correct data in components.
-   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
-   */
+
   return (
     <Layout
       head={{ title: `${sectionName}分類報導` }}
       header={{ type: 'premium', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <SectionContainer key={section.id}>
+      <SectionContainer>
         {shouldShowAd && (
           <StyledGPTAd_HD pageKey={SECTION_IDS['member']} adKey="HD" />
         )}

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -111,20 +111,14 @@ const RENDER_PAGE_SIZE = 12
 export default function Section({ postsCount, posts, section, headerData }) {
   const sectionName = section.name || ''
   const shouldShowAd = useDisplayAd()
-  /**
-   * The reason why component `<SectionContainer>` need to add `key`:
-   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
-   * we need to use key to tell React "this is an another page components".
-   * Otherwise, page will not render correct data in components.
-   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
-   */
+
   return (
     <Layout
       head={{ title: `${sectionName}分類報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <SectionContainer key={section.id}>
+      <SectionContainer>
         {shouldShowAd && (
           <StyledGPTAd
             pageKey={getSectionGPTPageKey(section.slug)}

--- a/packages/mirror-media-next/pages/section/topic.js
+++ b/packages/mirror-media-next/pages/section/topic.js
@@ -92,8 +92,6 @@ const RENDER_PAGE_SIZE = 12
  */
 
 /**
- *
- *
  * @param {Object} props
  * @param {Topic[]} props.topics
  * @param {number} props.topicsCount
@@ -102,20 +100,14 @@ const RENDER_PAGE_SIZE = 12
  */
 export default function Topics({ topics, topicsCount, headerData }) {
   const shouldShowAd = useDisplayAd()
-  /**
-   * The reason why component `<TopicsContainer>` need to add `key`:
-   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
-   * we need to use key to tell React "this is an another page components".
-   * Otherwise, page will not render correct data in components.
-   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
-   */
+
   return (
     <Layout
       head={{ title: `精選專區` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <TopicsContainer key={'topics'}>
+      <TopicsContainer>
         {shouldShowAd && <StyledGPTAd pageKey="other" adKey="HD" />}
         <TopicsTitle>精選專區</TopicsTitle>
         <SectionTopics

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -114,20 +114,14 @@ const RENDER_PAGE_SIZE = 12
 export default function Tag({ postsCount, posts, tag, headerData }) {
   const tagName = tag.name || ''
   const shouldShowAd = useDisplayAd()
-  /**
-   * The reason why component `<TagContainer>` need to add `key`:
-   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
-   * we need to use key to tell React "this is an another page components".
-   * Otherwise, page will not render correct data in components.
-   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
-   */
+
   return (
     <Layout
       head={{ title: `${tagName}相關報導` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <TagContainer key={tag.id}>
+      <TagContainer>
         {shouldShowAd && <StyledGPTAd pageKey="other" adKey="HD" />}
 
         {tagName && (

--- a/packages/mirror-media-next/pages/topic/[slug].js
+++ b/packages/mirror-media-next/pages/topic/[slug].js
@@ -13,7 +13,6 @@ import {
   sortArrayWithOtherArrayId,
 } from '../../utils/index'
 import { fetchTopicByTopicSlug } from '../../utils/api/topic'
-import { Fragment } from 'react'
 
 const RENDER_PAGE_SIZE = 12
 
@@ -62,13 +61,7 @@ export default function Topic({ topic, slideshowImages, headerData }) {
         </>
       )
   }
-  /**
-   * The reason why component `<Fragment>` need to add `key`:
-   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
-   * we need to use key to tell React "this is an another page components".
-   * Otherwise, page will not render correct data in components.
-   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
-   */
+
   return (
     <Layout
       head={{
@@ -84,7 +77,7 @@ export default function Topic({ topic, slideshowImages, headerData }) {
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <Fragment key={topic.id}>{topicJSX}</Fragment>
+      {topicJSX}
     </Layout>
   )
 }

--- a/packages/mirror-media-next/pages/video_category/[slug].js
+++ b/packages/mirror-media-next/pages/video_category/[slug].js
@@ -1,6 +1,6 @@
 import errors from '@twreporter/errors'
 import dynamic from 'next/dynamic'
-import Link from 'next/link'
+
 import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import CategoryVideos from '../../components/video_category/category-videos.js'
 import { VIDEOHUB_CATEGORIES_PLAYLIST_MAPPING } from '../../constants/index.js'
@@ -99,20 +99,14 @@ export default function VideoCategory({
   const categoryName = category.name || ''
 
   const shouldShowAd = useDisplayAd()
-  /**
-   * The reason why component `<Wrapper>` need to add `key`:
-   * When we use client-side navigation (such as `<Link>` from 'next/link', `router.push` from next/router),
-   * we need to use key to tell React "this is an another page components".
-   * Otherwise, page will not render correct data in components.
-   * See [React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) to get more information about how does key works.
-   */
+
   return (
     <Layout
       head={{ title: `${categoryName}影音` }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
-      <Wrapper key={category.id}>
+      <Wrapper>
         {shouldShowAd && <StyledGPTAd_PC_HD pageKey="videohub" adKey="PC_HD" />}
         <LeadingVideo
           video={firstVideo}


### PR DESCRIPTION
## Revert Reason
#532 將 `<a>` 改為 `next/link`，但會遇到廣告無法顯示的問題。

無法顯示的情境可以重現，情境發生步驟為：
1. 進到`category/A`頁，正常顯示廣告
2. 點擊header，從`category/A`頁跳轉到`category/B`，正常顯示廣告
3. 點擊header，再從`category/B`頁跳轉到`category/A`，無法顯示廣告
4.  點擊header，再從`category/A`頁跳轉到`category/B`，無法顯示廣告

簡單來說就是，如果該頁的廣告曾被載入過，在client-side navigation後都不會出現。

目前推測是以載入的廣告單元，需要透過`window.googletag.pubads().refresh`重新載入的緣故，但因改動幅度較大，且原本透過`<a>`跳轉的做法亦可被需求方接受，所以先revert回僅有`<a>`的版本，之後再另外花時間研究如何解決。

mirror-media-nuxt也有實作過`window.googletag.pubads().refresh`，可參考[這段程式碼](https://github.com/mirror-media/mirror-media-nuxt/blob/dev/plugins/gpt-ad/index.vue#L91-L109)。