### PR TITLE
refactor(mm-next/gpt-ad): add gpt-ad script to `_document` to reduce loading time

### DIFF
--- a/packages/mirror-media-next/components/whole-site-script.js
+++ b/packages/mirror-media-next/components/whole-site-script.js
@@ -1,13 +1,7 @@
-import GPTScript from './ads/gpt/gpt-script'
 import AvividScript from './ads/avivid/avivid-script'
 import { useDisplayAd } from '../hooks/useDisplayAd'
 
 export default function WholeSiteScript() {
   const shouldShowAd = useDisplayAd()
-  return (
-    <>
-      <GPTScript />
-      {shouldShowAd && <AvividScript />}
-    </>
-  )
+  return <>{shouldShowAd && <AvividScript />}</>
 }

--- a/packages/mirror-media-next/pages/_document.js
+++ b/packages/mirror-media-next/pages/_document.js
@@ -4,7 +4,7 @@
 
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
-
+import Script from 'next/script'
 export default class MyDocument extends Document {
   static async getInitialProps(ctx) {
     const sheet = new ServerStyleSheet()
@@ -67,10 +67,56 @@ export default class MyDocument extends Document {
             name="google-site-verification"
             content="8tUjQvQoBEANJ6nRE9fMnsw2qODvbAgqDjSkLj-Mdw0"
           />
+          <link
+            rel="preload"
+            href="https://securepubads.g.doubleclick.net/tag/js/gpt.js"
+            as="script"
+          />
         </Head>
+
         <body>
           <Main />
+
           <NextScript />
+          {/* Script for google publisher ad  */}
+          <Script
+            async
+            strategy="beforeInteractive"
+            src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"
+          />
+          <Script strategy="beforeInteractive" id="gpt-setup">
+            {`
+        window.googletag = window.googletag || {cmd: []};
+        window.googletag.cmd.push(() => {
+          /**
+           * Do not use lazy loading with SRA.
+           *
+           * With lazy loading in SRA,
+           * GPT will fetching multiple ads at the same time,
+           * which cause the call for the first ad and all other ad slots is made.
+           * https://developers.google.com/doubleclick-gpt/reference#googletag.PubAdsService_enableSingleRequest
+           */
+          // window.googletag.pubads().enableSingleRequest()
+
+          window.googletag.pubads().enableLazyLoad({
+            // Fetch slots within 1.5 viewports.
+            fetchMarginPercent: 150,
+
+            // Render slots within 1 viewports.
+            renderMarginPercent: 100,
+
+            /**
+             * Double the above values on mobile, where viewports are smaller
+             * and users tend to scroll faster.
+             */
+            mobileScaling: 2.0,
+          })
+          window.googletag.pubads().collapseEmptyDivs()
+          window.googletag.enableServices()
+
+          
+        })`}
+          </Script>
         </body>
       </Html>
     )


### PR DESCRIPTION
調整gpt 廣告script的位置，將其放置於 `_document.js` 中，並調整 strategy 為 `beforeInteractive`，以提升gpt廣告的載入速度。