### PR TITLE
refactor(mm-next): add type STORY_DEPRECATED of micro-ad-with-label

### DIFF
--- a/packages/mirror-media-next/components/ads/micro-ad/micro-ad-with-label.js
+++ b/packages/mirror-media-next/components/ads/micro-ad/micro-ad-with-label.js
@@ -231,7 +231,8 @@ const typeHome = css`
     }
   }
 `
-const typeStory = css`
+
+const typeStoryDeprecated = css`
   ${({ theme }) => theme.breakpoint.xl} {
     height: 90px;
   }
@@ -407,6 +408,199 @@ const typeStory = css`
   }
 `
 
+const typeStory = css`
+  ${({ theme }) => theme.breakpoint.xl} {
+    height: 90px;
+  }
+
+  // Mobile: Micro AD container
+  #compass-fit-widget-content {
+    height: 92px;
+    font-size: 15px;
+    line-height: 1.3;
+    color: black;
+    font-weight: 400;
+    flex-direction: row-reverse;
+    justify-content: space-between;
+    align-items: center;
+    color: #808080;
+    background-color: #eeeeee;
+    gap: 16px;
+    margin: 0 auto;
+    display: flex;
+    position: relative;
+
+    &::before {
+      position: absolute;
+      content: '';
+      width: 10px;
+      height: 100%;
+      background-color: #808080;
+      left: 0;
+      top: 0;
+    }
+
+    ${({ theme }) => theme.breakpoint.md} {
+      max-width: 640px;
+      height: 90px;
+      flex-direction: row-reverse;
+      justify-content: space-between;
+      color: #808080;
+      //Since AD uses inline-style to set the background-color, it is necessary to use !important.
+      background-color: #eeeeee !important;
+      gap: 20px;
+      align-items: start;
+      font-size: 18px;
+      &::before {
+        width: 7.72px;
+      }
+    }
+
+    // Mobile: AD Image
+    figure {
+      width: 100px;
+      min-width: 100px;
+      max-width: 100px;
+      height: 66px;
+      margin-right: 16px;
+      position: relative;
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+
+      ${({ theme }) => theme.breakpoint.md} {
+        width: 87px;
+        min-width: 87px;
+        max-width: 87px;
+        height: 100%;
+        margin-right: 0;
+      }
+    }
+
+    // Mobile: AD Title
+    .pop_item_title {
+      //Since AD uses inline-style to set the background-color, it is necessary to use !important.
+      background: none !important;
+      position: relative;
+      padding: 0 0 0 18px;
+      ${({ theme }) => theme.breakpoint.md} {
+        position: relative;
+        display: flex;
+        align-items: center;
+        padding: 16px 0 0 25.75px;
+      }
+    }
+
+    // Mobile: AD Label('特企')
+    .pop_item--colorBlock {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-style: normal;
+      font-weight: 500;
+      font-size: 14px;
+      line-height: 1;
+      padding: 4px;
+      background: #bcbcbc;
+      color: #ffffff;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+
+      ${({ theme }) => theme.breakpoint.md} {
+        font-weight: 300;
+        font-size: 12px;
+        line-height: 14px;
+      }
+    }
+
+    // Mobile: useless empty component
+    .compass-fit-clear {
+      display: none;
+    }
+
+    // Desktop: Micro AD container
+    .popListVert-list__item {
+      ${({ theme }) => theme.breakpoint.xl} {
+        width: 100%;
+        display: flex;
+        flex-direction: row-reverse;
+        justify-content: space-between;
+        position: relative;
+        height: 100%;
+      }
+
+      // Desktop: AD Image
+      > a {
+        ${({ theme }) => theme.breakpoint.xl} {
+          min-width: 135px;
+          max-width: 135px;
+
+          img {
+            height: 100%;
+            width: 100%;
+            object-fit: cover;
+          }
+        }
+      }
+
+      // Desktop: AD detail
+      .popListVert-list__item--text {
+        ${({ theme }) => theme.breakpoint.xl} {
+          // Desktop: AD Label('特企')
+          > div {
+            background: #bcbcbc;
+            color: #ffffff;
+            position: absolute;
+            bottom: 0;
+            right: 103px;
+            font-style: normal;
+            font-weight: 600;
+            font-size: 12px;
+            line-height: 14px;
+            padding: 4px;
+          }
+
+          // Desktop: AD Title
+          h2 {
+            text-align: left;
+            display: block;
+            height: 100%;
+            position: relative;
+            padding: 0 20px 0 40px;
+            font-style: normal;
+            //Since AD uses inline-style to set the font-weight, it is necessary to use !important.
+            font-weight: 400 !important;
+            font-size: 18px;
+            line-height: 1.5;
+            color: #808080;
+            display: flex;
+            align-items: center;
+
+            > a {
+              //Since AD uses inline-style to set the font-weight, it is necessary to use !important.
+              font-weight: 400 !important;
+            }
+
+            &::before {
+              position: absolute;
+              content: '';
+              width: 10px;
+              height: 100%;
+              background-color: #808080;
+              left: 0;
+              top: 0;
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
 /**
  * @typedef {import('../../../utils/ad').MicroAdType} MicroAdType
  */
@@ -421,6 +615,8 @@ const StyledMicroAd = styled(MicroAd)`
         return typeHome
       case 'LISTING':
         return typeListing
