### PR TITLE
refactor(WAS): mark GCS proxy as deprecated

### DIFF
--- a/packages/weekly-api-server/src/app.js
+++ b/packages/weekly-api-server/src/app.js
@@ -155,6 +155,7 @@ export function createApp({
     })
   )
 
+  // Deprecated API, don't use it anymore
   // mini app: GCS proxy
   app.use(
     createGcsProxy({

--- a/packages/weekly-api-server/src/app.js
+++ b/packages/weekly-api-server/src/app.js
@@ -1,4 +1,4 @@
-import consts from './constants'
+import { statusCodes } from './constants'
 import cors from 'cors'
 // @ts-ignore `@twreporter/errors` does not have tyepscript definition file yet
 import errors from '@twreporter/errors'
@@ -7,8 +7,6 @@ import middlewareCreator from './middlewares'
 import { createGcsProxy } from './gcs-proxy-mini-app'
 import { createGraphQLProxy } from './gql-proxy-mini-app'
 import { createYoutubeProxy } from './youtube-proxy-mini-app'
-
-const statusCodes = consts.statusCodes
 
 /**
  *  This function creates an express application.

--- a/packages/weekly-api-server/src/app.js
+++ b/packages/weekly-api-server/src/app.js
@@ -29,7 +29,7 @@ import { createYoutubeProxy } from './youtube-proxy-mini-app'
  *  @param {string} opts.gcsProxyOrigin
  *  @param {string} opts.youtubeProxyOrigin
  *  @param {string[]|'*'} [opts.corsAllowOrigin=[]]
- *  @return {express.Application}
+ *  @returns {express.Application}
  */
 export function createApp({
   gcpProjectId,

--- a/packages/weekly-api-server/src/constants.js
+++ b/packages/weekly-api-server/src/constants.js
@@ -1,8 +1,5 @@
-const statusCodes = {
+export const statusCodes = {
   ok: 200,
   unauthorized: 401,
   internalServerError: 500,
-}
-export default {
-  statusCodes,
 }

--- a/packages/weekly-api-server/src/gcs-proxy-mini-app.js
+++ b/packages/weekly-api-server/src/gcs-proxy-mini-app.js
@@ -7,11 +7,9 @@ import { createProxyMiddleware } from 'http-proxy-middleware'
  *
  *  @param {Object} opts
  *  @param {string} opts.proxyOrigin
- *  @return {express.Router}
+ *  @returns {express.Router}
  */
-export function createGcsProxy({
-  proxyOrigin,
-}) {
+export function createGcsProxy({ proxyOrigin }) {
   // create express mini app
   const router = express.Router()
 
@@ -22,6 +20,7 @@ export function createGcsProxy({
       target: proxyOrigin,
       changeOrigin: true,
       pathRewrite: (path) => path.replace(/^\/gcs/, ''),
+      // eslint-disable-next-line no-unused-vars
       onProxyReq: (proxyReq, req, res) => {
         proxyReq.setHeader('X-PROXIED-BY', 'Weekly API Server')
       },

--- a/packages/weekly-api-server/src/gql-proxy-mini-app.js
+++ b/packages/weekly-api-server/src/gql-proxy-mini-app.js
@@ -1,11 +1,9 @@
-import consts from './constants'
+import { statusCodes } from './constants'
 // @ts-ignore `@twreporter/errors` does not have tyepscript definition file yet
 import errors from '@twreporter/errors'
 import express from 'express'
 import middlewareCreator from './middlewares'
 import { createProxyMiddleware } from 'http-proxy-middleware'
-
-const statusCodes = consts.statusCodes
 
 /**
  *  This function creates a mini app.

--- a/packages/weekly-api-server/src/gql-proxy-mini-app.js
+++ b/packages/weekly-api-server/src/gql-proxy-mini-app.js
@@ -14,20 +14,14 @@ import { createProxyMiddleware } from 'http-proxy-middleware'
  *  @param {string} opts.jwtSecret
  *  @param {string} opts.proxyOrigin
  *  @param {'/content/graphql'|'/member/graphql'} opts.proxyPath
- *  @return {express.Router}
+ *  @returns {express.Router}
  */
-export function createGraphQLProxy({
-  jwtSecret,
-  proxyOrigin,
-  proxyPath,
-}) {
+export function createGraphQLProxy({ jwtSecret, proxyOrigin, proxyPath }) {
   // create express mini app
   const router = express.Router()
 
   // enable pre-flight request
-  router.options(
-    proxyPath,
-  )
+  router.options(proxyPath)
 
   const verifyAccessToken = middlewareCreator.verifyAccessToken({
     jwtSecret,
@@ -50,7 +44,6 @@ export function createGraphQLProxy({
       next()
     },
 
-
     // proxy request to API GraphQL endpoint
     createProxyMiddleware({
       target: proxyOrigin,
@@ -64,7 +57,10 @@ export function createGraphQLProxy({
         console.log(
           JSON.stringify({
             severity: 'DEBUG',
-            message: 'proxy to backed API origin server: ' + proxyOrigin + proxyReq.path,
+            message:
+              'proxy to backed API origin server: ' +
+              proxyOrigin +
+              proxyReq.path,
             ...res?.locals?.globalLogFields,
           })
         )

--- a/packages/weekly-api-server/src/middlewares/logger.js
+++ b/packages/weekly-api-server/src/middlewares/logger.js
@@ -7,7 +7,7 @@ import express from 'express' // eslint-disable-line
  *  @param {Object} req
  *  @param {Function} req.header
  *  @param {string} projectId
- *  @return {Object} globalLogFields
+ *  @returns {Object} globalLogFields
  */
 function getGlobalLogFields(req, projectId) {
   const globalLogFields = {}
@@ -26,7 +26,7 @@ function getGlobalLogFields(req, projectId) {
 /**
  *  Create an express middleware to log request.
  *  @param {string} projectId
- *  @return {express.RequestHandler} express middleware
+ *  @returns {express.RequestHandler} express middleware
  */
 export function createLoggerMw(projectId) {
   return (req, res, next) => {

--- a/packages/weekly-api-server/src/middlewares/member-info.js
+++ b/packages/weekly-api-server/src/middlewares/member-info.js
@@ -11,7 +11,7 @@ import express from 'express' // eslint-disable-line
  *
  *  @param {Object} opts
  *  @param {string} opts.apiUrl
- *  @return {express.RequestHandler} express middleware
+ *  @returns {express.RequestHandler} express middleware
  */
 export function queryMemberInfo(opts) {
   return async (req, res, next) => {

--- a/packages/weekly-api-server/src/youtube-proxy-mini-app.js
+++ b/packages/weekly-api-server/src/youtube-proxy-mini-app.js
@@ -1,18 +1,15 @@
 import express from 'express'
 import { createProxyMiddleware } from 'http-proxy-middleware'
 
-
 /**
  *  This function creates a mini app.
  *  This mini app aims to proxy requests to Google Cloud Storage.
  *
  *  @param {Object} opts
  *  @param {string} opts.proxyOrigin
- *  @return {express.Router}
+ *  @returns {express.Router}
  */
-export function createYoutubeProxy({
-  proxyOrigin,
-}) {
+export function createYoutubeProxy({ proxyOrigin }) {
   // create express mini app
   const router = express.Router()
 
@@ -23,6 +20,7 @@ export function createYoutubeProxy({
     createProxyMiddleware({
       target: proxyOrigin,
       changeOrigin: true,
+      // eslint-disable-next-line no-unused-vars
       onProxyReq: (proxyReq, req, res) => {
         proxyReq.setHeader('X-PROXIED-BY', 'Weekly API Server')
       },


### PR DESCRIPTION
## Notable Changes
* 調整 `statusCodes` 關聯的程式碼
* 調整程式碼格式
* 將 GCS proxy 標記為棄用