### PR TITLE
refactor(mm-next): add width and height on subbrand, search icon, add placeholder for gpt ad

### DIFF
--- a/packages/mirror-media-next/components/header.js
+++ b/packages/mirror-media-next/components/header.js
@@ -2,7 +2,7 @@
 import React, { useState, useRef, useEffect } from 'react'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
-
+import Image from 'next/image'
 import {
   SUB_BRAND_LINKS,
   PROMOTION_LINKS,
@@ -154,6 +154,20 @@ const TopicsAndSubscribe = styled.section`
 const StyledGPTAd = styled(GPTAd)`
   width: auto;
   height: auto;
+  margin-right: auto;
+  ${({ theme }) => theme.breakpoint.md} {
+    order: -1;
+    margin-right: 0;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin-left: 20px;
+    margin-right: auto;
+    order: 0;
+  }
+`
+const GPTAdPlaceHolder = styled.div`
+  width: 95px;
+  height: 50px;
   margin-right: auto;
   ${({ theme }) => theme.breakpoint.md} {
     order: -1;
@@ -385,7 +399,11 @@ export default function Header({
         <a href="/" className="GTM-header-logo">
           <HeaderLogo />
         </a>
-        {shouldShowAd && <StyledGPTAd pageKey="global" adKey="RWD_LOGO" />}
+        {shouldShowAd ? (
+          <StyledGPTAd pageKey="global" adKey="RWD_LOGO" />
+        ) : (
+          <GPTAdPlaceHolder />
+        )}
         <ActionWrapper>
           <SubBrandList subBrands={SUB_BRAND_LINKS} />
           <SearchBarDesktop
@@ -394,10 +412,12 @@ export default function Header({
             goSearch={goSearch}
           />
           <SearchButtonMobile ref={mobileSearchButtonRef}>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
+            <Image
+              width={20}
+              height={21}
               src="/images-next/search-button-mobile.svg"
               alt="search-button"
+              loading="eager"
             />
           </SearchButtonMobile>
           <MemberLoginButton />

--- a/packages/mirror-media-next/components/mobile-sidebar.js
+++ b/packages/mirror-media-next/components/mobile-sidebar.js
@@ -4,7 +4,7 @@ import useClickOutside from '../hooks/useClickOutside'
 import Link from 'next/link'
 import HamburgerButton from './shared/hamburger-button'
 import CloseButton from './shared/close-button'
-
+import Image from 'next/image'
 /**
  * @typedef {import('../apollo/fragments/section').Section} Section
  */
@@ -352,8 +352,9 @@ export default function MobileSidebar({
                   target="_blank"
                   rel="noopener noreferer noreferrer"
                 >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
+                  <Image
+                    width={brand.imageSize.colorless.width}
+                    height={brand.imageSize.colorless.height}
                     src={`/images-next/${brand.name}-colorless.png`}
                     alt={brand.title}
                   />

--- a/packages/mirror-media-next/components/sub-brand-list.js
+++ b/packages/mirror-media-next/components/sub-brand-list.js
@@ -34,8 +34,8 @@ export default function SubBrandList({ subBrands = [], className }) {
           rel="noopener noreferer"
         >
           <Image
-            width={imageSize.width}
-            height={imageSize.height}
+            width={imageSize.normal.width}
+            height={imageSize.normal.height}
             src={`/images-next/${name}.png`}
             alt={title}
             loading="eager"

--- a/packages/mirror-media-next/constants/index.js
+++ b/packages/mirror-media-next/constants/index.js
@@ -94,8 +94,14 @@ const MIRRORVOICE_LINK = {
   title: '鏡好聽',
   href: 'https://voice.mirrorfiction.com/',
   imageSize: {
-    width: 131.25,
-    height: 30,
+    normal: {
+      width: 131.25,
+      height: 30,
+    },
+    colorless: {
+      width: 85,
+      height: 19,
+    },
   },
 }
 const MIRRORFICTION_LINK = {
@@ -103,8 +109,14 @@ const MIRRORFICTION_LINK = {
   title: '鏡文學',
   href: 'https://www.mirrorfiction.com/',
   imageSize: {
-    width: 131.25,
-    height: 30,
+    normal: {
+      width: 131.25,
+      height: 30,
+    },
+    colorless: {
+      width: 88,
+      height: 19,
+    },
   },
 }
 const READR_LINK = {
@@ -112,8 +124,14 @@ const READR_LINK = {
   title: 'READr 讀+',
   href: READR_URL,
   imageSize: {
-    width: 38,
-    height: 30,
+    normal: {
+      width: 38,
+      height: 30,
+    },
+    colorless: {
+      width: 21.11,
+      height: 19,
+    },
   },
 }
 const SUB_BRAND_LINKS = [MIRRORVOICE_LINK, MIRRORFICTION_LINK, READR_LINK]

--- a/packages/mirror-media-next/type/index.js
+++ b/packages/mirror-media-next/type/index.js
@@ -29,11 +29,15 @@ export default {}
  */
 
 /**
+ * @typedef {{width: number, height:number}} ImageWidthAndHeight
+ *
  * @typedef {Object} SubBrand - Sub-brand belonging to Mirror Media, which propose is direct users to certain website of sub-brand
  * @property {string} name - English name of sub-brand
  * @property {string} title - Mandarin name of sub-brand
  * @property {string} href - Complete url of sub-brand
- * @property {{width: number, height: number}} imageSize - image size of sub-brand, use for setting <img> width and height to prevent CLS problem
+ * @property {Object} imageSize - image size of sub-brand, use for setting <img> width and height to prevent CLS problem
+ * @property {ImageWidthAndHeight} imageSize.normal - image size of sub-brand, use for setting <img> width and height to prevent CLS problem
+ * @property {ImageWidthAndHeight} imageSize.colorless - image size of sub-brand, use for setting <img> width and height to prevent CLS problem
  */
 
 /**


### PR DESCRIPTION
## Notable change
1. 調整手機版header子品牌與搜尋按鈕圖片，改為使用next/image，並新增width與height，避免CLS問題。
2. 針對平板版header的GPT廣告，新增寬95px高50px的place holder ，避免廣告載入後造成icon位移。