### PR TITLE
refactor(mm-next/web-vital): set ad script as async

### DIFF
--- a/packages/mirror-media-next/components/ads/avivid/avivid-script.js
+++ b/packages/mirror-media-next/components/ads/avivid/avivid-script.js
@@ -11,6 +11,7 @@ export default function AvividScript() {
   }
   return (
     <Script
+      async
       strategy="lazyOnload"
       id="likrNotification"
       dangerouslySetInnerHTML={{

--- a/packages/mirror-media-next/components/ads/dable/dable-ad.js
+++ b/packages/mirror-media-next/components/ads/dable/dable-ad.js
@@ -20,6 +20,7 @@ export default function DableAd({ isDesktop }) {
   return (
     <>
       <Script
+        async
         strategy="lazyOnload"
         id="dable"
         dangerouslySetInnerHTML={{

--- a/packages/mirror-media-next/components/ads/gpt/gpt-script.js
+++ b/packages/mirror-media-next/components/ads/gpt/gpt-script.js
@@ -11,11 +11,13 @@ export default function GPTScript() {
           as="script"
         />
       </Head>
-      <Script src="https://securepubads.g.doubleclick.net/tag/js/gpt.js" />
+      <Script
+        async
+        src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"
+      />
       <Script id="gpt-setup">
         {`
-        window.googletag = window.googletag || {}
-        window.googletag.cmd = window.googletag.cmd || []
+        window.googletag = window.googletag || {cmd: []};
         window.googletag.cmd.push(() => {
           /**
            * Do not use lazy loading with SRA.


### PR DESCRIPTION
調整google publisher tag、dable廣告、avivid廣告的script載入方式，將其改為`async`