### PR TITLE
feat(mm-next): add `comscore-script` and import it in wholesite-script

### DIFF
--- a/packages/mirror-media-next/components/comscore-script.js
+++ b/packages/mirror-media-next/components/comscore-script.js
@@ -1,0 +1,66 @@
+import Script from 'next/script'
+import { useRouter } from 'next/router'
+
+/**
+ * Component for implement comScore script.
+ * There are two different script, one for amp type page, one for other.
+ * See amp Docs to get more info about comScore amp page script: https://direct-support.comscore.com/hc/en-us/article_attachments/360058526434
+ *
+ */
+export default function ComScoreScript() {
+  const router = useRouter()
+  const { pathname } = router
+  const isAmpStoryPage = pathname.startsWith('/story/amp/')
+  if (isAmpStoryPage) {
+    return (
+      <>
+        <script
+          async
+          // eslint-disable-next-line react/no-unknown-property
+          custom-element="amp-analytics"
+          src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"
+        ></script>
+        {/* @ts-ignore */}
+        <amp-analytics type="comscore">
+          <script
+            type="application/json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify({
+                vars: {
+                  c2: '24318560',
+                },
+                extraUrlParams: {
+                  comscorekw: 'amp',
+                },
+              }),
+            }}
+          ></script>
+          {/* @ts-ignore */}
+        </amp-analytics>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Script
+        id="comScore"
+        dangerouslySetInnerHTML={{
+          __html: `var _comscore = _comscore || [];
+        _comscore.push({ c1: "2", c2: "24318560" });
+        (function() {
+        var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
+        s.src = (document.location.protocol == "https:" ? "https://sb" : "http://b") + ".scorecardresearch.com/beacon.js";
+        el.parentNode.insertBefore(s, el);
+        })();`,
+        }}
+      />
+      <noscript
+        data-hid="comScoreNoScript"
+        dangerouslySetInnerHTML={{
+          __html: `<img src="https://sb.scorecardresearch.com/p?c1=2&amp;c2=24318560&amp;cv=3.6.0&amp;cj=1" />`,
+        }}
+      ></noscript>
+    </>
+  )
+}

--- a/packages/mirror-media-next/components/whole-site-script.js
+++ b/packages/mirror-media-next/components/whole-site-script.js
@@ -1,7 +1,12 @@
 import AvividScript from './ads/avivid/avivid-script'
 import { useDisplayAd } from '../hooks/useDisplayAd'
-
+import ComScoreScript from './comscore-script'
 export default function WholeSiteScript() {
   const shouldShowAd = useDisplayAd()
-  return <>{shouldShowAd && <AvividScript />}</>
+  return (
+    <>
+      {shouldShowAd && <AvividScript />}
+      <ComScoreScript />
+    </>
+  )
 }

--- a/packages/mirror-media-next/pages/_app.js
+++ b/packages/mirror-media-next/pages/_app.js
@@ -8,7 +8,6 @@ import TagManager from 'react-gtm-module'
 import { GTM_ID } from '../config/index.mjs'
 import WholeSiteScript from '../components/whole-site-script'
 import UserBehaviorLogger from '../components/shared/user-behavior-logger'
-import Script from 'next/script'
 import { useRouter } from 'next/router'
 
 import { MembershipProvider } from '../context/membership'
@@ -50,24 +49,6 @@ function MyApp({ Component, pageProps }) {
           </ThemeProvider>
         </ApolloProvider>
       </MembershipProvider>
-      <Script
-        id="comScore"
-        dangerouslySetInnerHTML={{
-          __html: `var _comscore = _comscore || [];
-        _comscore.push({ c1: "2", c2: "24318560" });
-        (function() {
-        var s = document.createElement("script"), el = document.getElementsByTagName("script")[0]; s.async = true;
-        s.src = (document.location.protocol == "https:" ? "https://sb" : "http://b") + ".scorecardresearch.com/beacon.js";
-        el.parentNode.insertBefore(s, el);
-        })();`,
-        }}
-      />
-      <noscript
-        data-hid="comScoreNoScript"
-        dangerouslySetInnerHTML={{
-          __html: `<img src="https://sb.scorecardresearch.com/p?c1=2&amp;c2=24318560&amp;cv=3.6.0&amp;cj=1" />`,
-        }}
-      ></noscript>
     </>
   )
 }


### PR DESCRIPTION
## Notable Change
1. 新增元件 `comscore-script` ,用於載入comscore相關的script。
2. 該script共有兩種版本，一種是amp專用，一種是一般頁面使用。使用了nextjs `useRouter`去判斷是否為amp頁面，並依此新增不同類型的script。
3. 重構`_app.js`，將原本的comscore 相關程式碼移至元件`comscore-script`