### PR TITLE
refactor(mm-next/web-vital): add `width`, `height` in sub-brand icon

### DIFF
--- a/packages/mirror-media-next/components/logo.js
+++ b/packages/mirror-media-next/components/logo.js
@@ -16,6 +16,7 @@ export default function LogoLink({ className }) {
         layout="responsive"
         width={107}
         height={45}
+        loading="eager"
       ></Image>
     </div>
   )

--- a/packages/mirror-media-next/components/sub-brand-list.js
+++ b/packages/mirror-media-next/components/sub-brand-list.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-
+import Image from 'next/image'
 const SubBrandListWrapper = styled.ul`
   display: none;
   ${({ theme }) => theme.breakpoint.xl} {
@@ -15,10 +15,6 @@ const SubBrand = styled.a`
   flex: 0 0 auto;
   cursor: pointer;
 `
-const SubBrandIcon = styled.img`
-  height: 30px;
-  width: auto;
-`
 
 /**
  *
@@ -30,17 +26,20 @@ const SubBrandIcon = styled.img`
 export default function SubBrandList({ subBrands = [], className }) {
   return (
     <SubBrandListWrapper className={className}>
-      {subBrands.map(({ name, title, href }) => (
+      {subBrands.map(({ name, title, href, imageSize }) => (
         <SubBrand
           key={name}
           href={href}
           target="_blank"
           rel="noopener noreferer"
         >
-          <SubBrandIcon
+          <Image
+            width={imageSize.width}
+            height={imageSize.height}
             src={`/images-next/${name}.png`}
             alt={title}
-          ></SubBrandIcon>
+            loading="eager"
+          ></Image>
         </SubBrand>
       ))}
     </SubBrandListWrapper>

--- a/packages/mirror-media-next/constants/index.js
+++ b/packages/mirror-media-next/constants/index.js
@@ -93,16 +93,28 @@ const MIRRORVOICE_LINK = {
   name: 'mirrorvoice',
   title: '鏡好聽',
   href: 'https://voice.mirrorfiction.com/',
+  imageSize: {
+    width: 131.25,
+    height: 30,
+  },
 }
 const MIRRORFICTION_LINK = {
   name: 'mirrorfiction',
   title: '鏡文學',
   href: 'https://www.mirrorfiction.com/',
+  imageSize: {
+    width: 131.25,
+    height: 30,
+  },
 }
 const READR_LINK = {
   name: 'readr',
   title: 'READr 讀+',
   href: READR_URL,
+  imageSize: {
+    width: 38,
+    height: 30,
+  },
 }
 const SUB_BRAND_LINKS = [MIRRORVOICE_LINK, MIRRORFICTION_LINK, READR_LINK]
 

--- a/packages/mirror-media-next/type/index.js
+++ b/packages/mirror-media-next/type/index.js
@@ -33,6 +33,7 @@ export default {}
  * @property {string} name - English name of sub-brand
  * @property {string} title - Mandarin name of sub-brand
  * @property {string} href - Complete url of sub-brand
+ * @property {{width: number, height: number}} imageSize - image size of sub-brand, use for setting <img> width and height to prevent CLS problem
  */
 
 /**


### PR DESCRIPTION
1. 調整header子品牌圖片，改為使用next/image，並加入width與height以解決CLS問題，圖片設定`loading='eager'`，以確保馬上載入。
2. header 鏡週刊 icon 亦設定`loading='eager'`