### PR TITLE
feat(mm-next/gpt-ad): add placeholder to prevent CLS problem

### DIFF
--- a/packages/mirror-media-next/components/ads/gpt/gpt-placeholder.js
+++ b/packages/mirror-media-next/components/ads/gpt/gpt-placeholder.js
@@ -1,0 +1,94 @@
+import styled from 'styled-components'
+
+/**
+ * @typedef {string} Width
+ * @typedef {string} Height
+ * @typedef {string} Margin
+ *
+ *
+ * @typedef {Object} Rwd
+ * @property {{width: Width, height: Height, margin: Margin}} rwd.mobile
+ * @property {{width: Width, height: Height, margin: Margin}} rwd.tablet
+ * @property {{width: Width, height: Height, margin: Margin}} rwd.desktop
+ */
+
+const Container = styled.div`
+  min-width: ${
+    /** @param {{rwd: Rwd}} props*/
+    ({ rwd }) => rwd.mobile.width
+  };
+  min-height: ${({ rwd }) => rwd.mobile.height};
+  margin: ${({ rwd }) => rwd.mobile.margin};
+  ${({ theme }) => theme.breakpoint.md} {
+    min-width: ${
+      /** @param {{rwd: Rwd}} props*/
+      ({ rwd }) => rwd.tablet.width
+    };
+    min-height: ${({ rwd }) => rwd.tablet.height};
+    margin: ${({ rwd }) => rwd.tablet.margin};
+  }
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    min-width: ${({ rwd }) => rwd.desktop.width};
+    min-height: ${({ rwd }) => rwd.desktop.height};
+    margin: ${({ rwd }) => rwd.desktop.margin};
+  }
+`
+const ContainerMobileAndTablet = styled(Container)`
+  display: block;
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: none;
+  }
+`
+const ContainerDesktop = styled(Container)`
+  display: none;
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: block;
+  }
+`
+
+const DEFAULT_SIZES = {
+  mobile: {
+    width: '300px',
+    height: '250px',
+    margin: '20px auto 0px',
+  },
+  tablet: {
+    width: '300px',
+    height: '250px',
+    margin: '20px auto 0px',
+  },
+  desktop: {
+    width: '970px',
+    height: '250px',
+    margin: '20px auto 0px',
+  },
+}
+
+/**
+ *
+ * @param {Object} props
+ * @param {Rwd} [props.rwd]
+ * @param {JSX.Element} props.children
+ * @returns {JSX.Element}
+ */
+export default function GPT_Placeholder({ rwd = DEFAULT_SIZES, children }) {
+  return <Container rwd={rwd}>{children}</Container>
+}
+/**
+ *
+ * @param {Object} props
+ * @param {Rwd} [props.rwd]
+ * @param {JSX.Element} props.children
+ * @returns
+ */
+const GPT_Placeholder_MobileAndTablet = ({ rwd = DEFAULT_SIZES, children }) => {
+  return (
+    <ContainerMobileAndTablet rwd={rwd}>{children}</ContainerMobileAndTablet>
+  )
+}
+const GPT_Placeholder_Desktop = ({ rwd = DEFAULT_SIZES, children }) => {
+  return <ContainerDesktop rwd={rwd}>{children}</ContainerDesktop>
+}
+
+export { GPT_Placeholder_MobileAndTablet, GPT_Placeholder_Desktop }

--- a/packages/mirror-media-next/components/external/external-normal-style.js
+++ b/packages/mirror-media-next/components/external/external-normal-style.js
@@ -25,7 +25,7 @@ import {
   getActiveOrderSection,
 } from '../../utils'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
