### PR TITLE
style(mm-next): unify fony setting, only use shared-style

### DIFF
--- a/packages/mirror-media-next/components/ads/micro-ad/micro-ad-with-label.js
+++ b/packages/mirror-media-next/components/ads/micro-ad/micro-ad-with-label.js
@@ -34,7 +34,6 @@ const typeListing = css`
         padding: 8px;
         color: white;
         background-color: #bcbcbc;
-        font-family: 'PingFang TC';
         font-style: normal;
         font-weight: 600;
         font-size: 18px;
@@ -305,7 +304,6 @@ const typeStory = css`
       display: flex;
       align-items: center;
       justify-content: center;
-      font-family: 'PingFang TC';
       font-style: normal;
       font-weight: 600;
       font-size: 18px;
@@ -365,7 +363,6 @@ const typeStory = css`
             position: absolute;
             bottom: 0;
             right: 103px;
-            font-family: 'PingFang TC';
             font-style: normal;
             font-weight: 600;
             font-size: 12px;

--- a/packages/mirror-media-next/components/ads/pop-in/pop-in-ad-in-hot-list.js
+++ b/packages/mirror-media-next/components/ads/pop-in/pop-in-ad-in-hot-list.js
@@ -45,7 +45,6 @@ const StyledPopInAd = styled(PopInAd)`
       display: flex;
       align-items: center;
       justify-content: center;
-      font-family: 'PingFang TC';
       font-style: normal;
       font-weight: 600;
       font-size: 18px;

--- a/packages/mirror-media-next/components/ads/pop-in/pop-in-ad-in-related-list.js
+++ b/packages/mirror-media-next/components/ads/pop-in/pop-in-ad-in-related-list.js
@@ -67,7 +67,6 @@ const StyledPopInAd = styled(PopInAd)`
         display: flex;
         align-items: center;
         justify-content: center;
-        font-family: 'PingFang TC';
         font-style: normal;
         font-weight: 600;
         font-size: 18px;

--- a/packages/mirror-media-next/components/gdpr.js
+++ b/packages/mirror-media-next/components/gdpr.js
@@ -6,7 +6,6 @@ const Wrapper = styled.div`
   position: relative;
   z-index: ${Z_INDEX.coverHeader};
   color: white;
-  font-family: var(--notosansTC-font);
 
   ${
     /**

--- a/packages/mirror-media-next/components/magazine/ui-join-premium-member.js
+++ b/packages/mirror-media-next/components/magazine/ui-join-premium-member.js
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import SubscribeLink from '../../components/story/shared/subscribe-link'
 
 const Wrapper = styled.div`
-  font-family: PingFang TC;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -80,7 +79,6 @@ const Box = styled.div`
     border-radius: 12px;
     box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.1);
     font-size: 18px;
-    font-family: PingFang TC;
     font-style: normal;
     font-weight: 500;
     line-height: 150%;

--- a/packages/mirror-media-next/components/mobile-sidebar.js
+++ b/packages/mirror-media-next/components/mobile-sidebar.js
@@ -103,7 +103,6 @@ const Topics = styled.div`
 `
 const Topic = styled.a`
   font-weight: 500;
-  font-family: var(--notosansTC-font);
   color: #fff;
   text-decoration: underline;
   text-underline-offset: 3px;

--- a/packages/mirror-media-next/components/papermag/succeeded.js
+++ b/packages/mirror-media-next/components/papermag/succeeded.js
@@ -125,7 +125,6 @@ const Price = styled.div`
   color: var(--black-87, rgba(0, 0, 0, 0.87));
   text-align: right;
   /* Body_150% */
-  font-family: PingFang TC;
   font-size: 18px;
   font-style: normal;
   font-weight: 400;

--- a/packages/mirror-media-next/components/story/photography/hero-section.js
+++ b/packages/mirror-media-next/components/story/photography/hero-section.js
@@ -42,7 +42,6 @@ const TitleBox = styled.div`
   margin: 0 auto;
   text-align: center;
   margin-bottom: 120px;
-  font-family: var(--notosansTC-font);
 
   margin-top: 52px;
   ${({ theme }) => theme.breakpoint.md} {

--- a/packages/mirror-media-next/components/story/photography/related-posts.js
+++ b/packages/mirror-media-next/components/story/photography/related-posts.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 import Image from '@readr-media/react-image'
 import Link from 'next/link'
-
+import { defaultSerifFontFamily } from '../../../styles/shared-style'
 /**
  * @typedef {Pick<import('../../../apollo/fragments/post').HeroImage ,'id' | 'resized' | 'resizedWebp'>} HeroImage
  */
@@ -18,7 +18,6 @@ const Wrapper = styled.div`
 
 const Title = styled.div`
   color: white;
-  font-family: 'PingFang TC';
   font-weight: 600;
   font-size: 21px;
   line-height: 150%;
@@ -65,8 +64,8 @@ const PostCard = styled.div`
     ${({ theme }) => theme.breakpoint.md} {
       margin-top: 16px;
       font-size: 18px;
-      font-family: var(--notoserifTC-font);
-      font-weight: 500px;
+      ${defaultSerifFontFamily};
+      font-weight: 500;
       line-height: 150%;
     }
   }

