### PR TITLE
refactor(mm-next): add SITE_BASE_CONFIG to image paths

### DIFF
--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -9,6 +9,9 @@ const NEWEBPAY_PAPERMAG_KEY =
 const NEWEBPAY_PAPERMAG_IV =
   process.env.NEWEBPAY_PAPERMAG_IV || 'newebpay-papermag-iv'
 
+// should be applied in preview mode
+const SITE_BASE_PATH = IS_PREVIEW_MODE ? '/preview-server' : ''
+
 // The following variables are given values according to different `ENV`
 
 let SITE_URL = ''
@@ -218,6 +221,7 @@ export {
   IS_PREVIEW_MODE,
   PREVIEW_SERVER_ORIGIN,
   SITE_URL,
+  SITE_BASE_PATH,
   GCP_PROJECT_ID,
   API_TIMEOUT,
   API_TIMEOUT_GRAPHQL,

--- a/packages/mirror-media-next/middleware.js
+++ b/packages/mirror-media-next/middleware.js
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import { IS_PREVIEW_MODE, SITE_BASE_PATH } from './config/index.mjs'
+
+/** @typedef {import('next/server').NextRequest} NextRequest */
+
+/**
+ * @param {NextRequest} request
+ * @returns {NextResponse}
+ */
+export function middleware(request) {
+  if (IS_PREVIEW_MODE && request.nextUrl.pathname.startsWith('/images-next')) {
+    // applied SITE_BASE_PATH to images under /public folder when server in preview mode
+    return NextResponse.rewrite(
+      new URL(`${SITE_BASE_PATH}${request.nextUrl.pathname}`, request.url)
+    )
+  } else {
+    return NextResponse.next()
+  }
+}

--- a/packages/mirror-media-next/next.config.mjs
+++ b/packages/mirror-media-next/next.config.mjs
@@ -1,9 +1,8 @@
-import { DONATION_PAGE_URL, IS_PREVIEW_MODE } from './config/index.mjs'
+import { DONATION_PAGE_URL, SITE_BASE_PATH } from './config/index.mjs'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Add assetPrefix to prevent /_next route collision between CMS and preview server
-  assetPrefix: IS_PREVIEW_MODE ? '/preview-server' : undefined,
+  basePath: SITE_BASE_PATH,
   reactStrictMode: true,
   swcMinify: true,
   compiler: {


### PR DESCRIPTION
## Notable Changes
* 增加 `SITE_BASE_PATH` 設定
* 調整圖片連結資訊，在開頭增加 `SITE_BASE_PATH` 的資訊

## Reminders
* 因為 CMS 和本專案都是使用 Next.js 實作前端網頁，會在一些路徑上產生衝突，為了能夠在 preview mode 正確運作，須在本專案這邊藉由 `basePath` 的設定，讓它在特定子資料夾路徑下運作，網站自身使用的圖片也需要增加 `basePath` 相關資訊，才能夠被正確存取。