### PR TITLE
refactor(mm-next/amp): add fallback of hero image, adjust render logic

### DIFF
--- a/packages/mirror-media-next/components/amp/amp-hero.js
+++ b/packages/mirror-media-next/components/amp/amp-hero.js
@@ -59,27 +59,14 @@ export default function AmpHero({
   title = '',
 }) {
   const shouldShowHeroVideo = Boolean(heroVideo)
+  const shouldShowHeroImage = Boolean(heroImage)
+  const shouldShowHeroCaption =
+    heroCaption && (shouldShowHeroVideo || shouldShowHeroImage)
 
-  // TODO: add srcset and callback
-  // const srcset = Object.entries(heroImage?.resized)
-  //   .filter(([key, value]) => key !== 'original' && value !== '')
-  //   .filter(([key, value]) => key !== '__typename')
-  //   .map(([key, value]) => `${value} ${key.replace('w', '')}w`)
-  //   .join(', ')
-
-  return (
-    <figure>
-      {!shouldShowHeroVideo && (
-        <HeroWrapper>
-          {/** @ts-ignore */}
-          <amp-img
-            src={heroImage?.resized?.original}
-            alt={heroCaption ?? title}
-            layout="fill"
-          ></amp-img>
-        </HeroWrapper>
-      )}
-      {shouldShowHeroVideo && (
+  const heroJsx = () => {
+    const imageAlt = heroCaption ? heroCaption : title
+    if (shouldShowHeroVideo) {
+      return (
         <HeroWrapper>
           {/** @ts-ignore */}
           <amp-video
@@ -87,10 +74,52 @@ export default function AmpHero({
             layout="fill"
             poster={heroVideo?.heroImage?.resized?.original}
             src={heroVideo.urlOriginal}
+            title={imageAlt}
           />
         </HeroWrapper>
-      )}
-      {heroCaption && <HeroCaption>{heroCaption}</HeroCaption>}
+      )
+    } else if (shouldShowHeroImage) {
+      /**
+       * The rules for fallback of the heroImage:
+       * 1. Show w800 first.
+       * 2. If the URL of w800 is an empty string or an invalid URL, then show the original by using <amp-img> with `fallback` attribute.
+       * 3. If the URL of original is an empty string, then show the default image url by replacing src of <amp-img>.
+       */
+      return (
+        <HeroWrapper>
+          {/** @ts-ignore */}
+          <amp-img src={heroImage?.resized?.w800} alt={imageAlt} layout="fill">
+            {/** @ts-ignore */}
+            <amp-img
+              fallback
+              src={
+                heroImage?.resized?.original
+                  ? heroImage?.resized?.original
+                  : '/images-next/default-og-img.png'
+              }
+              alt={imageAlt}
+              layout="fill"
+            ></amp-img>
+          </amp-img>
+        </HeroWrapper>
+      )
+    }
+    return (
+      <HeroWrapper>
+        {/** @ts-ignore */}
+        <amp-img
+          src="/images-next/default-og-img.png"
+          alt={imageAlt}
+          layout="fill"
+        ></amp-img>
+      </HeroWrapper>
+    )
+  }
+
+  return (
+    <figure>
+      {heroJsx()}
+      {shouldShowHeroCaption && <HeroCaption>{heroCaption}</HeroCaption>}
     </figure>
   )
 }


### PR DESCRIPTION
## Notable Change
1. amp 的首圖新增fallback功能
2. 調整首圖、首影片的業務邏輯，使其與一般文章頁一致。

## Implement Detail
1. 日前需求方反應amp廣告經常無法出現，雖然目前仍未找出原因，但推測其中一原因為網路請求過多且檔案下載量過大，導致廣告script與對應的廣告素材下載過慢。經過觀察後，發現圖片皆為使用`original`，但 `original` 的檔案大小都非常大。
4. 就算撇開廣告問題，`original`的圖片由於過大所以載入十分緩慢，在較差的網路環境下甚至需要載入10秒以上，十分影響使用者體驗。
5. 所以本次PR的目標是「在保證圖片能夠顯示的前提下，盡量減少圖片下載量」，如果需要達到這個目標，需要像套件 `readr-media/react-image`一樣有圖片的fallback功能。
6. 但經過研究，amp並無法像前述套件那樣有多層的fallback功能，因此退而求其次，改為一層的fallback。而如果需要達成前述目標的話，最好的做法是 `w800` -> `original`（`w480`經過討論後，認為解析度太低）。
7. 我使用了amp的[`fallback`](https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/placeholders)屬性來處理。與[amp-image自身的fallback](https://amp.dev/documentation/components/amp-img)寫法不同的是，使用`fallback`屬性來處理，只會在需要fallback時請求對應的圖片，反而amp-image自身的fallback則會對兩張圖片發出請求。
8. 舉例來說，fallback屬性會先載入w800，如果w800失敗的話才會對original的url發出請求；amp-image自身的fallback則會同時對w800與original發出請求。（這是我自身測試的結果，文件上沒有寫）
9. 除此之外，也調整了首圖、首影片的顯示邏輯，讓它與一般文章頁一致。