### PR TITLE
feat(mm-next): adjust pageKey of gpt-ad

### DIFF
--- a/packages/mirror-media-next/components/shared/article-list.js
+++ b/packages/mirror-media-next/components/shared/article-list.js
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment } from 'react'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 import ArticleListItem from './article-list-item'
@@ -55,25 +55,14 @@ const StyledGPTAd = styled(GPTAd)`
  * @returns {React.ReactElement}
  */
 export default function ArticleList({ renderList, section }) {
-  const [GptPageKey, setGptPageKey] = useState('other')
   const shouldShowAd = useDisplayAd()
-
   /**
    * 這個元件會被共用於 author/tag/category/section 列表頁
-   * 在 author/tag 列表頁時，GPT 廣告的 PageKey 固定為 'other'
+   * 在 author/tag 列表頁時，由於沒有section?.slug，函式 `getSectionGPTPageKey`會回傳 'other'
    * 在 section/category 列表頁時，GPT 廣告的 PageKey 設定為 'section.slug'
-   * 若 category 無所屬的 section (related-Section)，則 PageKey 一律為 'other'
+   * 若 category 無所屬的 section (related-Section)，函式 `getSectionGPTPageKey`會回傳 'other'
    */
-  useEffect(() => {
-    /**
-     * When the component is used on `author` or `tag` listing pages, there won't be a "section" parameter.
-     * As a result, it will return and directly use the default GptPageKey value: "other".
-     */
-    if (!section?.slug) {
-      return
-    }
-    setGptPageKey(getSectionGPTPageKey(section.slug))
-  }, [section])
+  const gptAdPageKey = getSectionGPTPageKey(section?.slug)
 
   const renderListWithAd = shouldShowAd
     ? renderList.slice(0, 9)
@@ -99,7 +88,7 @@ export default function ArticleList({ renderList, section }) {
         ))}
       </ItemContainer>
 
-      {shouldShowAd && <StyledGPTAd pageKey={GptPageKey} adKey="FT" />}
+      {shouldShowAd && <StyledGPTAd pageKey={gptAdPageKey} adKey="FT" />}
 
       <ItemContainer>
         {renderListWithoutAd.map((item) => (

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -501,10 +501,7 @@ export default function StoryNormalStyle({
 
   const [section] = sectionsWithOrdered
 
-  // 廣編文章的 pageKey 是 other
-  const pageKeyForGptAd = postData.isAdvertised
-    ? 'other'
-    : getSectionGPTPageKey(section?.slug)
+  const pageKeyForGptAd = getSectionGPTPageKey(section?.slug)
 
   /**
    * @returns {Promise<AsideArticleDataContainSectionsWithOrdered[] | []>}

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -213,7 +213,6 @@ export default function StoryPremiumStyle({
     relatedsInInputOrder = [],
     slug = '',
     hiddenAdvertised = false,
-    isAdvertised = false,
   } = postData
 
   const shouldShowArticleMask =
@@ -243,7 +242,7 @@ export default function StoryPremiumStyle({
     { vocals: vocals },
     { extend_byline: extend_byline },
   ]
-  const pageKeyForGptAd = isAdvertised ? 'other' : SECTION_IDS['member']
+  const pageKeyForGptAd = SECTION_IDS['member']
 
   const shouldShowAd = useDisplayAd(hiddenAdvertised)
 

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -200,8 +200,7 @@ export default function Category({
   //The type of GPT ad to display depends on which category the section belongs to.
   //If category not have related-section, use `other` ad units
   const sectionSlug = category?.sections?.[0]?.slug ?? ''
-  const GptPageKey =
-    getSectionGPTPageKey(isPremium ? 'member' : sectionSlug) ?? 'other'
+  const GptPageKey = getSectionGPTPageKey(isPremium ? 'member' : sectionSlug)
 
   return (
     <Layout

--- a/packages/mirror-media-next/utils/ad.js
+++ b/packages/mirror-media-next/utils/ad.js
@@ -71,11 +71,11 @@ function getPageKeyByPartnerShowOnIndex(partnerShowOnIndex) {
  * Returns the GPT pageKey associated with section's slug.
  *
  * @param {string} sectionSlug
- * @returns {string | undefined}
+ * @returns {string}
  */
 const getSectionGPTPageKey = (sectionSlug) => {
   if (!sectionSlug || typeof sectionSlug !== 'string') {
-    return
+    return 'other'
   }
 
   let GptPageKey


### PR DESCRIPTION
## Notable Change
1. 依據需求變更，調整文章頁的gpt廣告pageKey：不論是否為廣編文章，皆依據section.slug顯示對應pageKey廣告
2. 依據需求變更，調整函式 `getSectionGPTPageKey`：原本預設會回傳undefined，現在則會回傳'other'。並調整對應頁面的函式使用方式。