### PR TITLE
refactor(mm-next): add assetPrefix setting to prevent route collision

### DIFF
--- a/packages/mirror-media-next/next.config.mjs
+++ b/packages/mirror-media-next/next.config.mjs
@@ -1,7 +1,9 @@
-import { DONATION_PAGE_URL } from './config/index.mjs'
+import { DONATION_PAGE_URL, IS_PREVIEW_MODE } from './config/index.mjs'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Add assetPrefix to prevent /_next route collision between CMS and preview server
+  assetPrefix: IS_PREVIEW_MODE ? '/preview-server' : undefined,
   reactStrictMode: true,
   swcMinify: true,
   compiler: {


### PR DESCRIPTION
## Notable Changes
* 增加 assetPrefix 設定，讓生成的 `/_next` 路徑有額外的前綴，避免 preview 與 CMS 在該路徑上衝突