### PR TITLE
refactor(mm-next): seperated mb_st logic from gptAd

### DIFF
--- a/packages/mirror-media-next/components/ads/gpt/gpt-ad.js
+++ b/packages/mirror-media-next/components/ads/gpt/gpt-ad.js
@@ -1,5 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
-import useFirstScrollDetector from '../../../hooks/useFirstScrollDetector.js'
+import { useState, useEffect } from 'react'
 
 import {
   getAdSlotParam,
@@ -22,16 +21,6 @@ const Wrapper = styled.div`
       display: block;
     }
   }
-  ${
-    /**
-     * @param {Object} props
-     * @param {boolean} props.shouldHideComponent
-     * @returns
-     */
-    ({ shouldHideComponent }) => {
-      return shouldHideComponent && 'display: none !important;'
-    }
-  };
 `
 
 const Ad = styled.div`
@@ -78,13 +67,7 @@ export default function GPTAd({
   const [adUnitPath, setAdUnitPath] = useState('')
   const [adWidth, setAdWidth] = useState('')
 
-  const hasScrolled = useFirstScrollDetector()
-  const shouldHideAtFirst = adKey === 'MB_ST'
   const adDivId = adUnitPath // Set the id of the ad `<div>` to be the same as the `adUnitPath`.
-
-  const shouldHideComponent = useMemo(() => {
-    return shouldHideAtFirst && !hasScrolled
-  }, [shouldHideAtFirst, hasScrolled])
 
   useEffect(() => {
     let newAdSize, newAdUnitPath, newAdWidth
@@ -177,10 +160,7 @@ export default function GPTAd({
   }, [adDivId, adSize, adUnitPath, adWidth, onSlotRenderEnded, onSlotRequested])
 
   return (
-    <Wrapper
-      className={`${className} gpt-ad`}
-      shouldHideComponent={shouldHideComponent}
-    >
+    <Wrapper className={`${className} gpt-ad`}>
       <Ad width={adWidth} id={adDivId} />
     </Wrapper>
   )

--- a/packages/mirror-media-next/components/ads/gpt/gpt-mb-st-ad.js
+++ b/packages/mirror-media-next/components/ads/gpt/gpt-mb-st-ad.js
@@ -14,8 +14,8 @@ export default function GPTMbStAd({ pageKey, className }) {
   const hasScrolled = useFirstScrollDetector()
 
   return (
-    <div className={`${className}`}>
-      {hasScrolled && <GPTAd pageKey={pageKey} adKey="MB_ST" />}
-    </div>
+    hasScrolled && (
+      <GPTAd pageKey={pageKey} adKey="MB_ST" className={className} />
+    )
   )
 }

--- a/packages/mirror-media-next/components/ads/gpt/gpt-mb-st-ad.js
+++ b/packages/mirror-media-next/components/ads/gpt/gpt-mb-st-ad.js
@@ -1,0 +1,21 @@
+import useFirstScrollDetector from '../../../hooks/useFirstScrollDetector.js'
+
+import GPTAd from './gpt-ad.js'
+
+/**
+ * @typedef {function(googletag.events.SlotRequestedEvent):void} GoogleTagEventHandler
+ *
+ * @param {Object} props
+ * @param {string} [props.pageKey] - key to access GPT_UNITS first layer
+ * @param {string} [props.className] - for styled-component method to add styles
+ * @returns
+ */
+export default function GPTMbStAd({ pageKey, className }) {
+  const hasScrolled = useFirstScrollDetector()
+
+  return (
+    <div className={`${className}`}>
+      {hasScrolled && <GPTAd pageKey={pageKey} adKey="MB_ST" />}
+    </div>
+  )
+}

--- a/packages/mirror-media-next/components/external/external-normal-style.js
+++ b/packages/mirror-media-next/components/external/external-normal-style.js
@@ -24,6 +24,7 @@ import {
   transformTimeDataIntoDotFormat,
   getActiveOrderSection,
 } from '../../utils'
+import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 
 import {
   URL_STATIC_POPULAR_NEWS,
@@ -382,7 +383,7 @@ const StyledGPTAd_FT = styled(GPTAd)`
   }
 `
 
-const StickyGPTAd_MB_ST = styled(GPTAd)`
+const StickyGPTAd_MB_ST = styled(GPTMbStAd)`
   display: block;
   position: fixed;
   left: 0;
@@ -678,7 +679,6 @@ export default function ExternalNormalStyle({ external }) {
           />
           <StickyGPTAd_MB_ST
             pageKey={getPageKeyByPartnerShowOnIndex(partner?.showOnIndex)}
-            adKey="MB_ST"
           />
         </>
       )}

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -21,6 +21,7 @@ import HeroImageAndVideo from './hero-image-and-video'
 import Divider from '../shared/divider'
 import ShareHeader from '../../shared/share-header'
 import Footer from '../../shared/footer'
+import GPTMbStAd from '../../ads/gpt/gpt-mb-st-ad'
 
 import {
   transformTimeDataIntoDotFormat,
@@ -397,7 +398,7 @@ const StyledGPTAd_FT = styled(GPTAd)`
   }
 `
 
-const StickyGPTAd_MB_ST = styled(GPTAd)`
+const StickyGPTAd_MB_ST = styled(GPTMbStAd)`
   display: block;
   position: fixed;
   left: 0;
@@ -751,7 +752,7 @@ export default function StoryNormalStyle({
       {shouldShowAd && <StyledGPTAd_FT pageKey={pageKeyForGptAd} adKey="FT" />}
 
       {shouldShowAd && noCategoryOfWineSlug ? (
-        <StickyGPTAd_MB_ST pageKey={pageKeyForGptAd} adKey="MB_ST" />
+        <StickyGPTAd_MB_ST pageKey={pageKeyForGptAd} />
       ) : null}
 
       <Footer footerType="default" />

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -21,6 +21,7 @@ import { useDisplayAd } from '../../../hooks/useDisplayAd'
 import { Z_INDEX } from '../../../constants/index'
 import { SECTION_IDS } from '../../../constants/index'
 import { getCategoryOfWineSlug, getActiveOrderSection } from '../../../utils'
+import GPTMbStAd from '../../../components/ads/gpt/gpt-mb-st-ad'
 const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
   ssr: false,
 })
@@ -95,7 +96,7 @@ const StyledGPTAd_FT = styled(GPTAd)`
   }
 `
 
-const StickyGPTAd_MB_ST = styled(GPTAd)`
+const StickyGPTAd_MB_ST = styled(GPTMbStAd)`
   display: block;
   position: fixed;
   left: 0;
@@ -343,7 +344,7 @@ export default function StoryPremiumStyle({
 
       {shouldShowAd && <StyledGPTAd_FT pageKey={pageKeyForGptAd} adKey="FT" />}
       {shouldShowAd && noCategoryOfWineSlug ? (
-        <StickyGPTAd_MB_ST pageKey={pageKeyForGptAd} adKey="MB_ST" />
+        <StickyGPTAd_MB_ST pageKey={pageKeyForGptAd} />
       ) : null}
 
       <Footer footerType="default" />

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -18,6 +18,7 @@ const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
 })
 import FullScreenAds from '../../components/ads/full-screen-ads'
+import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 
 const AuthorContainer = styled.main`
   width: 320px;
