### PR TITLE
fix(mm-next/user-behavior-log): use `router.asPath` as pathname

### DIFF
--- a/packages/mirror-media-next/components/shared/user-behavior-logger.js
+++ b/packages/mirror-media-next/components/shared/user-behavior-logger.js
@@ -41,12 +41,8 @@ export default function UserBehaviorLogger({ isMemberArticle = false }) {
   //Since `usePathname()` is recommend to use at Next.js 13 App route, we use `useRouter` to get pathname instead to prevent unexpected error.
   const router = useRouter()
   const { asPath } = router
-  const isStoryPage = asPath.startsWith('/story/')
-  /**
-   * Story page need specific pathname, such as `/story/20231026-this-is-an-story`, other page only need which page is, such as `/section/[slug]`.
-   */
-  const pathname = isStoryPage ? asPath?.split('?')?.[0] : router.pathname
 
+  const pathname = asPath?.split('?')?.[0]
   const {
     isLogInProcessFinished,
     memberInfo: { memberType },


### PR DESCRIPTION
原本在文章頁以外的user-behavior-log，是使用`router.pathname`，但是如果使用 `next/link` 的`<Link>`跳轉的話，pathname可以不會變化。比如說從 `section/news` 跳轉到 `section/entertainment` 時，兩個頁面的 `router.pathname` 都是 `section/[slug]`。在不會變化的情況下，pageview event不會觸發。
為了避免上述情況發生，目前使用router.asPath取代pathname，並使用`String.split` 刪除query資料