### PR TITLE
feat(mm-next): add custom hooks for saving article history

### DIFF
--- a/packages/mirror-media-next/constants/member-article-history.js
+++ b/packages/mirror-media-next/constants/member-article-history.js
@@ -1,0 +1,3 @@
+const LOCAL_STORAGE_KEY = 'memberArticleRecords'
+
+export { LOCAL_STORAGE_KEY }

--- a/packages/mirror-media-next/hooks/member-article-history/use-save-member-article-history-locally.js
+++ b/packages/mirror-media-next/hooks/member-article-history/use-save-member-article-history-locally.js
@@ -1,0 +1,54 @@
+import { useEffect } from 'react'
+
+import { useMembership } from '../../context/membership'
+import { LOCAL_STORAGE_KEY } from '../../constants/member-article-history'
+const HISTORY_EXPIRE_TIME = 30 * 60 * 1000 //milliseconds, which is equal to 30 minutes
+
+/**
+ * @typedef {{ts: number,slug: string}} ArticleRecord
+ */
+
+/**
+ * Save member's article (/story) browsing history.
+ * Renew the localStorage.memberArticleRecords every time with fresh record corresponding to the logged-in user.
+ * Only store articles read within certain period of time, time is determined by `HISTORY_EXPIRE_TIME`.
+ * @param {string} storySlug
+ */
+export default function useSaveMemberArticleHistoryLocally(storySlug = '') {
+  const { firebaseId, isLogInProcessFinished } = useMembership()
+  useEffect(() => {
+    if (!storySlug || !isLogInProcessFinished || !firebaseId) {
+      return
+    }
+    const nowTs = new Date().valueOf()
+    const expireTs = nowTs - HISTORY_EXPIRE_TIME
+    const newArticleRecord = { ts: nowTs, slug: storySlug }
+    /**
+     * @type {{ [id: string] : ArticleRecord[]}}
+     */
+    const memberArticleRecords =
+      JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY)) || {}
+
+    const hasArticleRecordsInLocalStorage = Boolean(
+      memberArticleRecords[firebaseId] &&
+        Array.isArray(memberArticleRecords[firebaseId]) &&
+        memberArticleRecords[firebaseId].length
+    )
+
+    const articleRecords = hasArticleRecordsInLocalStorage
+      ? memberArticleRecords[firebaseId]
+          .filter((record) => record.ts > expireTs)
+          .concat(newArticleRecord)
+      : [newArticleRecord]
+
+    const newMemberArticleRecords = {
+      ...memberArticleRecords,
+      [firebaseId]: articleRecords,
+    }
+
+    localStorage.setItem(
+      LOCAL_STORAGE_KEY,
+      JSON.stringify(newMemberArticleRecords)
+    )
+  }, [storySlug, isLogInProcessFinished, firebaseId])
+}

--- a/packages/mirror-media-next/hooks/member-article-history/use-upload-member-article-history.js
+++ b/packages/mirror-media-next/hooks/member-article-history/use-upload-member-article-history.js
@@ -1,0 +1,9 @@
+/**
+ * Work in Progress.
+ * Should implement after feature of member subscription is developed and released in Adam/mirror-media-next.
+ * Currently our feature of member subscription is executing at mirror-media-nuxt.
+ * @see https://github.com/mirror-media/mirror-media-nuxt/blob/dev/mixins/upload-member-article-history.js
+ */
+export default function useUploadMemberArticleHistory() {
+  return null
+}

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -9,6 +9,7 @@ import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
 import WineWarning from '../../components/shared/wine-warning'
 import AdultOnlyWarning from '../../components/story/shared/adult-only-warning'
 import { useMembership } from '../../context/membership'
+import useSaveMemberArticleHistoryLocally from '../../hooks/member-article-history/use-save-member-article-history-locally'
 import {
   fetchPostBySlug,
   fetchPostFullContentBySlug,
@@ -121,6 +122,7 @@ export default function Story({ postData, headerData, storyLayoutType }) {
       ? { type: 'fullContent', data: content, isLoaded: true }
       : { type: 'trimmedContent', data: trimmedContent, isLoaded: false }
   )
+  useSaveMemberArticleHistoryLocally(slug)
   useEffect(() => {
     const fetchPostFullContent = async () => {
       try {


### PR DESCRIPTION
## Notable Change
1. 將mirror-media-nuxt中，儲存會員閱讀記錄的功能，搬移至mm-next中，並小幅度重構。

## Implement Detail
1. 本次PR主要的目標是「將既有功能從vue的mixins，搬為react的custom hook」（題外話，vue 3 也有功能類似於custom hook的[Composable](https://vuejs.org/guide/reusability/composables.html)，其中一個用途也是取代mixins的缺點）。
2. 承上，這次創建了兩個custom hook：`useSaveMemberArticleHistoryLocally`, `useUploadMemberArticleHistory`。
3. 本次PR主要改動為`useSaveMemberArticleHistoryLocally`，`useUploadMemberArticleHistory`僅有創建檔案並留下註解。
4. 在保持既有功能正常運作的前提下，`useSaveMemberArticleHistoryLocally`做了以下重構：
   -  存取localStorage中特定屬性的值，從`localStorage.keyName `改為`localStorage.getItem(keyName)`/ `localStorage.setItem(keyName, value)`。原因是`localStorage.getItem`, `localStorage.setItem` 有型別可以參考。
   - 改寫既有的寫法，減少變數重新附值的過程（即`let xxx = a;  xxx = b;`），陣列方法也改用不會修改既有陣列的方法`.concat` 以取代`.push `。
   - 將localStorage的key name抽成一個常數，並放在constants資料夾中，以便後續共用。

## Ref 
[mirror-media-nuxt 2.0 PR](https://github.com/mirror-media/mirror-media-nuxt/pull/908)
