### PR TITLE
style(mm-next): remove `max-width` `max-height` in gpt ad which pageKey contain `AT`

### DIFF
--- a/packages/mirror-media-next/components/amp/amp-main.js
+++ b/packages/mirror-media-next/components/amp/amp-main.js
@@ -110,6 +110,7 @@ const AmpContentContainer = styled.section`
   margin-top: 36px;
 `
 
+//Because AT1, AT2 contain full-screen size ads content, should not set max-width and max-height
 const StyledAmpGptAd = styled(AmpGptAd)`
   margin: 32px 0;
 `

--- a/packages/mirror-media-next/components/external/external-normal-style.js
+++ b/packages/mirror-media-next/components/external/external-normal-style.js
@@ -275,12 +275,12 @@ const StyledGPTAd_HD = styled(GPTAd)`
   }
 `
 
+//Because AT1, AT2, AT3 contain full-screen size ads content, should not set max-width and max-height
+
 const StyledGPTAd_MB_AT3 = styled(GPTAd)`
   display: block;
   width: 100%;
   height: auto;
-  max-height: 280px;
-  max-width: 336px;
   margin: 0 auto;
 
   ${({ theme }) => theme.breakpoint.xl} {

--- a/packages/mirror-media-next/components/story/normal/article-content.js
+++ b/packages/mirror-media-next/components/story/normal/article-content.js
@@ -27,11 +27,11 @@ const ContentContainer = styled.section`
   margin-top: 32px;
   margin-bottom: 32px;
 `
+//Because AT1, AT2 contain full-screen size ads content, should not set max-width and max-height
 const StyledGPTAd = styled(GPTAd)`
   width: 100%;
   height: auto;
-  max-width: 336px;
-  max-height: 280px;
+
   margin: 32px auto;
   display: ${
     /**
@@ -40,11 +40,6 @@ const StyledGPTAd = styled(GPTAd)`
      */
     (props) => (props.pageKey ? 'block' : 'none')
   };
-
-  ${({ theme }) => theme.breakpoint.xl} {
-    max-width: 640px;
-    max-height: 390px;
-  }
 `
 
 /**

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -345,14 +345,12 @@ const StyledGPTAd_HD = styled(GPTAd)`
     max-height: 250px;
   }
 `
-
+//Because AT1, AT2, AT3 contain full-screen size ads content, should not set max-width and max-height
 const StyledGPTAd_MB_AT3 = styled(GPTAd)`
   display: block;
   margin: 0 -20px;
   width: 100%;
   height: auto;
-  max-height: 280px;
-  max-width: 336px;
 
   @media (min-width: 336px) {
     margin: 0 auto;

--- a/packages/mirror-media-next/components/story/premium/article-content.js
+++ b/packages/mirror-media-next/components/story/premium/article-content.js
@@ -17,17 +17,11 @@ const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
  * @typedef {import('../../../type/draft-js').Draft} Content
  */
 
+//Because AT1, AT2 contain full-screen size ads content, should not set max-width and max-height
 const StyledGPTAd = styled(GPTAd)`
   width: 100%;
   height: auto;
-  max-width: 336px;
-  max-height: 280px;
   margin: 32px auto;
-
-  ${({ theme }) => theme.breakpoint.xl} {
-    max-width: 640px;
-    max-height: 390px;
-  }
 `
 const ContentContainer = styled.section`
   margin-top: 32px;


### PR DESCRIPTION
## Notable change
由於GPT廣告 中，AT1, AT2, AT3 會有特殊尺寸的廣告，故移除max-width、max-height，避免破版。
若其他廣告也有此需求，則另開PR實作