### PR TITLE
feat(mm-next): add canonical link

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -161,7 +161,7 @@ export const post = gql`
     id
     slug
     title
-
+    state
     style
     isMember
     isAdult

--- a/packages/mirror-media-next/components/shared/custom-head.js
+++ b/packages/mirror-media-next/components/shared/custom-head.js
@@ -98,6 +98,7 @@ const OpenGraph = ({ properties }) => {
  * @property {string} [title] - head title used to setup title other title related meta
  * @property {string} [description] - head description used to setup description related meta
  * @property {string} [imageUrl] - image url used to setup image related meta
+ * @property {React.ReactNode} [otherHead] - other head tag needed to add
  */
 
 /**
@@ -136,6 +137,7 @@ export default function CustomHead(props) {
       />
       <OpenGraph properties={siteInformation} />
       <meta name="application-name" content={siteInformation.title} />
+      {props.otherHead}
     </Head>
   )
 }

--- a/packages/mirror-media-next/components/shared/custom-head.js
+++ b/packages/mirror-media-next/components/shared/custom-head.js
@@ -23,6 +23,24 @@ import { useRouter } from 'next/router'
  */
 
 /**
+ * Create canonical link based on router.asPath
+ * Since '/story' page and '/story/amp' page has special logic on creating canonical link,
+ * we decide not handle canonical link on these page.
+ * @param {string} routerAsPath
+ * @return {null | JSX.Element}
+ */
+const createCanonicalLink = (routerAsPath) => {
+  const isStoryPage = routerAsPath.startsWith('/story/')
+
+  if (isStoryPage) {
+    return null
+  }
+  const url = 'https://' + SITE_URL + routerAsPath
+
+  return <link rel="canonical" href={url} key="canonical" />
+}
+
+/**
  * @param {Object} props
  * @param {OGProperties} props.properties
  * @returns
@@ -107,6 +125,7 @@ const OpenGraph = ({ properties }) => {
  */
 export default function CustomHead(props) {
   const router = useRouter()
+  const canonicalLink = createCanonicalLink(router.asPath)
   const siteInformation = {
     title: props.title ? `${props.title} - ${SITE_TITLE}` : SITE_TITLE,
     description:
@@ -137,6 +156,7 @@ export default function CustomHead(props) {
       />
       <OpenGraph properties={siteInformation} />
       <meta name="application-name" content={siteInformation.title} />
+      {canonicalLink}
       {props.otherHead}
     </Head>
   )

--- a/packages/mirror-media-next/components/shared/layout.js
+++ b/packages/mirror-media-next/components/shared/layout.js
@@ -29,6 +29,7 @@ export default function Layout({ head, header, footer, children }) {
         title={head?.title}
         description={head?.description}
         imageUrl={head?.imageUrl}
+        otherHead={head?.otherHead}
       />
       <ShareHeader pageLayoutType={header.type} headerData={header.data} />
       {children}

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -4,7 +4,7 @@ import client from '../../apollo/apollo-client'
 import errors from '@twreporter/errors'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
-import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
+import { GCP_PROJECT_ID, ENV, SITE_URL } from '../../config/index.mjs'
 import WineWarning from '../../components/shared/wine-warning'
 import AdultOnlyWarning from '../../components/story/shared/adult-only-warning'
 import { useMembership } from '../../context/membership'
@@ -89,12 +89,14 @@ export default function Story({ postData, headerData, storyLayoutType }) {
   const {
     title = '',
     slug = '',
+    state = 'draft',
     isAdult = false,
     categories = [],
     isMember = false,
     content = null,
     trimmedContent = null,
     hiddenAdvertised = false,
+    isAdvertised = false,
   } = postData
   /**
    * The logic for rendering the article content:
@@ -233,6 +235,24 @@ export default function Story({ postData, headerData, storyLayoutType }) {
   //If no wine category, then should show gpt ST ad, otherwise, then should not show gpt ST ad.
   const noCategoryOfWineSlug = getCategoryOfWineSlug(categories).length === 0
 
+  /**
+   *
+   * @returns {React.ReactNode}
+   */
+  const createCanonicalLink = () => {
+    const nonAmpUrl = `https://${SITE_URL}/story/${slug}`
+    const ampUrl = `https://${SITE_URL}/story/amp/${slug}`
+    const shouldCreateAmpHtmlLink = state === 'published' && !isAdvertised
+    const canonicalLink = (
+      <>
+        <link rel="canonical" href={nonAmpUrl} />
+        {shouldCreateAmpHtmlLink && <link rel="amphtml" href={ampUrl} />}
+      </>
+    )
+    return canonicalLink
+  }
+
+  const canonicalLink = createCanonicalLink()
   return (
     <Layout
       head={{
@@ -243,6 +263,7 @@ export default function Story({ postData, headerData, storyLayoutType }) {
         imageUrl:
           getResizedUrl(postData.og_image?.resized) ||
           getResizedUrl(postData.heroImage?.resized),
+        otherHead: canonicalLink,
       }}
       header={{ type: 'empty' }}
       footer={{ type: 'empty' }}

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -19,6 +19,7 @@ import {
   GCP_PROJECT_ID,
   ENV,
   GA_MEASUREMENT_ID,
+  SITE_URL,
 } from '../../../config/index.mjs'
 import styled from 'styled-components'
 import AdultOnlyWarning from '../../../components/story/shared/adult-only-warning'
@@ -29,7 +30,6 @@ import Taboola from '../../../components/amp/amp-ads/taboola-ad'
 import AmpGptAd from '../../../components/amp/amp-ads/amp-gpt-ad'
 import AmpGptStickyAd from '../../../components/amp/amp-ads/amp-gpt-sticky-ad'
 import { getAmpGptDataSlotSection } from '../../../utils/ad'
-import Head from 'next/head'
 
 export const config = { amp: true }
 
@@ -61,6 +61,7 @@ const AmpBody = styled.body`
 function StoryAmpPage({ postData }) {
   const {
     title = '',
+    slug = '',
     relateds = [],
     relatedsInInputOrder = [],
     isMember = false,
@@ -84,18 +85,20 @@ function StoryAmpPage({ postData }) {
     relatedsInInputOrder && relatedsInInputOrder.length
       ? relatedsInInputOrder
       : relateds
-
+  const nonAmpUrl = `https://${SITE_URL}/story/${slug}`
+  const ampGptStickyAdScript = (
+    <script
+      async
+      // eslint-disable-next-line react/no-unknown-property
+      custom-element="amp-sticky-ad"
+      src="https://cdn.ampproject.org/v0/amp-sticky-ad-1.0.js"
+    />
+  )
+  const canonicalLink = (
+    <link rel="canonical" href={nonAmpUrl} key="canonical"></link>
+  )
   return (
     <>
-      <Head>
-        {/* Add the script for amp-sticky-ad */}
-        <script
-          async
-          // eslint-disable-next-line react/no-unknown-property
-          custom-element="amp-sticky-ad"
-          src="https://cdn.ampproject.org/v0/amp-sticky-ad-1.0.js"
-        />
-      </Head>
       <Layout
         head={{
           title: `${title}`,
@@ -105,6 +108,12 @@ function StoryAmpPage({ postData }) {
           imageUrl:
             getResizedUrl(postData.og_image?.resized) ||
             getResizedUrl(postData.heroImage?.resized),
+          otherHead: (
+            <>
+              {ampGptStickyAdScript}
+              {canonicalLink}
+            </>
+          ),
         }}
         header={{ type: 'empty' }}
         footer={{ type: 'empty' }}


### PR DESCRIPTION
## Notable Change
1. 調整layout，新增一props `head.otherHead`，該props使得可自行添加特定頁面需要的head tag。
2. 新增canonical link。由於story頁有non-amp與amp版本，所以story頁、story/amp頁於該頁面設定canonical link，其他頁面則統一在layout中設定。

## ref
https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls?hl=zh-tw
https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/discovery?referrer=ampproject.org
https://sitebulb.com/hints/amp/amp-page-url-has-canonical-url-which-is-canonicalized/