+      case 'STORY_DEPRECATED':
+        return typeStoryDeprecated
       case 'STORY':
         return typeStory
       default:

--- a/packages/mirror-media-next/components/story/normal/related-article-list-deprecated.js
+++ b/packages/mirror-media-next/components/story/normal/related-article-list-deprecated.js
@@ -50,7 +50,7 @@ const Wrapper = styled.section`
   }
 `
 
-const Article = styled.figure`
+const ArticleDeprecated = styled.figure`
   max-width: 280px;
   font-size: 18px;
   line-height: 1.5;
@@ -106,8 +106,7 @@ const Article = styled.figure`
   }
 `
 
-const ArticleWrapper = styled.ul`
-  background: #eeeeee;
+const ArticleWrapperDeprecated = styled.ul`
   padding: 48px 10px;
   display: flex;
   flex-direction: column;
@@ -166,10 +165,10 @@ export default function RelatedArticleListDeprecated({
   const shouldShowAd = useDisplayAd(hiddenAdvertised)
 
   const relatedsArticleJsx = relateds.length ? (
-    <ArticleWrapper>
+    <ArticleWrapperDeprecated>
       {relateds.map((related) => (
         <li key={related.id}>
-          <Article>
+          <ArticleDeprecated>
             <Link
               href={`/story/${related.slug}`}
               target="_blank"
@@ -198,17 +197,21 @@ export default function RelatedArticleListDeprecated({
                 {related.title}
               </Link>
             </StyledFigcaption>
-          </Article>
+          </ArticleDeprecated>
         </li>
       ))}
-    </ArticleWrapper>
+    </ArticleWrapperDeprecated>
   ) : null
 
   const advertisementJsx = shouldShowAd ? (
     <AdvertisementWrapper>
       {/* micro ad */}
       {MICRO_AD_UNITS.STORY[device].map((unit) => (
-        <StyledMicroAd key={unit.name} unitId={unit.id} microAdType="STORY" />
+        <StyledMicroAd
+          key={unit.name}
+          unitId={unit.id}
+          microAdType="STORY_DEPRECATED"
+        />
       ))}
       {/* pop-in ad */}
       <StyledPopInAdRelated />

--- a/packages/mirror-media-next/components/story/normal/related-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/related-article-list.js
@@ -132,11 +132,12 @@ const ArticleWrapper = styled.ul`
   padding: 0 10px;
   display: flex;
   flex-direction: column;
-  margin-bottom: 24px;
+  margin-bottom: 12px;
   gap: 12px;
   ${({ theme }) => theme.breakpoint.md} {
     padding: 0;
     gap: 20px;
+    margin-bottom: 20px;
   }
 `
 
@@ -145,7 +146,7 @@ const AdvertisementWrapper = styled.div`
   padding: 0px 10px;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 12px;
 
   ${({ theme }) => theme.breakpoint.md} {
     background: transparent;

--- a/packages/mirror-media-next/utils/ad.js
+++ b/packages/mirror-media-next/utils/ad.js
@@ -19,7 +19,7 @@ const needInsertMicroAdAfter = (index = 0) => {
 }
 
 /**
- * @typedef {'HOME' | 'LISTING' | 'STORY' } MicroAdType
+ * @typedef {'HOME' | 'LISTING' | 'STORY' | 'STORY_DEPRECATED' } MicroAdType
  * @typedef {'PC' | 'MB' | 'RWD' } Device
  *
  * Determining which Micro advertisement ID to take based on the `index`.


### PR DESCRIPTION
### Notable Change
- 一般文章和外部文章下方相關文章改版，針對 micro-ad 修改樣式。
- 為了不污染原本的樣式，將原本的樣式改至 `STORY_DEPRECATED`，因此之後拔除 feature toggle 只要拔除相關 code 就好，比較乾淨。