### PR TITLE
refactor(mm-next): adjust `fb-page-plugin` to improve performance

### DIFF
--- a/packages/mirror-media-next/components/story/normal/fb-page-plugin.js
+++ b/packages/mirror-media-next/components/story/normal/fb-page-plugin.js
@@ -1,52 +1,10 @@
-import { useEffect, useRef, useState } from 'react'
+import Script from 'next/script'
 
-const FB_SDK_URL = 'https://connect.facebook.net/zh_TW/sdk.js'
+const FB_SDK_URL =
+  'https://connect.facebook.net/zh_TW/sdk.js#xfbml=1&version=v18.0'
 const FB_PAGE_URL = 'https://www.facebook.com/mirrormediamg'
 
 /** @typedef {import('../../../type/theme').Theme} Theme */
-
-/**
- * @function
- * Insert div for initializing facebook page plugin.
- */
-function insertRootDiv() {
-  if (document.getElementById('fb-root')) {
-    return
-  }
-  const fbRoot = document.createElement('div')
-  fbRoot.id = 'fb-root'
-  document.body.appendChild(fbRoot)
-}
-
-/**
- * @async
- * Load script of facebook javascript sdk for initializing facebook page plugin.
- */
-async function loadFbSdk() {
-  if (window.FB) return
-
-  await new Promise((resolve, reject) => {
-    const fbSdkScript = document.createElement('script')
-
-    const loadHandler = () => {
-      resolve()
-      fbSdkScript.removeEventListener('load', loadHandler)
-    }
-    const errorHandler = (e) => {
-      reject(e?.target?.src)
-      fbSdkScript.removeEventListener('error', errorHandler)
-    }
-
-    fbSdkScript.src = FB_SDK_URL
-    fbSdkScript.addEventListener('load', loadHandler)
-    fbSdkScript.addEventListener('error', errorHandler)
-    document.body.appendChild(fbSdkScript)
-  })
-  window.FB.init({
-    xfbml: true,
-    version: 'v16.0',
-  })
-}
 
 /**
  * - Settings for facebook page plugin, such as `data-tabs`, `data-width`.
@@ -55,7 +13,7 @@ async function loadFbSdk() {
  * @typedef {Object} FacebookPagePluginSetting
  * @property {string} [data-href]
  * @property {number} [data-width]
- * @property {number} [data-height ]
+ * @property {number} [data-height]
  * @property {'timeline' | 'events' | 'messages' } [data-tabs]
  * @property {boolean} [data-hide-cover]
  * @property {boolean} [data-show-facepile]
@@ -76,55 +34,32 @@ export default function FbPage({
   facebookPagePluginSetting = {},
   className = '',
 }) {
-  const embedRef = useRef(null)
-  const [isLoaded, setIsLoaded] = useState(false)
-  useEffect(() => {
-    let callback = (entries, observer) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          if (!isLoaded) {
-            insertRootDiv()
-            loadFbSdk()
-              .then(() => {
-                // parse only the part we needed to improve web performance.
-                // docs: https://developers.facebook.com/docs/reference/javascript/FB.XFBML.parse
-                window.FB.XFBML.parse(embedRef.current)
-              })
-              .catch((src) => {
-                console.warn(`Unable to load facebook SDK script ${src}`)
-              })
-            setIsLoaded(true)
-            observer.unobserve(embedRef.current)
-          }
-        }
-      })
-    }
-    const observer = new IntersectionObserver(callback, {
-      root: null,
-      rootMargin: '200px',
-      threshold: 0,
-    })
-    observer.observe(embedRef.current)
-
-    return () => observer.disconnect()
-  }, [isLoaded])
   return (
-    <section className={className}>
-      <div
-        ref={embedRef}
-        className="fb-page"
-        data-href={FB_PAGE_URL}
-        data-tabs="timeline"
-        data-small-header={false}
-        data-adapt-container-width={true}
-        data-hide-cover={false}
-        data-show-facepile={true}
-        {...facebookPagePluginSetting}
-      >
-        <blockquote cite={FB_PAGE_URL} className="fb-xfbml-parse-ignore">
-          <a href={FB_PAGE_URL}>鏡週刊</a>
-        </blockquote>
-      </div>
-    </section>
+    <>
+      <div id="fb-root"></div>
+      <Script
+        crossOrigin="anonymous"
+        src={FB_SDK_URL}
+        strategy="lazyOnload"
+        nonce="SMSY4ynQ"
+      ></Script>
+      <section className={className}>
+        <div
+          className="fb-page"
+          data-href={FB_PAGE_URL}
+          data-tabs="timeline"
+          data-small-header={false}
+          data-adapt-container-width={true}
+          data-hide-cover={false}
+          data-show-facepile={true}
+          data-lazy={true}
+          {...facebookPagePluginSetting}
+        >
+          <blockquote cite={FB_PAGE_URL} className="fb-xfbml-parse-ignore">
+            <a href={FB_PAGE_URL}>鏡週刊</a>
+          </blockquote>
+        </div>
+      </section>
+    </>
   )
 }

--- a/packages/mirror-media-next/components/story/normal/social-network-service.js
+++ b/packages/mirror-media-next/components/story/normal/social-network-service.js
@@ -142,6 +142,7 @@ export default function SocialNetworkService({
     'data-tabs': 'events',
     'data-small-header': true,
     'data-width': 180,
+    'data-height': 71,
   }
   let facebookPagePluginSize = {
     width: '180px',
@@ -151,10 +152,12 @@ export default function SocialNetworkService({
     facebookPagePluginSetting = {
       'data-tabs': 'timeline',
       'data-small-header': false,
+      'data-width': 340,
+      'data-height': 500,
     }
     facebookPagePluginSize = {
-      width: '100%',
-      height: '100%',
+      width: '340px',
+      height: '500px',
     }
   }
   return (


### PR DESCRIPTION
## Notable Change 
由於需求方時常反應文章頁會有載入過慢、突然閃動的問題，經過研究，發現是facebook social plugin當初並沒有寫好所導致：
1. 載入過慢是由於原本的fb sdk載入並沒有加入 `async`，導致載入script時主線程會阻塞（不過是否能真的有效降低TBT，仍待觀察）
2. 閃動則是因為fb social plugin沒有設定 data-width跟data-height，而是設`100%`所導致的。
3. 為了解決上述問題，fb sdk 改用nextjs/script來載入，並且取消了使用intersection observer API實現懶載入的功能，而改用fb social plugin的內建attribute `data-lazy`來實作。
4. 閃動則設定`data-width`跟`data-height`為固定寬高px