### PR TITLE
refactor(mm-next/gpt-ad): show ad in corresponding viewport

### DIFF
--- a/packages/mirror-media-next/components/ads/gpt/gpt-ad.js
+++ b/packages/mirror-media-next/components/ads/gpt/gpt-ad.js
@@ -46,23 +46,27 @@ const Ad = styled.div`
 /**
  * @typedef {function(googletag.events.SlotRequestedEvent):void} GoogleTagEventHandler
  *
- * @param {Object} props
- * @param {string} [props.pageKey] - key to access GPT_UNITS first layer
- * @param {string} [props.adKey] - key to access GPT_UNITS second layer, might need to complete with device
- * @param {string} [props.adUnit]
- * @param {GoogleTagEventHandler} [props.onSlotRequested] - callback when slotRequested event occurs
- * @param {GoogleTagEventHandler} [props.onSlotRenderEnded] - callback when slotRenderEnded event occurs
- * @param {string} [props.className] - for styled-component method to add styles
+ * @typedef {object} GPTAdProps
+ * @property {string} [pageKey] - key to access GPT_UNITS first layer
+ * @property {string} [adKey] - key to access GPT_UNITS second layer, might need to complete with device
+ * @property {string} [adUnit]
+ * @property {GoogleTagEventHandler} [onSlotRequested] - callback when slotRequested event occurs
+ * @property {GoogleTagEventHandler} [onSlotRenderEnded] - callback when slotRenderEnded event occurs
+ * @property {string} [className] - for styled-component method to add styles
+ *
+ 
+/** 
+ * @param {GPTAdProps} props
  * @returns
  */
-export default function GPTAd({
+const GPTAdRoot = ({
   pageKey,
   adKey,
   adUnit,
   onSlotRequested,
   onSlotRenderEnded,
   className,
-}) {
+}) => {
   const [adSize, setAdSize] = useState([])
   const [adUnitPath, setAdUnitPath] = useState('')
   const [adWidth, setAdWidth] = useState('')
@@ -163,5 +167,70 @@ export default function GPTAd({
     <Wrapper className={`${className} gpt-ad`}>
       <Ad width={adWidth} id={adDivId} />
     </Wrapper>
+  )
+}
+
+/**
+ * @param {GPTAdProps} props
+ * @returns
+ */
+export default function GptAd({
+  pageKey,
+  adKey,
+  adUnit,
+  onSlotRequested,
+  onSlotRenderEnded,
+  className,
+}) {
+  const [shouldShowAd, setShouldAd] = useState(false)
+  const isBuildInAdUnit = pageKey && adKey
+  const isCustomAdUnit = adUnit
+  const isValidAd = isBuildInAdUnit || isCustomAdUnit
+
+  /**
+   * If adKey contain 'MB', which means this ad should only render at device which viewport is smaller then 1200px.
+   * If adKey contain 'PC', which means this ad should only render at device which viewport is smaller larger 1200px.
+   *
+   * Why we use `window.innerWidth` to decide should show GPT ad, not just using css `@media-query`?
+   * Because in GPT ad, ad unit will load even if ad is unseen (`display: none`).
+   * The inconsistency between the loading and rendering of ads does not align with our business logic.
+   */
+  useEffect(() => {
+    const width = window.innerWidth
+
+    if (!width || !isValidAd) {
+      return
+    }
+    const isDesktopWidth = width >= 1200
+    if (isBuildInAdUnit) {
+      switch (true) {
+        case adKey?.includes('MB'):
+          setShouldAd(!isDesktopWidth)
+          return
+        case adKey?.includes('PC'):
+          setShouldAd(isDesktopWidth)
+          return
+        default:
+          setShouldAd(true)
+          return
+      }
+    } else if (isCustomAdUnit) {
+      setShouldAd(true)
+      return
+    }
+  }, [adKey, pageKey, isBuildInAdUnit, isCustomAdUnit, isValidAd])
+  return (
+    <>
+      {shouldShowAd && isValidAd ? (
+        <GPTAdRoot
+          className={className}
+          pageKey={pageKey}
+          adKey={adKey}
+          adUnit={adUnit}
+          onSlotRenderEnded={onSlotRenderEnded}
+          onSlotRequested={onSlotRequested}
+        ></GPTAdRoot>
+      ) : null}
+    </>
   )
 }


### PR DESCRIPTION
## Notable change
1. 原本的廣告元件`GptAd`，更名為`GptAdRoot`，用於依據`adKey`、`pageKey`、`adUnit` 初始化廣告，並依據需求註冊事件。
2. 在`GptAdRoot`外部新增一層父元件`GptAd`，並依據螢幕寬度與`adKey`等資訊，決定是否需要顯示廣告。
3. 需要使用`window.innerWidth` 來決定是否顯示廣告，而非僅使用css `@media-query`，是因為就算使用css `@media-query` 與`display:none`使廣告不顯示，但廣告單元還是會載入。廣告單元載入與顯示的不一致性，並不符合我們的業務邏輯。
4. 將元件分為`GptAdRoot` 與 `GptAd` ，是希望將「顯示邏輯」與「廣告載入邏輯」分開，方便日後理解與閱讀。