### PR TITLE
feat(mm-next/topic): add `ListArticleAboveAd` in topic list

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/topic.js
+++ b/packages/mirror-media-next/apollo/fragments/topic.js
@@ -21,6 +21,7 @@ import { tag } from './tag'
  * @property {string} type
  * @property {string} style
  * @property {number} postsCount
+ * @property {number} featuredPostsCount
  * @property {import('./post').Post[]} posts
  * @property {import('./tag').Tag[]} tags
  * @property {string} og_description
@@ -65,6 +66,7 @@ export const topic = gql`
     type
     style
     postsCount(where: $postsFilter)
+    featuredPostsCount: postsCount(where: $featuredPostsCountFilter)
     posts(
       where: $postsFilter
       orderBy: $postsOrderBy
@@ -72,6 +74,7 @@ export const topic = gql`
       skip: $postsSkip
     ) {
       ...post
+      isFeatured
     }
     tags {
       ...tag

--- a/packages/mirror-media-next/apollo/query/topics.js
+++ b/packages/mirror-media-next/apollo/query/topics.js
@@ -21,6 +21,7 @@ const fetchTopic = gql`
   query (
     $topicFilter: TopicWhereInput!
     $postsFilter: PostWhereInput!
+    $featuredPostsCountFilter: PostWhereInput
     $postsOrderBy: [PostOrderByInput!]!
     $postsTake: Int
     $postsSkip: Int!
@@ -30,5 +31,15 @@ const fetchTopic = gql`
     }
   }
 `
+const fetchTopicPostCount = gql`
+  query Topic(
+    $topicFilter: TopicWhereUniqueInput!
+    $postsCountFilter: PostWhereInput
+  ) {
+    topic(where: $topicFilter) {
+      postsCount(where: $postsCountFilter)
+    }
+  }
+`
 
-export { fetchTopics, fetchTopic }
+export { fetchTopics, fetchTopic, fetchTopicPostCount }

--- a/packages/mirror-media-next/components/infinite-scroll-list.js
+++ b/packages/mirror-media-next/components/infinite-scroll-list.js
@@ -1,9 +1,6 @@
 import styled from 'styled-components'
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 
-// force page index start from 1 to prevent counting miscalculation
-const INITIAL_PAGE = 1
-
 const Test = styled.div`
   display: none;
   position: fixed;
