### PR TITLE
chore(mm-next): bump Dep `@readr-media/react-image` version

### DIFF
--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -17,7 +17,7 @@
     "@mirrormedia/lilith-draft-renderer": "^1.3.0-alpha.5",
     "@mirrormedia/newebpay-node": "^1.0.8",
     "@next/font": "^13.1.2",
-    "@readr-media/react-image": "^2.1.3",
+    "@readr-media/react-image": "2.2.0",
     "@readr-media/share-button": "^1.0.3",
     "@svgr/webpack": "^6.3.1",
     "@twreporter/errors": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,10 +1866,15 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@readr-media/react-image@2.1.3", "@readr-media/react-image@^2.1.3":
+"@readr-media/react-image@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.1.3.tgz#97834255b39f42d15b93449637131d28a3aca168"
   integrity sha512-XAuKKSqRNSvH/CJAfbBhVE7Ezkaetc0pM3AEKUPydYJP51N6fp8mWfPR0HUSw/7QLElHSGXVKCvyuOpVIXa5eQ==
+
+"@readr-media/react-image@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.2.0.tgz#bd1e6ea4c6497fdade32d0345cf46ddc14440745"
+  integrity sha512-W2A+gb7lwPccbcQIzuNy4SP/Z0Oj8jkpcj4rli85PPwOvk3gOo1WPNFG1fdfdtutbYSgl2RIgemDRGF/DeE1ag==
 
 "@readr-media/react-image@^1.5.1":
   version "1.5.1"


### PR DESCRIPTION
## Notable Change
1. 套件`@readr-media/react-image` 升版至2.2.0，該版本使用了`useState`以儲存圖片狀態。該改動可避免列表頁loadmore後，造成原本已經載入的圖片會再次載入的問題