--- a/packages/mirror-media-next/components/story/shared/hero-image-and-video.js
+++ b/packages/mirror-media-next/components/story/shared/hero-image-and-video.js
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components'
 import CustomImage from '@readr-media/react-image'
-
+import { defaultSerifFontFamily } from '../../../styles/shared-style'
 /**
  * @typedef {Pick<import('../../../apollo/fragments/post').HeroImage ,'id' | 'resized' | 'resizedWebp'>} HeroImage
  */
@@ -20,7 +20,7 @@ const heroCssPremium = css`
 const ArticleTitle = styled.h1`
   color: rgba(0, 0, 0, 0.87);
   font-size: 24px;
-  font-family: var(--notoserifTC-font);
+  ${defaultSerifFontFamily};
   font-weight: 700;
   text-align: center;
   margin: 20px 10px 0;

--- a/packages/mirror-media-next/components/story/shared/related-article-list.js
+++ b/packages/mirror-media-next/components/story/shared/related-article-list.js
@@ -3,7 +3,7 @@
 import styled from 'styled-components'
 import Image from '@readr-media/react-image'
 import Link from 'next/link'
-
+import { defaultSerifFontFamily } from '../../../styles/shared-style'
 /**
  * @typedef {Pick<import('../../../apollo/fragments/post').HeroImage ,'id' | 'resized' | 'resizedWebp'>} HeroImage
  */
