### PR TITLE
refactor(mm-next): add link for topic slideshow image

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/photo.js
+++ b/packages/mirror-media-next/apollo/fragments/photo.js
@@ -31,6 +31,7 @@ import { gql } from '@apollo/client'
  * @property {Resized} resized
  * @property {Resized} resizedWebp
  * @property {string} name
+ * @property {string} topicKeywords
  */
 
 export const heroImage = gql`
@@ -70,5 +71,6 @@ export const slideshowImage = gql`
       w2400
     }
     name
+    topicKeywords
   }
 `

--- a/packages/mirror-media-next/components/topic/list/topic-list.js
+++ b/packages/mirror-media-next/components/topic/list/topic-list.js
@@ -244,21 +244,45 @@ export default function TopicList({ topic, renderPageSize, slideshowImages }) {
                   modules={[Autoplay, Navigation]}
                 >
                   {slideshowImages.map((item) => (
-                    <SwiperSlide key={item.id}>
-                      <CustomImage
-                        images={item?.resized}
-                        imagesWebP={item?.resizedWebp}
-                        loadingImage={'/images-next/loading@4x.gif'}
-                        defaultImage={'/images-next/default-og-img.png'}
-                        rwd={{
-                          mobile: '450px',
-                          tablet: '850px',
-                          desktop: '850px',
-                          default: '850px',
-                        }}
-                        priority={true}
-                        alt={item.name}
-                      />
+                    <SwiperSlide key={item?.id}>
+                      {item?.topicKeywords &&
+                      item?.topicKeywords.startsWith('@-') ? (
+                        <Link
+                          href={item.topicKeywords.slice(2)}
+                          target="_blank"
+                          rel="noreferrer noopenner"
+                        >
+                          <CustomImage
+                            images={item?.resized}
+                            imagesWebP={item?.resizedWebp}
+                            loadingImage={'/images-next/loading@4x.gif'}
+                            defaultImage={'/images-next/default-og-img.png'}
+                            rwd={{
+                              mobile: '450px',
+                              tablet: '850px',
+                              desktop: '850px',
+                              default: '850px',
+                            }}
+                            priority={true}
+                            alt={item.name}
+                          />
+                        </Link>
+                      ) : (
+                        <CustomImage
+                          images={item?.resized}
+                          imagesWebP={item?.resizedWebp}
+                          loadingImage={'/images-next/loading@4x.gif'}
+                          defaultImage={'/images-next/default-og-img.png'}
+                          rwd={{
+                            mobile: '450px',
+                            tablet: '850px',
+                            desktop: '850px',
+                            default: '850px',
+                          }}
+                          priority={true}
+                          alt={item.name}
+                        />
+                      )}
                     </SwiperSlide>
                   ))}
                 </Swiper>

--- a/packages/mirror-media-next/components/topic/list/topic-list.js
+++ b/packages/mirror-media-next/components/topic/list/topic-list.js
@@ -1,6 +1,8 @@
 import styled from 'styled-components'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import { Autoplay, Navigation } from 'swiper'
+import Link from 'next/link'
+
 import TopicListArticles from './topic-list-articles'
 import CustomImage from '@readr-media/react-image'
 // Import Swiper styles
@@ -43,6 +45,7 @@ const Container = styled.main`
 
 const Topic = styled.div`
   display: block;
+  position: relative;
   background-repeat: no-repeat;
   height: auto;
   padding-top: 66.66%;
@@ -149,6 +152,14 @@ const CustomSwiperNext = styled.div`
   }
 `
 
+const TopicLink = styled(Link)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`
+
 /**
  * @typedef {import('../../../apollo/fragments/photo').Photo & {
  *  id: string;
@@ -208,13 +219,8 @@ export default function TopicList({ topic, renderPageSize, slideshowImages }) {
   return (
     <>
       <Container customCss={style}>
-        <Topic
-          className="topic"
-          as={topic?.heroUrl ? 'a' : 'div'}
-          backgroundUrl={backgroundUrl}
-          href={topic?.heroUrl}
-          target={topic?.heroUrl ? '_blank' : null}
-        >
+        <Topic className="topic" backgroundUrl={backgroundUrl}>
+          <TopicLink href={topic?.heroUrl} target="_blank" />
           <TopicTitle className="topic-title" />
           <TopicLeading className="leading">
             {!!slideshowImages.length && (


### PR DESCRIPTION
# Notable Change

Topic 頁如有 slideshow image 且 slideshow image 中含有有效 topicKeywords (字串格式 @-[連結])，就把該連結加到對應的 slide 上面。

修改 `Topic` component 結構，原本 `Topic` component 如有 heroUrl 會直接把 `Topic` 透過 styled-components 的 `as` props 指定成 <a> element，但這次的修改 `Topic` 中的 element 可能會有 nested 的 <a> element (可點擊的 slide)，導致出現 <a> 的 children 中含有另一個 <a> 等不合法的狀況，因此在這個 [commit](https://github.com/mirror-media/Adam/commit/1cfbbaaa40dae5bea44f8609202807481d4dab4a) 中修改成 heroUrl 是透過 `Topic` 下的 <Link> 來達成點擊效果。