### PR TITLE
refactor(mm-next/web-vital): remove gfonts related script

### DIFF
--- a/packages/mirror-media-next/pages/_document.js
+++ b/packages/mirror-media-next/pages/_document.js
@@ -36,16 +36,6 @@ export default class MyDocument extends Document {
     return (
       <Html lang="zh-Hant">
         <Head>
-          <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link
-            rel="preconnect"
-            href="https://fonts.gstatic.com"
-            crossOrigin="anonymous"
-          />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@100;300;400;500;700;900&display=swap"
-            rel="stylesheet"
-          />
           <link
             rel="apple-touch-icon"
             sizes="180x180"


### PR DESCRIPTION
目前未使用字體noto sans tc，故移除對應的google font