### PR TITLE
refactor(mm-next): hide link if heroUrl not exists

### DIFF
--- a/packages/mirror-media-next/components/topic/list/topic-list.js
+++ b/packages/mirror-media-next/components/topic/list/topic-list.js
@@ -220,7 +220,9 @@ export default function TopicList({ topic, renderPageSize, slideshowImages }) {
     <>
       <Container customCss={style}>
         <Topic className="topic" backgroundUrl={backgroundUrl}>
-          <TopicLink href={topic?.heroUrl} target="_blank" />
+          {topic?.heroUrl && (
+            <TopicLink href={topic?.heroUrl} target="_blank" />
+          )}
           <TopicTitle className="topic-title" />
           <TopicLeading className="leading">
             {!!slideshowImages.length && (


### PR DESCRIPTION
修正 [pr] (https://github.com/mirror-media/Adam/pull/823) 沒有 `heroUrl` 的時候需要隱藏 link