@@ -55,7 +56,7 @@ const StyledGPTAd = styled(GPTAd)`
   margin: 20px auto 0px;
 `
 
-const StickyGPTAd = styled(GPTAd)`
+const StickyGPTAd = styled(GPTMbStAd)`
   position: fixed;
   left: 0;
   right: 0;
@@ -105,7 +106,7 @@ export default function Author({ postsCount, posts, author, headerData }) {
           authorId={author.id}
           renderPageSize={RENDER_PAGE_SIZE}
         />
-        {shouldShowAd && <StickyGPTAd pageKey="other" adKey="MB_ST" />}
+        {shouldShowAd && <StickyGPTAd pageKey="other" />}
         {shouldShowAd && <FullScreenAds />}
       </AuthorContainer>
     </Layout>

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -24,6 +24,7 @@ const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
 })
 import FullScreenAds from '../../components/ads/full-screen-ads'
+import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -150,7 +151,7 @@ const StyledGPTAd = styled(GPTAd)`
   margin: 20px auto 0px;
 `
 
-const StickyGPTAd = styled(GPTAd)`
+const StickyGPTAd = styled(GPTMbStAd)`
   position: fixed;
   left: 0;
   right: 0;
@@ -230,7 +231,7 @@ export default function Category({
         />
 
         {shouldShowAd && isNotWineCategory ? (
-          <StickyGPTAd pageKey={GptPageKey} adKey="MB_ST" />
+          <StickyGPTAd pageKey={GptPageKey} />
         ) : null}
         <WineWarning categories={[category]} />
         {isNotWineCategory && <FullScreenAds />}

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -19,6 +19,7 @@ import { Z_INDEX } from '../../constants/index'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
 
 import FullScreenAds from '../../components/ads/full-screen-ads'
+import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -71,7 +72,7 @@ const StyledGPTAd = styled(GPTAd)`
   margin: 20px auto 0px;
 `
 
-const StickyGPTAd = styled(GPTAd)`
+const StickyGPTAd = styled(GPTMbStAd)`
   position: fixed;
   left: 0;
   right: 0;
@@ -136,7 +137,6 @@ export default function ExternalPartner({
         {shouldShowAd && (
           <StickyGPTAd
             pageKey={getPageKeyByPartnerShowOnIndex(partner?.showOnIndex)}
-            adKey="MB_ST"
           />
         )}
         {shouldShowAd && <FullScreenAds />}

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -16,6 +16,7 @@ import { fetchExternalCounts } from '../../apollo/query/externals'
 import { fetchExternalsWhichPartnerIsNotShowOnIndex } from '../../utils/api/externals'
 
 import FullScreenAds from '../../components/ads/full-screen-ads'
+import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -67,7 +68,7 @@ const StyledGPTAd = styled(GPTAd)`
   margin: 20px auto 0px;
 `
 
-const StickyGPTAd = styled(GPTAd)`
+const StickyGPTAd = styled(GPTMbStAd)`
   position: fixed;
   left: 0;
   right: 0;
@@ -120,9 +121,7 @@ export default function WarmLife({
           fetchExternalsFunction={fetchExternalsWhichPartnerIsNotShowOnIndex}
           externalsCount={warmLifeDataCount}
         />
-        {shouldShowAd && (
-          <StickyGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} adKey="MB_ST" />
-        )}
+        {shouldShowAd && <StickyGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} />}
         {shouldShowAd && <FullScreenAds />}
       </WarmLifeContainer>
     </Layout>

--- a/packages/mirror-media-next/pages/premiumsection/[slug].js
+++ b/packages/mirror-media-next/pages/premiumsection/[slug].js
@@ -15,6 +15,7 @@ import { SECTION_IDS } from '../../constants/index'
 import { Z_INDEX } from '../../constants/index'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
 import FullScreenAds from '../../components/ads/full-screen-ads'
+import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -87,7 +88,7 @@ const StyledGPTAd_HD = styled(GPTAd)`
   margin: 20px auto 0px;
 `
 
-const StickyGPTAd_MB_ST = styled(GPTAd)`
+const StickyGPTAd_MB_ST = styled(GPTMbStAd)`
   display: block;
   position: fixed;
   left: 0;
@@ -143,9 +144,7 @@ export default function Section({ postsCount, posts, section, headerData }) {
           renderPageSize={RENDER_PAGE_SIZE}
           isPremium={true}
         />
-        {shouldShowAd && (
-          <StickyGPTAd_MB_ST pageKey={SECTION_IDS['member']} adKey="MB_ST" />
-        )}
+        {shouldShowAd && <StickyGPTAd_MB_ST pageKey={SECTION_IDS['member']} />}
         {shouldShowAd && <FullScreenAds />}
       </SectionContainer>
     </Layout>

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -15,6 +15,7 @@ import {
 import { useDisplayAd } from '../../hooks/useDisplayAd'
 import { getSectionGPTPageKey } from '../../utils/ad'
 import FullScreenAds from '../../components/ads/full-screen-ads'
+import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -69,7 +70,7 @@ const StyledGPTAd = styled(GPTAd)`
   margin: 20px auto 0px;
 `
 
-const StickyGPTAd = styled(GPTAd)`
+const StickyGPTAd = styled(GPTMbStAd)`
   position: fixed;
   left: 0;
   right: 0;
@@ -131,10 +132,7 @@ export default function Section({ postsCount, posts, section, headerData }) {
         />
 
         {shouldShowAd && (
-          <StickyGPTAd
-            pageKey={getSectionGPTPageKey(section.slug)}
-            adKey="MB_ST"
-          />
+          <StickyGPTAd pageKey={getSectionGPTPageKey(section.slug)} />
         )}
         {shouldShowAd && <FullScreenAds />}
       </SectionContainer>

--- a/packages/mirror-media-next/pages/section/topic.js
+++ b/packages/mirror-media-next/pages/section/topic.js
@@ -11,6 +11,7 @@ import { fetchTopicList } from '../../utils/api/section-topic'
 import { Z_INDEX } from '../../constants/index'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
 import FullScreenAds from '../../components/ads/full-screen-ads'
+import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -61,7 +62,7 @@ const StyledGPTAd = styled(GPTAd)`
   margin: 20px auto 0px;
 `
 
-const StickyGPTAd = styled(GPTAd)`
+const StickyGPTAd = styled(GPTMbStAd)`
   position: fixed;
   left: 0;
   right: 0;
@@ -106,7 +107,7 @@ export default function Topics({ topics, topicsCount, headerData }) {
           topics={topics}
           renderPageSize={RENDER_PAGE_SIZE}
         />
-        {shouldShowAd && <StickyGPTAd pageKey="other" adKey="MB_ST" />}
+        {shouldShowAd && <StickyGPTAd pageKey="other" />}
         {shouldShowAd && <FullScreenAds />}
       </TopicsContainer>
     </Layout>

--- a/packages/mirror-media-next/pages/section/videohub.js
+++ b/packages/mirror-media-next/pages/section/videohub.js
@@ -25,6 +25,7 @@ import {
 import { Z_INDEX } from '../../constants/index'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
 import FullScreenAds from '../../components/ads/full-screen-ads'
+import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -96,7 +97,7 @@ const StyledGPTAd_MB_FT = styled(GPTAd)`
   }
 `
 
-const StickyGPTAd_MB_ST = styled(GPTAd)`
+const StickyGPTAd_MB_ST = styled(GPTMbStAd)`
   display: block;
   position: fixed;
   left: 0;
@@ -169,7 +170,7 @@ export default function SectionVideohub({
           />
         ))}
         {shouldShowAd && <StyledGPTAd_PC_FT pageKey="videohub" adKey="PC_FT" />}
-        {shouldShowAd && <StickyGPTAd_MB_ST pageKey="videohub" adKey="MB_ST" />}
+        {shouldShowAd && <StickyGPTAd_MB_ST pageKey="videohub" />}
         {shouldShowAd && <FullScreenAds />}
       </Wrapper>
     </Layout>

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -14,6 +14,7 @@ import FullScreenAds from '../../components/ads/full-screen-ads'
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
 })
+import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 
 const TagContainer = styled.main`
   width: 320px;
@@ -72,7 +73,7 @@ const StyledGPTAd = styled(GPTAd)`
   margin: 20px auto 0px;
 `
 
-const StickyGPTAd = styled(GPTAd)`
+const StickyGPTAd = styled(GPTMbStAd)`
   position: fixed;
   left: 0;
   right: 0;
@@ -128,7 +129,7 @@ export default function Tag({ postsCount, posts, tag, headerData }) {
           renderPageSize={RENDER_PAGE_SIZE}
         />
 
-        {shouldShowAd && <StickyGPTAd pageKey="other" adKey="MB_ST" />}
+        {shouldShowAd && <StickyGPTAd pageKey="other" />}
         {shouldShowAd && <FullScreenAds />}
       </TagContainer>
     </Layout>

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -21,6 +21,7 @@ import {
   fetchYoutubeVideoByVideoId,
 } from '../../utils/api/video'
 import FullScreenAds from '../../components/ads/full-screen-ads'
+import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -94,7 +95,7 @@ const StyledGPTAd_FT = styled(GPTAd)`
   }
 `
 
-const StickyGPTAd = styled(GPTAd)`
+const StickyGPTAd = styled(GPTMbStAd)`
   position: fixed;
   left: 0;
   right: 0;
@@ -149,7 +150,7 @@ export default function Video({ video, latestVideos, headerData }) {
         {shouldShowAd && (
           <>
             <StyledGPTAd_FT pageKey="videohub" adKey="FT" />
-            <StickyGPTAd pageKey="videohub" adKey="MB_ST" />
+            <StickyGPTAd pageKey="videohub" />
             <FullScreenAds />
           </>
         )}

--- a/packages/mirror-media-next/pages/video_category/[slug].js
+++ b/packages/mirror-media-next/pages/video_category/[slug].js
@@ -17,6 +17,7 @@ import {
 import { Z_INDEX } from '../../constants/index'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
 import FullScreenAds from '../../components/ads/full-screen-ads'
+import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad.js'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -56,7 +57,7 @@ const StyledGPTAd_MB_HD = styled(GPTAd)`
   }
 `
 
-const StickyGPTAd_MB_ST = styled(GPTAd)`
+const StickyGPTAd_MB_ST = styled(GPTMbStAd)`
   display: block;
   position: fixed;
   left: 0;
@@ -119,7 +120,7 @@ export default function VideoCategory({
             categorySlug={category.slug}
           />
         )}
-        {shouldShowAd && <StickyGPTAd_MB_ST pageKey="videohub" adKey="MB_ST" />}
+        {shouldShowAd && <StickyGPTAd_MB_ST pageKey="videohub" />}
         {shouldShowAd && <FullScreenAds />}
       </Wrapper>
     </Layout>


### PR DESCRIPTION
### Notable Change
將 `MB_ST` 的 gpt 廣告邏輯額外抽出成新的 components。