-
+import GPT_Placeholder from '../ads/gpt/gpt-placeholder'
 import {
   URL_STATIC_POPULAR_NEWS,
   URL_STATIC_LATEST_NEWS_IN_CERTAIN_SECTION,
@@ -266,7 +266,6 @@ const AsideFbPagePlugin = styled(FbPagePlugin)`
 const StyledGPTAd_HD = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
 `
 
 //Because AT1, AT2, AT3 contain full-screen size ads content, should not set max-width and max-height
@@ -509,12 +508,14 @@ export default function ExternalNormalStyle({ external }) {
 
   return (
     <>
-      {shouldShowAd && (
-        <StyledGPTAd_HD
-          pageKey={getPageKeyByPartnerShowOnIndex(partner?.showOnIndex)}
-          adKey="HD"
-        />
-      )}
+      <GPT_Placeholder>
+        {shouldShowAd && (
+          <StyledGPTAd_HD
+            pageKey={getPageKeyByPartnerShowOnIndex(partner?.showOnIndex)}
+            adKey="HD"
+          />
+        )}
+      </GPT_Placeholder>
 
       <Main>
         <Article>

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -37,6 +37,7 @@ import { useDisplayAd } from '../../../hooks/useDisplayAd'
 import { Z_INDEX } from '../../../constants/index'
 import { getSectionGPTPageKey } from '../../../utils/ad'
 import { getActiveOrderSection } from '../../../utils'
+import GPT_Placeholder from '../../ads/gpt/gpt-placeholder'
 
 const DableAd = dynamic(() => import('../../ads/dable/dable-ad'), {
   ssr: false,
@@ -338,7 +339,6 @@ const DableADContainer_Mobile = styled.div`
 const StyledGPTAd_HD = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
 `
 //Because AT1, AT2, AT3 contain full-screen size ads content, should not set max-width and max-height
 const StyledGPTAd_MB_AT3 = styled(GPTAd)`
@@ -593,7 +593,11 @@ export default function StoryNormalStyle({
         }}
       />
 
-      {shouldShowAd && <StyledGPTAd_HD pageKey={pageKeyForGptAd} adKey="HD" />}
+      <GPT_Placeholder>
+        {shouldShowAd && (
+          <StyledGPTAd_HD pageKey={pageKeyForGptAd} adKey="HD" />
+        )}
+      </GPT_Placeholder>
 
       <Main>
         <Article>

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -22,6 +22,7 @@ import { Z_INDEX } from '../../../constants/index'
 import { SECTION_IDS } from '../../../constants/index'
 import { getCategoryOfWineSlug, getActiveOrderSection } from '../../../utils'
 import GPTMbStAd from '../../../components/ads/gpt/gpt-mb-st-ad'
+import GPT_Placeholder from '../../ads/gpt/gpt-placeholder'
 const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
   ssr: false,
 })
@@ -83,7 +84,6 @@ const SocialMedia = styled.li`
 const StyledGPTAd_HD = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
 `
 
 const StyledGPTAd_FT = styled(GPTAd)`
@@ -268,7 +268,11 @@ export default function StoryPremiumStyle({
         }}
       />
 
-      {shouldShowAd && <StyledGPTAd_HD pageKey={pageKeyForGptAd} adKey="HD" />}
+      <GPT_Placeholder>
+        {shouldShowAd && (
+          <StyledGPTAd_HD pageKey={pageKeyForGptAd} adKey="HD" />
+        )}
+      </GPT_Placeholder>
 
       <Main>
         <article>

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -19,6 +19,7 @@ const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
 })
 import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
+import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 
 const AuthorContainer = styled.main`
   width: 320px;
@@ -53,7 +54,6 @@ const AuthorTitle = styled.h1`
 const StyledGPTAd = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
 `
 
 const StickyGPTAd = styled(GPTMbStAd)`
@@ -98,7 +98,9 @@ export default function Author({ postsCount, posts, author, headerData }) {
       footer={{ type: 'default' }}
     >
       <AuthorContainer>
-        {shouldShowAd && <StyledGPTAd pageKey="other" adKey="HD" />}
+        <GPT_Placeholder>
+          {shouldShowAd && <StyledGPTAd pageKey="other" adKey="HD" />}
+        </GPT_Placeholder>
         {authorName && <AuthorTitle>{authorName}</AuthorTitle>}
         <AuthorArticles
           postsCount={postsCount}

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -25,6 +25,7 @@ const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
 })
 import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
+import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -148,7 +149,6 @@ const PremiumCategoryTitle = styled.h1`
 const StyledGPTAd = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
 `
 
 const StickyGPTAd = styled(GPTMbStAd)`
@@ -210,7 +210,9 @@ export default function Category({
       footer={{ type: 'default' }}
     >
       <CategoryContainer isPremium={isPremium}>
-        {shouldShowAd && <StyledGPTAd pageKey={GptPageKey} adKey="HD" />}
+        <GPT_Placeholder>
+          {shouldShowAd && <StyledGPTAd pageKey={GptPageKey} adKey="HD" />}
+        </GPT_Placeholder>
 
         {isPremium ? (
           <PremiumCategoryTitle sectionName={sectionSlug}>

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -20,6 +20,7 @@ import { useDisplayAd } from '../../hooks/useDisplayAd'
 
 import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
+import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -69,7 +70,6 @@ const PartnerTitle = styled.h1`
 const StyledGPTAd = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
 `
 
 const StickyGPTAd = styled(GPTMbStAd)`
@@ -118,12 +118,14 @@ export default function ExternalPartner({
       footer={{ type: 'default' }}
     >
       <PartnerContainer>
-        {shouldShowAd && (
-          <StyledGPTAd
-            pageKey={getPageKeyByPartnerShowOnIndex(partner?.showOnIndex)}
-            adKey="HD"
-          />
-        )}
+        <GPT_Placeholder>
+          {shouldShowAd && (
+            <StyledGPTAd
+              pageKey={getPageKeyByPartnerShowOnIndex(partner?.showOnIndex)}
+              adKey="HD"
+            />
+          )}
+        </GPT_Placeholder>
         <PartnerTitle partnerColor={getExternalPartnerColor(partner)}>
           {partner?.name}
         </PartnerTitle>

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -17,6 +17,7 @@ import { fetchExternalsWhichPartnerIsNotShowOnIndex } from '../../utils/api/exte
 
 import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
+import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -65,7 +66,6 @@ const WarmLifeTitle = styled.h1`
 const StyledGPTAd = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
 `
 
 const StickyGPTAd = styled(GPTMbStAd)`
@@ -111,9 +111,11 @@ export default function WarmLife({
       footer={{ type: 'default' }}
     >
       <WarmLifeContainer>
-        {shouldShowAd && (
-          <StyledGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} adKey="HD" />
-        )}
+        <GPT_Placeholder>
+          {shouldShowAd && (
+            <StyledGPTAd pageKey={WARMLIFE_GPT_SECTION_IDS} adKey="HD" />
+          )}
+        </GPT_Placeholder>
         <WarmLifeTitle>{WARMLIFE_DEFAULT_TITLE}</WarmLifeTitle>
         <PartnerArticles
           externals={warmLifeData}

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -20,6 +20,7 @@ import LatestNews from '../components/latest-news'
 import Layout from '../components/shared/layout'
 import { useDisplayAd } from '../hooks/useDisplayAd'
 import FullScreenAds from '../components/ads/full-screen-ads'
+import GPT_Placeholder from '../components/ads/gpt/gpt-placeholder'
 
 const GPTAd = dynamic(() => import('../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -57,7 +58,6 @@ const IndexContainer = styled.main`
 const StyledGPTAd_HD = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
 `
 
 const StyledGPTAd_PC_B1 = styled(GPTAd)`
@@ -129,7 +129,9 @@ export default function Home({
       }}
     >
       <IndexContainer>
-        {shouldShowAd && <StyledGPTAd_HD pageKey="home" adKey="HD" />}
+        <GPT_Placeholder>
+          {shouldShowAd && <StyledGPTAd_HD pageKey="home" adKey="HD" />}
+        </GPT_Placeholder>
         <EditorChoice editorChoice={editorChoice}></EditorChoice>
         {shouldShowAd && <StyledGPTAd_PC_B1 pageKey="home" adKey="PC_B1" />}
         {shouldShowAd && <StyledGPTAd_MB_L1 pageKey="home" adKey="MB_L1" />}

--- a/packages/mirror-media-next/pages/premiumsection/[slug].js
+++ b/packages/mirror-media-next/pages/premiumsection/[slug].js
@@ -16,6 +16,7 @@ import { Z_INDEX } from '../../constants/index'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
 import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
+import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -85,7 +86,6 @@ const SectionTitle = styled.h1`
 const StyledGPTAd_HD = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
 `
 
 const StickyGPTAd_MB_ST = styled(GPTMbStAd)`
@@ -131,9 +131,11 @@ export default function Section({ postsCount, posts, section, headerData }) {
       footer={{ type: 'default' }}
     >
       <SectionContainer>
-        {shouldShowAd && (
-          <StyledGPTAd_HD pageKey={SECTION_IDS['member']} adKey="HD" />
-        )}
+        <GPT_Placeholder>
+          {shouldShowAd && (
+            <StyledGPTAd_HD pageKey={SECTION_IDS['member']} adKey="HD" />
+          )}
+        </GPT_Placeholder>
         {sectionName && (
           <SectionTitle sectionName={section.slug}>{sectionName}</SectionTitle>
         )}

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -16,6 +16,7 @@ import { useDisplayAd } from '../../hooks/useDisplayAd'
 import { getSectionGPTPageKey } from '../../utils/ad'
 import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
+import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -67,7 +68,6 @@ const SectionTitle = styled.h1`
 const StyledGPTAd = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
 `
 
 const StickyGPTAd = styled(GPTMbStAd)`
@@ -113,13 +113,14 @@ export default function Section({ postsCount, posts, section, headerData }) {
       footer={{ type: 'default' }}
     >
       <SectionContainer>
-        {shouldShowAd && (
-          <StyledGPTAd
-            pageKey={getSectionGPTPageKey(section.slug)}
-            adKey="HD"
-          />
-        )}
-
+        <GPT_Placeholder>
+          {shouldShowAd && (
+            <StyledGPTAd
+              pageKey={getSectionGPTPageKey(section.slug)}
+              adKey="HD"
+            />
+          )}
+        </GPT_Placeholder>
         {sectionName && (
           <SectionTitle sectionName={section.slug}>{sectionName}</SectionTitle>
         )}

--- a/packages/mirror-media-next/pages/section/topic.js
+++ b/packages/mirror-media-next/pages/section/topic.js
@@ -12,6 +12,7 @@ import { Z_INDEX } from '../../constants/index'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
 import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
+import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -59,7 +60,6 @@ const TopicsTitle = styled.h1`
 const StyledGPTAd = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
 `
 
 const StickyGPTAd = styled(GPTMbStAd)`
@@ -100,7 +100,9 @@ export default function Topics({ topics, topicsCount, headerData }) {
       footer={{ type: 'default' }}
     >
       <TopicsContainer>
-        {shouldShowAd && <StyledGPTAd pageKey="other" adKey="HD" />}
+        <GPT_Placeholder>
+          {shouldShowAd && <StyledGPTAd pageKey="other" adKey="HD" />}
+        </GPT_Placeholder>
         <TopicsTitle>精選專區</TopicsTitle>
         <SectionTopics
           topicsCount={topicsCount}

--- a/packages/mirror-media-next/pages/section/videohub.js
+++ b/packages/mirror-media-next/pages/section/videohub.js
@@ -26,6 +26,10 @@ import { Z_INDEX } from '../../constants/index'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
 import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
+import {
+  GPT_Placeholder_Desktop,
+  GPT_Placeholder_MobileAndTablet,
+} from '../../components/ads/gpt/gpt-placeholder'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -55,25 +59,9 @@ const Wrapper = styled.main`
   }
 `
 
-const StyledGPTAd_PC_HD = styled(GPTAd)`
-  display: none;
-
-  ${({ theme }) => theme.breakpoint.xl} {
-    width: 100%;
-    height: auto;
-    margin: 20px auto 0px;
-    display: block;
-  }
-`
-
-const StyledGPTAd_MB_HD = styled(GPTAd)`
+const StyledGPTAd_HD = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
-
-  ${({ theme }) => theme.breakpoint.xl} {
-    display: none;
-  }
 `
 
 const StyledGPTAd_PC_FT = styled(GPTAd)`
@@ -139,7 +127,9 @@ export default function SectionVideohub({
       footer={{ type: 'default' }}
     >
       <Wrapper>
-        {shouldShowAd && <StyledGPTAd_PC_HD pageKey="videohub" adKey="PC_HD" />}
+        <GPT_Placeholder_Desktop>
+          {shouldShowAd && <StyledGPTAd_HD pageKey="videohub" adKey="PC_HD" />}
+        </GPT_Placeholder_Desktop>
         {hasHVCVideo && (
           <LeadingVideo
             video={highestViewCountVideo}
@@ -150,7 +140,9 @@ export default function SectionVideohub({
             }}
           />
         )}
-        {shouldShowAd && <StyledGPTAd_MB_HD pageKey="videohub" adKey="MB_HD" />}
+        <GPT_Placeholder_MobileAndTablet>
+          {shouldShowAd && <StyledGPTAd_HD pageKey="videohub" adKey="MB_HD" />}
+        </GPT_Placeholder_MobileAndTablet>
         {hasLatestVideo && (
           <VideoList
             videos={latestVideos}

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -15,6 +15,7 @@ const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
 })
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
+import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 
 const TagContainer = styled.main`
   width: 320px;
@@ -70,7 +71,6 @@ const TagTitle = styled.h1`
 const StyledGPTAd = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
 `
 
 const StickyGPTAd = styled(GPTMbStAd)`
@@ -114,7 +114,9 @@ export default function Tag({ postsCount, posts, tag, headerData }) {
       footer={{ type: 'default' }}
     >
       <TagContainer>
-        {shouldShowAd && <StyledGPTAd pageKey="other" adKey="HD" />}
+        <GPT_Placeholder>
+          {shouldShowAd && <StyledGPTAd pageKey="other" adKey="HD" />}
+        </GPT_Placeholder>
 
         {tagName && (
           <TagTitleWrapper>

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -22,6 +22,10 @@ import {
 } from '../../utils/api/video'
 import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
+import {
+  GPT_Placeholder_Desktop,
+  GPT_Placeholder_MobileAndTablet,
+} from '../../components/ads/gpt/gpt-placeholder'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -58,16 +62,6 @@ const ContentWrapper = styled.div`
 const StyledGPTAd_HD = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 8px auto;
-
-  ${({ theme }) => theme.breakpoint.md} {
-    margin: 24px auto;
-  }
-
-  ${({ theme }) => theme.breakpoint.xl} {
-    margin: 0px auto 28px;
-    order: -1;
-  }
 `
 
 const StyledGPTAd_E1 = styled(GPTAd)`
@@ -109,6 +103,13 @@ const StickyGPTAd = styled(GPTMbStAd)`
     display: none;
   }
 `
+
+const GPT_PLACEHOLDER_SIZES = {
+  mobile: { width: '300px', height: '250px', margin: '8px auto' },
+  tablet: { width: '300px', height: '250px', margin: '24px auto' },
+  desktop: { width: '970px', height: '250px', margin: '0px auto 28px' },
+}
+
 /**
  * @param {Object} props
  * @param {import('../../type/youtube').YoutubeVideo} props.video
@@ -130,9 +131,14 @@ export default function Video({ video, latestVideos, headerData }) {
       footer={{ type: 'default' }}
     >
       <Wrapper>
+        <GPT_Placeholder_Desktop rwd={GPT_PLACEHOLDER_SIZES}>
+          {shouldShowAd && <StyledGPTAd_HD pageKey="videohub" adKey="PC_HD" />}
+        </GPT_Placeholder_Desktop>
         <YoutubeIframe videoId={video.id} gtmClassName="GTM-video-yt-play" />
 
-        {shouldShowAd && <StyledGPTAd_HD pageKey="videohub" adKey="HD" />}
+        <GPT_Placeholder_MobileAndTablet rwd={GPT_PLACEHOLDER_SIZES}>
+          {shouldShowAd && <StyledGPTAd_HD pageKey="videohub" adKey="MB_HD" />}
+        </GPT_Placeholder_MobileAndTablet>
 
         <ContentWrapper>
           <YoutubeArticle video={video} />

--- a/packages/mirror-media-next/pages/video_category/[slug].js
+++ b/packages/mirror-media-next/pages/video_category/[slug].js
@@ -18,6 +18,10 @@ import { Z_INDEX } from '../../constants/index'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
 import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad.js'
+import {
+  GPT_Placeholder_Desktop,
+  GPT_Placeholder_MobileAndTablet,
+} from '../../components/ads/gpt/gpt-placeholder.js'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -36,25 +40,9 @@ const Wrapper = styled.div`
   }
 `
 
-const StyledGPTAd_PC_HD = styled(GPTAd)`
-  display: none;
-
-  ${({ theme }) => theme.breakpoint.xl} {
-    width: 100%;
-    height: auto;
-    margin: 20px auto 0px;
-    display: block;
-  }
-`
-
-const StyledGPTAd_MB_HD = styled(GPTAd)`
+const StyledGPTAd_HD = styled(GPTAd)`
   width: 100%;
   height: auto;
-  margin: 20px auto 0px;
-
-  ${({ theme }) => theme.breakpoint.xl} {
-    display: none;
-  }
 `
 
 const StickyGPTAd_MB_ST = styled(GPTMbStAd)`
@@ -102,7 +90,9 @@ export default function VideoCategory({
       footer={{ type: 'default' }}
     >
       <Wrapper>
-        {shouldShowAd && <StyledGPTAd_PC_HD pageKey="videohub" adKey="PC_HD" />}
+        <GPT_Placeholder_Desktop>
+          {shouldShowAd && <StyledGPTAd_HD pageKey="videohub" adKey="PC_HD" />}
+        </GPT_Placeholder_Desktop>
         <LeadingVideo
           video={firstVideo}
           title={categoryName}
@@ -112,7 +102,9 @@ export default function VideoCategory({
             youtube: 'GTM-leading-video-yt-play',
           }}
         />
-        {shouldShowAd && <StyledGPTAd_MB_HD pageKey="videohub" adKey="MB_HD" />}
+        <GPT_Placeholder_MobileAndTablet>
+          {shouldShowAd && <StyledGPTAd_HD pageKey="videohub" adKey="MB_HD" />}
+        </GPT_Placeholder_MobileAndTablet>
         {hasMoreThanOneVideo && (
           <CategoryVideos
             videoItems={remainingVideos}


### PR DESCRIPTION
## Notable change
1. 新增元件`gpt-placeholder`，可傳入不同尺寸下的最小寬度、最小高度、margin。
2. 將上述元件使用在gpt HD廣告中，避免CLS問題。