### PR TITLE
fix(mm-next): add redirect to author page

### DIFF
--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -141,6 +141,16 @@ export async function getServerSideProps({ query, req, res }) {
 
   const authorId = Array.isArray(query.id) ? query.id[0] : query.id
 
+  //When `authorId` is not only numeric, redirect to the '/'.
+  if (!/^\d+$/.test(authorId)) {
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    }
+  }
+
   const traceHeader = req.headers?.['x-cloud-trace-context']
   let globalLogFields = {}
   if (traceHeader && !Array.isArray(traceHeader)) {


### PR DESCRIPTION
### Notable Changes 
- 作者列表頁針對 query id 是否為「數字」增加導向判斷。

   - author/[id] → id 為數字，且該 id CMS 有資料：正常顯示
   - author/[id] → id 為數字，但該 id CMS 沒有資料：顯示 404
   - author/[id] → id 含有數字以外的符號（ex: 英文、標點符號）：導向首頁 '/'