### PR TITLE
feat(mm-next/story): add gtm className for collecting pageview

### DIFF
--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -450,13 +450,18 @@ const StyledGPTAd_PC_E2 = styled(GPTAd)`
 
 /**
  *
- * @param {{postData: PostData,postContent: PostContent, headerData: any}} param
+ * @param {Object} param
+ * @param {PostData} param.postData
+ * @param {PostContent} param.postContent
+ * @param {any} param.headerData
+ * @param {string} [param.classNameForGTM]
  * @returns {JSX.Element}
  */
 export default function StoryNormalStyle({
   postData,
   postContent,
   headerData,
+  classNameForGTM = '',
 }) {
   const {
     title = '',
@@ -596,7 +601,7 @@ export default function StoryNormalStyle({
         )}
       </GPT_Placeholder>
 
-      <Main>
+      <Main className={classNameForGTM}>
         <Article>
           <SectionAndDate>
             {/* hide section for advertised article but remain the same architecture*/}

--- a/packages/mirror-media-next/components/story/photography/index.js
+++ b/packages/mirror-media-next/components/story/photography/index.js
@@ -141,10 +141,15 @@ const ArrowButton = styled.button`
  * @param {Object} param
  * @param {PostData} param.postData
  * @param {PostContent} param.postContent
+ * @param {string} [param.classNameForGTM]
  * @returns
  */
 
-export default function StoryPhotographyStyle({ postData, postContent }) {
+export default function StoryPhotographyStyle({
+  postData,
+  postContent,
+  classNameForGTM = '',
+}) {
   const {
     title = '',
     heroImage = null,
@@ -246,6 +251,7 @@ export default function StoryPhotographyStyle({ postData, postContent }) {
     <Main
       // @ts-ignore
       isSafari={isSafariDevice}
+      className={classNameForGTM}
     >
       <Header />
       <Page>

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -178,12 +178,14 @@ function getSectionLabelFirst(sections) {
  * @param {PostData} props.postData
  * @param {PostContent} props.postContent
  * @param {any} props.headerData
+ * @param {string} [props.classNameForGTM]
  * @returns {JSX.Element}
  */
 export default function StoryPremiumStyle({
   postData,
   postContent,
   headerData,
+  classNameForGTM = '',
 }) {
   const { isLoggedIn, memberInfo } = useMembership()
   const { memberType } = memberInfo
@@ -273,7 +275,7 @@ export default function StoryPremiumStyle({
         )}
       </GPT_Placeholder>
 
-      <Main>
+      <Main className={classNameForGTM}>
         <article>
           <TitleAndInfoAndHero
             sectionLabelFirst={sectionLabelFirst}

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -116,9 +116,14 @@ const DonateSubscribeWrapper = styled.div`
  * @param {Object} param
  * @param {PostData} param.postData
  * @param {PostContent} param.postContent
+ * @param {string} [param.classNameForGTM]
  * @returns {JSX.Element}
  */
-export default function StoryWideStyle({ postData, postContent }) {
+export default function StoryWideStyle({
+  postData,
+  postContent,
+  classNameForGTM = '',
+}) {
   const {
     id = '',
     title = '',
@@ -193,7 +198,7 @@ export default function StoryWideStyle({ postData, postContent }) {
   return (
     <>
       <Header h2AndH3Block={h2AndH3Block} />
-      <Main>
+      <Main className={classNameForGTM}>
         <article>
           <HeroImageAndVideo
             heroImage={heroImage}

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -23,7 +23,6 @@ import { handleStoryPageRedirect } from '../../utils/story'
 import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import { fetchHeaderDataInPremiumPageLayout } from '../../utils/api'
-import { sendGAEvent } from '../../utils/gtag'
 import { setPageCache } from '../../utils/cache-setting'
 
 import FullScreenAds from '../../components/ads/full-screen-ads'
@@ -177,17 +176,13 @@ export default function Story({ postData, headerData, storyLayoutType }) {
     storyLayoutType,
   ])
 
-  //Send custom event to Google Analytics
-  //Which event should be send is based on whether is member-only article.
-  useEffect(() => {
-    if (isMember) {
-      sendGAEvent('premium_page_view')
-    } else {
-      sendGAEvent('story_page_view')
-    }
-  }, [isMember])
-
   const renderStoryLayout = () => {
+    /**
+     * Because GA is currently unable to send custom event, we use gtm className to collect custom page-view.
+     */
+    const classNameForGTM = isMember
+      ? 'GTM-premium-page-view'
+      : 'GTM-story-page-view'
     switch (storyLayoutType) {
       case 'style-normal':
         return (
@@ -195,6 +190,7 @@ export default function Story({ postData, headerData, storyLayoutType }) {
             postData={postData}
             postContent={postContent}
             headerData={headerData}
+            classNameForGTM={classNameForGTM}
           />
         )
       case 'style-premium':
@@ -203,15 +199,23 @@ export default function Story({ postData, headerData, storyLayoutType }) {
             postData={postData}
             postContent={postContent}
             headerData={headerData}
+            classNameForGTM={classNameForGTM}
           />
         )
       case 'style-wide':
-        return <StoryWideStyle postData={postData} postContent={postContent} />
+        return (
+          <StoryWideStyle
+            postData={postData}
+            postContent={postContent}
+            classNameForGTM={classNameForGTM}
+          />
+        )
       case 'style-photography':
         return (
           <StoryPhotographyStyle
             postData={postData}
             postContent={postContent}
+            classNameForGTM={classNameForGTM}
           />
         )
       default:
@@ -220,6 +224,7 @@ export default function Story({ postData, headerData, storyLayoutType }) {
             postData={postData}
             postContent={postContent}
             headerData={headerData}
+            classNameForGTM={classNameForGTM}
           />
         )
     }


### PR DESCRIPTION
## Notable Change
由於目前GA4並無法送出自訂事件，所以暫時改採用自訂的className，搭配gtm去蒐集數據。
GA4無法送出自訂事件的原因，目前仍未知，但疑似與gtm後台也有設定GA4有關。
未來若時間允許，將研究具體成因，以及是否該將gtm的ga或程式碼中的ga移除。