### PR TITLE
fix(mm-next): unable pass amp vaildator when adding comscore cript

### DIFF
--- a/packages/mirror-media-next/components/comscore-script.js
+++ b/packages/mirror-media-next/components/comscore-script.js
@@ -1,6 +1,6 @@
 import Script from 'next/script'
 import { useRouter } from 'next/router'
-// import Head from 'next/head'
+import Head from 'next/head'
 
 /**
  * Component for implement comScore script.
@@ -13,7 +13,36 @@ export default function ComScoreScript() {
   const { pathname } = router
   const isAmpStoryPage = pathname.startsWith('/story/amp/')
   if (isAmpStoryPage) {
-    return null
+    return (
+      <>
+        <Head>
+          <script
+            async
+            // eslint-disable-next-line react/no-unknown-property
+            custom-element="amp-analytics"
+            src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"
+          ></script>
+        </Head>
+
+        {/* @ts-ignore */}
+        <amp-analytics type="comscore">
+          <script
+            type="application/json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify({
+                vars: {
+                  c2: '24318560',
+                },
+                extraUrlParams: {
+                  comscorekw: 'amp',
+                },
+              }),
+            }}
+          ></script>
+          {/* @ts-ignore */}
+        </amp-analytics>
+      </>
+    )
   }
 
   return (


### PR DESCRIPTION
## Problem Description
加入comscore的script時，會使得amp頁面無法通過amp validator，導致網址無法被google search console收錄。
經過排查後，發現是當初的寫法出了問題：
依據comscore的文件，會需要寫入兩個html tag：
1. `<script>`，並載入 `https://cdn.ampproject.org/v0/amp-analytics-0.1.js`
2. `<amp-analytics>`，並載入另一個inline script，inline script是comscore的相關設定。

我使用了[google chrome extension](https://chromewebstore.google.com/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc) 檢查後，發現1.需要設置於`<head>`中，而2需要設置於`<body>`。
因此調整寫法，將1.外層加上父元件 `<Head>`