@@ -104,8 +104,8 @@ const Article = styled.figure`
     align-items: center;
     background-color: transparent;
     color: rgba(0, 0, 0, 0.87);
+    ${defaultSerifFontFamily};
     font-weight: 500;
-    font-family: var(--notoserifTC-font);
     line-height: 1.5;
     margin-bottom: 36px;
     .article-image {

--- a/packages/mirror-media-next/components/story/shared/support-mirrormedia-banner.js
+++ b/packages/mirror-media-next/components/story/shared/support-mirrormedia-banner.js
@@ -19,7 +19,6 @@ const Container = styled.div`
 
   .title {
     color: white;
-    font-family: 'PingFang TC';
     font-weight: 500;
     font-size: 18px;
     line-height: 1.5;
@@ -56,7 +55,6 @@ const InnerBox = styled.div`
   border-radius: 20px;
 
   .desc {
-    font-family: 'PingFang TC';
     font-weight: 400;
     font-size: 14px;
     line-height: 150%;
@@ -69,7 +67,6 @@ const InnerBox = styled.div`
     width: 100%;
     height: 48px;
     padding: 10.5px;
-    font-family: 'PingFang TC';
     font-style: normal;
     font-weight: 500;
     font-size: 18px;

--- a/packages/mirror-media-next/components/story/shared/support-single-article-banner.js
+++ b/packages/mirror-media-next/components/story/shared/support-single-article-banner.js
@@ -14,7 +14,6 @@ const Container = styled.div`
 
   .title {
     color: white;
-    font-family: 'PingFang TC';
     margin-bottom: 12px;
     font-weight: 500;
     font-size: 18px;
@@ -24,7 +23,6 @@ const Container = styled.div`
   }
 
   .desc {
-    font-family: 'PingFang TC';
     margin-bottom: 12px;
     font-style: normal;
     font-weight: 500;
@@ -38,7 +36,6 @@ const Container = styled.div`
     width: 100%;
     height: 70px;
     padding: 20px;
-    font-family: 'PingFang TC';
     font-style: normal;
     font-weight: 500;
     font-size: 20px;

--- a/packages/mirror-media-next/pages/404.js
+++ b/packages/mirror-media-next/pages/404.js
@@ -31,7 +31,6 @@ const MsgContainer = styled.div`
 `
 
 const H1 = styled.h1`
-  font-family: 'Helvetica Neue';
   font-weight: 400;
   font-size: 128px;
   line-height: 128px;
@@ -39,7 +38,6 @@ const H1 = styled.h1`
 `
 
 const Text = styled.p`
-  font-family: var(--notosansTC-font);
   font-size: 24px;
   color: #000000;
 `

--- a/packages/mirror-media-next/pages/500.js
+++ b/packages/mirror-media-next/pages/500.js
@@ -17,7 +17,6 @@ const MsgContainer = styled.div`
 `
 
 const H1 = styled.h1`
-  font-family: 'Helvetica Neue';
   font-weight: 400;
   font-size: 128px;
   line-height: 120%;
@@ -25,7 +24,6 @@ const H1 = styled.h1`
 `
 
 const Text = styled.p`
-  font-family: var(--notosansTC-font);
   font-weight: 500;
   font-size: 24px;
   color: #61b8c6;

--- a/packages/mirror-media-next/styles/global-styles.js
+++ b/packages/mirror-media-next/styles/global-styles.js
@@ -1,22 +1,6 @@
 import { createGlobalStyle } from 'styled-components'
-import { Noto_Sans_TC, Oswald, Noto_Serif_TC, Inter } from '@next/font/google'
 
-const oswald = Oswald({
-  subsets: ['latin'],
-})
-const notosansTC = Noto_Sans_TC({
-  subsets: ['latin'],
-  weight: ['900', '500', '400'],
-})
-const notoserifTC = Noto_Serif_TC({
-  subsets: ['latin'],
-  weight: ['500', '700'],
-})
-
-const inter = Inter({
-  subsets: ['latin'],
-  weight: ['400', '500'],
-})
+import { defaultSansSerifFontFamily } from './shared-style'
 
 export const GlobalStyles = createGlobalStyle`
 /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
@@ -29,17 +13,11 @@ export const GlobalStyles = createGlobalStyle`
  * 2. Prevent adjustments of font size after orientation changes in iOS.
  */
 
-//add css variable if needed
-:root{
-      --oswald-font : ${oswald.style.fontFamily};
-      --notosansTC-font : ${notosansTC.style.fontFamily};
-      --notoserifTC-font : ${notoserifTC.style.fontFamily};
-      --inter-font : ${inter.style.fontFamily};
-   }
+
 
  //default font family  
  html {
-  font-family: PingFang TC, ${notosansTC.style.fontFamily},${notoserifTC.style.fontFamily},${inter.style.fontFamily}, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; 
+  ${defaultSansSerifFontFamily};
   line-height: 1.5; /* 2 */
   -webkit-text-size-adjust: 100%; /* 2 */
 }

--- a/packages/mirror-media-next/styles/shared-style/index.js
+++ b/packages/mirror-media-next/styles/shared-style/index.js
@@ -1,0 +1,14 @@
+import { css } from 'styled-components'
+
+const defaultSansSerifFontFamily = css`
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+`
+
+const defaultSerifFontFamily = css`
+  font-family: 'Noto Serif TC', source-han-serif-tc, 'Songti TC', serif,
+    PMingLiU;
+`
+
+export { defaultSansSerifFontFamily, defaultSerifFontFamily }


### PR DESCRIPTION
## Notable Change

目前的網站字體設定，在不同作業系統會有缺字的情形產生，原因來自於某些字體僅有macOS才有，windows 系統並無內建（如蘋方），若特定元件僅有套用上述類型的字體，則會造成在windows系統缺字。

在與設計討論後，確定網站目前僅使用兩組字體，無襯線字與襯線字各一組。

為了使各元件都能套用相同的字體設定，同時減少重複的css設定，故將兩組字體設定寫在`styles/shared-styled/index.js`中。由於網站絕大部分元件都是使用無襯線字，所以直接在`global-style.js` 使用無襯線字體組，元件不另外寫入`font-family`，需要使用襯線字的元件，則引入`styles/shared-styled/index.js`中的css。

另外，由於next/font會有不穩的問題，在不穩的狀況下會fallback到非原始設定的字體，所以這次改動也移除了next/font，改用原生的字體。