### PR TITLE
refactor(mm): refine external amp support elements

### DIFF
--- a/packages/mirror-media-next/components/external/external-article-content.js
+++ b/packages/mirror-media-next/components/external/external-article-content.js
@@ -13,6 +13,25 @@ const Wrapper = styled.section`
   iframe {
     max-width: 100%;
   }
+
+  .amp-img-wrapper {
+    margin-top: 20px;
+    width: 100%;
+    height: 50vw;
+    position: relative;
+    display: flex;
+    justify-content: center;
+    img {
+      object-fit: contain;
+    }
+  }
+  .amp-iframe-wrapper {
+    display: block;
+    position: relative;
+    width: 100%;
+    padding-top: 56.25%;
+    overflow: hidden;
+  }
 `
 
 /**


### PR DESCRIPTION
# Support elements

- youtube iframe (the only iframe type not being removed): add amp-youtube and required attributes
- amp-image: add required attributes
- amp-video: add required attributes
- amp-audio: add required attributes