@@ -52,11 +49,17 @@ export default function InfiniteScrollList({
    */
 
   const [dataList, setDataList] = useState([...initialList])
+  /**
+   * Force page index start from 1 to prevent counting miscalculation.
+   * If initialList is an empty array, it means that no elements have been displayed at the beginning,
+   * so initialPage needs to be set to 0, to avoid setting it to 1 and causing undisplayed elements be skipped.
+   */
+  const initialPage = initialList.length ? 1 : 0
 
   /**
    * The number of fetches that is send currently. State will possibly change when executing function `handleLoadMore`
    */
-  const [fetchPage, setFetchPage] = useState(INITIAL_PAGE)
+  const [fetchPage, setFetchPage] = useState(initialPage)
 
   const [renderCount, setRenderCount] = useState(renderAmount)
 

--- a/packages/mirror-media-next/components/topic/list/list-articles-above-ad.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles-above-ad.js
@@ -1,0 +1,64 @@
+import ListArticles from './list-articles'
+import styled from 'styled-components'
+import { useState } from 'react'
+import { useLazyQuery } from '@apollo/client'
+import { fetchTopic } from '../../../apollo/query/topics'
+const ShowMoreButton = styled.button`
+  width: 100%;
+  height: 200px;
+  background-color: pink;
+  margin: 0 auto;
+`
+export default function ListArticlesAboveAd({
+  posts = [],
+  topicSlug = '',
+  featuredPostsCount = 0,
+  renderPageSize = 12,
+}) {
+  const [renderPosts, setRenderPosts] = useState(posts)
+
+  /**
+   * Two situation:
+   * 1. `featurePostsCount` is greater than `renderPosts.length`, which means there are some featured post is not fetched and render yet.
+   * 2.  `featurePostsCount` is equal to or lower than `renderPosts.length`, which means all featured post has rendered.
+   */
+  const hasMoreFeaturedPosts = featuredPostsCount > renderPosts.length
+  const [getFeaturedPostsInTopic] = useLazyQuery(fetchTopic, {
+    variables: {
+      topicFilter: { slug: { equals: topicSlug } },
+      postsFilter: {
+        state: { equals: 'published' },
+        isFeatured: { equals: true },
+      },
+      postsOrderBy: [{ isFeatured: 'desc' }, { publishedDate: 'desc' }],
+      postsTake: renderPageSize,
+      postsSkip: renderPosts.length,
+    },
+  })
+
+  const handleLoadMore = async () => {
+    const res = await getFeaturedPostsInTopic()
+
+    if (res.called && !res.loading) {
+      const newPosts = res.data?.topics?.[0].posts
+
+      setRenderPosts((pre) => [...pre, ...newPosts])
+    }
+  }
+
+  return (
+    <>
+      <div>上方文章區</div>
+      <div>置頂文章共有 {featuredPostsCount} 篇</div>
+      <div>
+        目前上方文章顯示 {renderPosts.length} 篇，其中置頂文章有
+        {renderPosts.filter((post) => post.isFeatured).length} 篇，一般文章中有
+        {renderPosts.filter((post) => !post.isFeatured).length} 篇
+      </div>
+      <ListArticles renderList={renderPosts} />
+      {hasMoreFeaturedPosts && (
+        <ShowMoreButton onClick={handleLoadMore}>看更多</ShowMoreButton>
+      )}
+    </>
+  )
+}

--- a/packages/mirror-media-next/components/topic/list/list-articles-below-ad.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles-below-ad.js
@@ -1,0 +1,95 @@
+import styled from 'styled-components'
+import InfiniteScrollList from '../../infinite-scroll-list'
+import Image from 'next/legacy/image'
+// @ts-ignore
+import LoadingPage from '../../../public/images-next/loading_page.gif'
+import ListArticles from './list-articles'
+import { fetchTopicByTopicSlug } from '../../../utils/api/topic'
+
+const Loading = styled.div`
+  margin: 20px auto 0;
+  padding: 0 0 20px;
+  text-align: center;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 64px auto 0;
+    padding: 0 0 64px;
+  }
+`
+
+/**
+ * TODO: add comment to explain props
+ * @param {Object} props
+ * @param {string} props.topicSlug
+ * @param {boolean} props.hasNonFeaturedPostsInListAboveAd
+ * @param {number} props.renderPageSize
+ * @param {number} props.totalPostsCount
+ * @param {number} props.featuredPostsCount
+ * @returns
+ */
+export default function ListArticlesBelowAd({
+  topicSlug,
+  hasNonFeaturedPostsInListAboveAd,
+  renderPageSize,
+  totalPostsCount,
+  featuredPostsCount,
+}) {
+  /**
+   * Calculate how many total posts should render in this component.
+   * The value is depend on how many featured posts in certain topic (featured post will displayed at another component <`<ListArticlesAboveAd>`>)
+   * Two situation should be handled:
+   * 1. `featuredPostsCount` is greater than or equal to `renderPageSize`:
+   *    - The `<ListArticlesAboveAd>` component only shows featured posts,
+   *      and the `postsCount` only counts non-featured posts.
+   * 2. `featuredPostsCount` is lower than `renderPageSize`:
+   *    - The `<ListArticlesAboveAd>` component will include both featured and non-featured posts,
+   *      while the `postsCount` counts all posts except for the ones rendered in `<ListArticlesAboveAd>`.
+   */
+  const postsCount =
+    totalPostsCount -
+    (featuredPostsCount >= renderPageSize ? featuredPostsCount : renderPageSize)
+  const fetchPageSize = renderPageSize
+
+  async function fetchTopicPostsFromPage(page) {
+    if (!topicSlug) {
+      return
+    }
+    try {
+      const take = fetchPageSize
+
+      const minimumSkipAmount = hasNonFeaturedPostsInListAboveAd
+        ? take
+        : featuredPostsCount
+      const skip = (page - 1) * take + minimumSkipAmount
+
+      const response = await fetchTopicByTopicSlug(topicSlug, take, skip)
+      return response.data.topics[0].posts
+    } catch (error) {
+      // [to-do]: use beacon api to log error on gcs
+      console.error(error)
+    }
+    return
+  }
+
+  const loader = (
+    <Loading key={0}>
+      <Image src={LoadingPage} alt="loading page"></Image>
+    </Loading>
+  )
+
+  return (
+    <>
+      <div>下方文章區</div>
+      <div>下方文章共有 {postsCount} 篇</div>
+      <div>如果要計算下方文章目前顯示幾篇，請用command + f 搜尋</div>
+      <InfiniteScrollList
+        renderAmount={renderPageSize}
+        fetchCount={Math.ceil(postsCount / fetchPageSize)}
+        fetchListInPage={fetchTopicPostsFromPage}
+        loader={loader}
+      >
+        {(renderList) => <ListArticles renderList={renderList} />}
+      </InfiniteScrollList>
+    </>
+  )
+}

--- a/packages/mirror-media-next/components/topic/list/list-articles-item.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles-item.js
@@ -109,6 +109,7 @@ const ItemBrief = styled.div`
  *
  * @typedef {Pick<import('../../../apollo/fragments/post').HeroImage ,'id' | 'resized' | 'resizedWebp'>} HeroImage
  *
+ * //TODO: using Pick to write typedef
  * @typedef {import('../../../apollo/fragments/post').Post & {
  *  id: string,
  *  slug: string,
@@ -147,7 +148,11 @@ export default function ListArticlesItem({ item }) {
         )}
       </ImageContainer>
       <ItemDetail>
-        <ItemTitle>{item.title}</ItemTitle>
+        <ItemTitle>
+          {/* `item.isFeatured` is for testing, should remove after testing is completed */}
+          {item.isFeatured ? 'featured' : 'normal'}
+          {item.title}
+        </ItemTitle>
         <ItemBrief>{item.brief?.blocks[0]?.text}</ItemBrief>
       </ItemDetail>
     </ItemWrapper>

--- a/packages/mirror-media-next/components/topic/list/list-articles.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles.js
@@ -1,20 +1,5 @@
 import styled from 'styled-components'
 import ListArticlesItem from './list-articles-item'
-import dynamic from 'next/dynamic'
-
-import { useDisplayAd } from '../../../hooks/useDisplayAd'
-const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
-  ssr: false,
-})
-
-const StyledGPTAd = styled(GPTAd)`
-  width: 100%;
-  height: auto;
-  margin: 0 auto 20px auto;
-  ${({ theme }) => theme.breakpoint.xl} {
-    margin: 0 auto 35px auto;
-  }
-`
 
 const ItemContainer = styled.div`
   display: grid;
@@ -40,27 +25,14 @@ const ItemContainer = styled.div`
 /**
  * @param {Object} props
  * @param {Article[]} props.renderList
- * @param {string} props.dfp
  * @returns {React.ReactElement}
  */
-export default function ListArticles({ renderList, dfp }) {
-  const shouldShowAd = useDisplayAd()
-  const renderListBeforeAd = renderList.slice(0, 12)
-  const renderListAfterAd = renderList.slice(12)
-
+export default function ListArticles({ renderList }) {
   return (
-    <>
-      <ItemContainer>
-        {renderListBeforeAd.map((item) => (
-          <ListArticlesItem key={item.id} item={item} />
-        ))}
-      </ItemContainer>
-      {shouldShowAd && dfp && <StyledGPTAd adUnit={dfp} />}
-      <ItemContainer>
-        {renderListAfterAd.map((item) => (
-          <ListArticlesItem key={item.id} item={item} />
-        ))}
-      </ItemContainer>
-    </>
+    <ItemContainer>
+      {renderList.map((item) => (
+        <ListArticlesItem key={item.id} item={item} />
+      ))}
+    </ItemContainer>
   )
 }

--- a/packages/mirror-media-next/components/topic/list/topic-list-articles.js
+++ b/packages/mirror-media-next/components/topic/list/topic-list-articles.js
@@ -1,20 +1,19 @@
 import styled from 'styled-components'
+import dynamic from 'next/dynamic'
 
-import InfiniteScrollList from '../../infinite-scroll-list'
-import Image from 'next/legacy/image'
-// @ts-ignore
-import LoadingPage from '../../../public/images-next/loading_page.gif'
-import ListArticles from './list-articles'
-import { fetchTopicByTopicSlug } from '../../../utils/api/topic'
+import ListArticlesAboveAd from './list-articles-above-ad'
+import ListArticlesBelowAd from './list-articles-below-ad'
 
-const Loading = styled.div`
-  margin: 20px auto 0;
-  padding: 0 0 20px;
-  text-align: center;
-
+const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
+  ssr: false,
+})
+import { useDisplayAd } from '../../../hooks/useDisplayAd'
+const StyledGPTAd = styled(GPTAd)`
+  width: 100%;
+  height: auto;
+  margin: 0 auto 20px auto;
   ${({ theme }) => theme.breakpoint.xl} {
-    margin: 64px auto 0;
-    padding: 0 0 64px;
+    margin: 0 auto 35px auto;
   }
 `
 
