### PR TITLE
fix(mm-next): replace `next/link` to `<a>` to prevent unable render gpt ads

### DIFF
--- a/packages/mirror-media-next/components/amp/amp-header.js
+++ b/packages/mirror-media-next/components/amp/amp-header.js
@@ -1,4 +1,3 @@
-import Link from 'next/link'
 import styled from 'styled-components'
 
 const HeaderWrapper = styled.header`
@@ -9,7 +8,7 @@ const HeaderWrapper = styled.header`
   justify-content: center;
 `
 
-const HeaderLogo = styled(Link)`
+const HeaderLogo = styled.a`
   position: relative;
   width: 73.5px;
 `

--- a/packages/mirror-media-next/components/external/external-article-info.js
+++ b/packages/mirror-media-next/components/external/external-article-info.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import Link from 'next/link'
+
 import Image from 'next/image'
 import ButtonCopyLink from '../../components/story/shared/button-copy-link'
 import DonateLink from '../../components/story/shared/donate-link'
@@ -126,14 +126,15 @@ export default function ArticleInfo({ updatedDate, publishedDate, credits }) {
       {creditJsx}
 
       <SocialMediaAndDonateLink>
-        <Link className="link-to-index" href="/">
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+        <a className="link-to-index" href="/">
           <Image
             width={35}
             height={35}
             alt="go-to-index-page"
             src="/images-next/logo-circle@2x.png"
           ></Image>
-        </Link>
+        </a>
         <SocialMedia>
           <ButtonSocialNetworkShare type="facebook" />
           <ButtonSocialNetworkShare type="line" />

--- a/packages/mirror-media-next/components/header.js
+++ b/packages/mirror-media-next/components/header.js
@@ -2,7 +2,7 @@
 import React, { useState, useRef, useEffect } from 'react'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
-import Link from 'next/link'
+
 import {
   SUB_BRAND_LINKS,
   PROMOTION_LINKS,
@@ -381,9 +381,10 @@ export default function Header({
   return (
     <HeaderWrapper>
       <HeaderTop>
-        <Link href="/" className="GTM-header-logo">
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+        <a href="/" className="GTM-header-logo">
           <HeaderLogo />
-        </Link>
+        </a>
         {shouldShowAd && <StyledGPTAd pageKey="global" adKey="RWD_LOGO" />}
         <ActionWrapper>
           <SubBrandList subBrands={SUB_BRAND_LINKS} />

--- a/packages/mirror-media-next/components/nav-sections.js
+++ b/packages/mirror-media-next/components/nav-sections.js
@@ -3,7 +3,7 @@
 import styled, { css } from 'styled-components'
 import { minWidth } from '../styles/media'
 import Logo from './logo'
-import Link from 'next/link'
+
 /**
  * @typedef {import('../type/theme').Theme} Theme
  */
@@ -229,9 +229,10 @@ export default function NavSections({ sectionsAndCategories = [] }) {
   return (
     <SectionsWrapper>
       <SectionLogo>
-        <Link href="/">
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+        <a href="/">
           <LogoIcon />
-        </Link>
+        </a>
       </SectionLogo>
       <Sections>{sectionsAndCategoriesJsx}</Sections>
     </SectionsWrapper>

--- a/packages/mirror-media-next/components/story/normal/article-info.js
+++ b/packages/mirror-media-next/components/story/normal/article-info.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import Link from 'next/link'
+
 import Image from 'next/image'
 import ButtonCopyLink from '../shared/button-copy-link'
 import DonateLink from '../shared/donate-link'
@@ -136,14 +136,15 @@ export default function ArticleInfo({
 
       <Credits credits={credits}></Credits>
       <SocialMediaAndDonateLink>
-        <Link className="link-to-index" href="/">
+        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+        <a className="link-to-index" href="/">
           <Image
             width={35}
             height={35}
             alt="go-to-index-page"
             src="/images-next/logo-circle@2x.png"
           ></Image>
-        </Link>
+        </a>
         <SocialMedia>
           <ButtonSocialNetworkShare type="facebook" />
           <ButtonSocialNetworkShare type="line" />

--- a/packages/mirror-media-next/components/story/shared/adult-only-warning.js
+++ b/packages/mirror-media-next/components/story/shared/adult-only-warning.js
@@ -1,6 +1,5 @@
 import styled from 'styled-components'
 import { Z_INDEX } from '../../../constants'
-import NextLink from 'next/link'
 import { useState, useEffect, useRef } from 'react'
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock'
 import { useAmp } from 'next/amp'
@@ -150,9 +149,10 @@ export default function AdultOnlyWarning({ isAdult = false }) {
 
         <ButtonWrapper>
           {agreeBtnJsx}
-          <NextLink href="/" aria-label="離開">
+          {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+          <a href="/" aria-label="離開">
             <button>離開</button>
-          </NextLink>
+          </a>
         </ButtonWrapper>
       </WarningContent>
     </Wrapper>

--- a/packages/mirror-media-next/components/story/wide/header.js
+++ b/packages/mirror-media-next/components/story/wide/header.js
@@ -1,6 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
 import styled from 'styled-components'
-import Link from 'next/link'
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock'
 import useClickOutside from '../../../hooks/useClickOutside'
 
@@ -111,9 +110,10 @@ export default function Header({ h2AndH3Block = [] }) {
 
   return (
     <HeaderWrapper>
-      <Link href="/">
+      {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+      <a href="/">
         <LogoSvg></LogoSvg>
-      </Link>
+      </a>
       <HamburgerButton
         color="lightBlue"
         handleOnClick={() => setShouldOpenSideBar((val) => !val)}


### PR DESCRIPTION
## Problem 
蓋板廣告在頁面跳轉會無法更新。
出現情境：當使用`next/link`跳轉時，若不為另開分頁，則廣告不會更新、或是重複蓋板廣告的問題。
（重複蓋板廣告無法重現，僅推測同為`next/link`跳轉所引起的）

## Solution 
暫時將header、頁面的`next/link`改為一般`<a>`。
完整的解法，仍需另外survey。