### PR TITLE
fix(mm-next): unable set `og:image` on `head` when `w1200` is empty

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -229,7 +229,7 @@ export const post = gql`
     redirect
     og_image {
       resized {
-        w1200
+        w1600
       }
     }
     hiddenAdvertised

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -289,18 +289,14 @@ const convertDraftToText = (rawContentBlock) => {
 /**
  * To get the URL link for `og-image`, sorted in ascending order based on file size.
  * Skip w480 to prevent image size minimum 200 x 200.
+ * It's recommended for using images which is at least 1200 * 630 pixels on high resolution devices, so we use w1600 at first.
+ * @see https://developers.facebook.com/docs/sharing/webmasters/images
  * @param {import('../apollo/fragments/photo').Resized | undefined | null} resized
  * @returns {string | undefined}
  */
 const getResizedUrl = (resized) => {
   if (resized) {
-    return (
-      resized?.w800 ||
-      resized?.w1200 ||
-      resized?.w1600 ||
-      resized?.w2400 ||
-      resized?.original
-    )
+    return resized?.w1600 || resized?.w2400 || resized?.original
   } else {
     return undefined
   }


### PR DESCRIPTION
## Notable Change
原本post 欄位og_image（FB縮圖）緊抓取resize的`w1200`，但由於橫圖並不會產生w1200的網址，所以會使得文章頁無法使用og_image作為head中的`og:image`。
本次改動將其改為使用w1600，且調整函式getResizedUrl，改為最優先使用使用w1600。

至於為什麼要使用w1600，是因為facebook推薦在高解析度的裝置（如iphone）使用1200 * 630 px以上的圖檔。


## Ref

[facebook doc](https://developers.facebook.com/docs/sharing/webmasters/images)