@@ -26,51 +25,65 @@ const Loading = styled.div`
  *
  * @param {Object} props
  * @param {number} props.postsCount
- * @param {Article[]} props.posts
+ * @param {number} props.featuredPostsCount
+ * @param {Article[]} props.initialPosts
  * @param {string} props.topicSlug
  * @param {number} props.renderPageSize
  * @param {string} props.dfp
  * @returns {React.ReactElement}
  */
 export default function TopicListArticles({
-  postsCount,
-  posts,
+  postsCount: totalPostsCount,
+  featuredPostsCount,
+  initialPosts,
   topicSlug,
   renderPageSize,
   dfp,
 }) {
-  const fetchPageSize = renderPageSize
-  async function fetchTopicPostsFromPage(page) {
-    if (!topicSlug) {
-      return
-    }
-    try {
-      const take = fetchPageSize
-      const skip = (page - 1) * take
-      const response = await fetchTopicByTopicSlug(topicSlug, take, skip)
-      return response.data.topics[0].posts
-    } catch (error) {
-      // [to-do]: use beacon api to log error on gcs
-      console.error(error)
-    }
-    return
-  }
-
-  const loader = (
-    <Loading key={0}>
-      <Image src={LoadingPage} alt="loading page"></Image>
-    </Loading>
+  const shouldShowAd = useDisplayAd()
+  const hasNonFeaturedPostsInListAboveAd = initialPosts.some(
+    (post) => !post.isFeatured
   )
 
+  /**
+   * Handle logic of render component `ListArticlesBelowAd`.
+   * Two situation need to handle:
+   * 1. Has non-featured post in `initialPosts`:
+   *    - We check whether all posts has been fetched and displayed.
+   *    - For example, if `totalPostsCount` is 30 , and `initialPosts.length` is 12, which means there are 18 posts not fetched yet
+   *      and should fetch and render at `ListArticlesBelowAd`.
+   *    - If `totalPostsCount` is 10 , and `initialPosts.length` is 10, which means all post has been fetched and render at `ListArticlesAboveAd`,
+   *      and no need to render component `ListArticlesBelowAd`.
+   * 2. No non-featured post in `initialPosts`, all post in `initialPosts` is featured:
+   *    - We check whether has non-featured post.
+   *    - For example, if `totalPostsCount` is 50 , and `featuredPostsCount` is 30, which means there are 20 non-featured posts
+   *      and should fetch and render at `ListArticlesBelowAd`.
+   *    - If `totalPostsCount` is 50 , and `initialPosts.length` is 50, which means all post are featured posts and should render at `ListArticlesAboveAd`
+   *      and no need to render component `ListArticlesBelowAd`.
+   */
+  const shouldShowListArticlesBelowAd = hasNonFeaturedPostsInListAboveAd
+    ? totalPostsCount > initialPosts.length
+    : totalPostsCount > featuredPostsCount
   return (
-    <InfiniteScrollList
-      initialList={posts}
-      renderAmount={renderPageSize}
-      fetchCount={Math.ceil(postsCount / fetchPageSize)}
-      fetchListInPage={fetchTopicPostsFromPage}
-      loader={loader}
-    >
-      {(renderList) => <ListArticles renderList={renderList} dfp={dfp} />}
-    </InfiniteScrollList>
+    <>
+      <div>全部文章共有 {totalPostsCount} 篇</div>
+
+      <ListArticlesAboveAd
+        posts={initialPosts}
+        topicSlug={topicSlug}
+        featuredPostsCount={featuredPostsCount}
+        renderPageSize={renderPageSize}
+      ></ListArticlesAboveAd>
+      {shouldShowAd && dfp && <StyledGPTAd adUnit={dfp}></StyledGPTAd>}
+      {shouldShowListArticlesBelowAd && (
+        <ListArticlesBelowAd
+          topicSlug={topicSlug}
+          hasNonFeaturedPostsInListAboveAd={hasNonFeaturedPostsInListAboveAd}
+          renderPageSize={renderPageSize}
+          totalPostsCount={totalPostsCount}
+          featuredPostsCount={featuredPostsCount}
+        />
+      )}
+    </>
   )
 }

--- a/packages/mirror-media-next/components/topic/list/topic-list.js
+++ b/packages/mirror-media-next/components/topic/list/topic-list.js
@@ -192,7 +192,7 @@ const CustomSwiperNext = styled.div`
  */
 export default function TopicList({ topic, renderPageSize, slideshowImages }) {
   const [swiperRef, setSwiperRef] = useState(null)
-  const { postsCount, posts, slug, style } = topic
+  const { postsCount, posts, slug, style, featuredPostsCount } = topic
   const backgroundUrl = parseUrl(topic.style)
     ? ''
     : topic.og_image?.resized?.original || topic.heroImage?.resized?.original
@@ -262,8 +262,9 @@ export default function TopicList({ topic, renderPageSize, slideshowImages }) {
         </Topic>
         <TopicListArticles
           topicSlug={slug}
-          posts={posts}
+          initialPosts={posts}
           postsCount={postsCount}
+          featuredPostsCount={featuredPostsCount}
           renderPageSize={renderPageSize}
           dfp={topic.dfp}
         />

--- a/packages/mirror-media-next/utils/api/topic.js
+++ b/packages/mirror-media-next/utils/api/topic.js
@@ -12,6 +12,10 @@ export function fetchTopicByTopicSlug(topicSlug, postsTake, postsSkip) {
     variables: {
       topicFilter: { slug: { equals: topicSlug } },
       postsFilter: { state: { equals: 'published' } },
+      featuredPostsCountFilter: {
+        state: { equals: 'published' },
+        isFeatured: { equals: true },
+      },
       postsOrderBy: [{ isFeatured: 'desc' }, { publishedDate: 'desc' }],
       postsTake,
       postsSkip,


### PR DESCRIPTION
## Notable Change
1. 於topic list頁新增上方文章區塊，放置置頂文章。
2. 業務邏輯如下：
    - 假如該 `Topic` 關聯的 `Post` 中，大於 12 篇屬於置頂文章，則上方區塊只會顯示「置頂文章」，下方區塊（即原有的無限滾動文章區塊），則顯示「非置頂文章」，且上方文章區塊可以點擊「看更多」按鈕，點擊後上方文章區塊會載入並顯示更多「置頂文章」。
    - 假如該 `Topic` 關聯的 `Post` 中，等於 12 篇屬於置頂文章，則上方區塊只會顯示「置頂文章」，下方區塊（即原有的無限滾動文章區塊），則顯示「非置頂文章」。但上方文章區塊不會有「看更多」按鈕。
    - 假如該 `Topic` 關聯的 `Post` 中，小於 12 篇屬於置頂文章，則上方區塊會顯示「置頂文章+非置頂文章」，且兩個相加為12篇，下方區塊（即原有的無限滾動文章區塊），則顯示「非置頂文章」，且顯示的數量為「所有非置頂文章 - 上方區塊的非置頂文章」。
    - 舉例來說，假如topic總共有50篇，其中有20篇置頂文章、30篇非置頂文章，則上方文章區塊一開始會顯示12篇置頂文章，且點擊「看更多」後，會顯示剩下的8篇；下方文章區塊則會顯示30篇非置頂文章。
    - 假如topic總共有50篇，其中10篇置頂文章、40篇非置頂文章，則上方文章會顯示「10篇置頂文章 + 2篇非置頂文章」，下方文章區塊則會顯「40 - 2」篇非置頂文章。
3. 下方文章區塊則改由client-side取得與顯示資料，意味著一開始下方文章區塊並不會有任何文章顯示。由於原本的無限滾動元件都預設有初始資料顯示，因此微調元件 `InfinteScrollList`，以涵蓋上述邏輯。
4. 因應上述調整，調整apollo query與fragment，取得上述業務邏輯所需要的資料。
5. 調整gpt-ad元件的位置。

## Commit Detail
- [b30bde5](https://github.com/mirror-media/Adam/pull/710/commits/b30bde599badf7d67d20942919afa24a58eadbe7)：調整apollo/fragment，新增post的 `isFeatured` 屬性，該屬性將用於計算上方文章區塊是否該顯示看更多按鈕、下方文章區塊的抓取文章函式[`fetchTopicPostsFromPage`](https://github.com/mirror-media/Adam/pull/710/commits/e57995fd09b78764b8be218a1f3f926c1886b7c9#diff-933ef89ee266892b47b0ee6b27cf4c283c0b0c04b52009f7a76a42f4b4b02e39R75-R85)的其中一個參數`skip`，而該參數在上方文章區塊有無非置頂文章時，會有不同的值。
- [cf49f4f](https://github.com/mirror-media/Adam/pull/710/commits/cf49f4f006c1ec46f2efb80981d490ae4b713fcb)：新增apollo query，用於抓取topic中置頂文章的數量，並進而計算下方文章區塊該顯示的文章數量。「下方文章區塊該顯示的文章數量」會影響到無限滾動元件參數`fetchCount`的計算。
- [7a13a85](https://github.com/mirror-media/Adam/pull/710/commits/7a13a85cd8e566b4c1d9309bcdc80295eac3b068)：由於下方文章區塊目前皆在client-side抓取資料，所以元件`InfiniteScrollList`的參數`initialList`改為傳入空陣列。但原本該元件的設計，預設都有初始資訊。所以必須將常數`INITIAL_PAGE`改為變數，並依據`initialList`是否為空陣列決定其值，避免該抓取或顯示的資料被略過。
- [4cd8c45](https://github.com/mirror-media/Adam/pull/710/commits/4cd8c4555b0e7e051ffc8dd621f539f1427f464c)：新增元件 `ListArticleAboveAd `。
- [e57995f](https://github.com/mirror-media/Adam/pull/710/commits/e57995fd09b78764b8be218a1f3f926c1886b7c9)：調整元件 `TopicListArticles`，除了引入元件 `ListArticleAboveAd `，同時也使用了apollo-client `useQuery` 抓取置頂文章的數量，並依此計算函式`fetchTopicPostsFromPage` 的抓取數量。
- [95d029b](https://github.com/mirror-media/Adam/pull/710/commits/95d029bd3fb7e43c295afcf5c1831d90b93ba7c7)：新增測試用文字。測試用文章會在測試機驗收後刪除。
- [cf20b07](https://github.com/mirror-media/Adam/pull/710/commits/cf20b0755736f96f08c40f75f2ac76b246fdc2fd)：調整元件架構，將gpt廣告元件放置於上方文章區塊與下方文章區塊的中間。


## Todo
1. 新增元件 `ListArticleAboveAd`的jsDoc。
6. 調整元件 `ListArticleAboveAd` 的UI，包含「看更多」按鈕、loading特效等。
上述待辦事項將另開PR處理。