### PR TITLE
fix(papermag): send papermag-order data into Israfel

### DIFF
--- a/packages/mirror-media-next/components/papermag/form-detail/apply-discount.js
+++ b/packages/mirror-media-next/components/papermag/form-detail/apply-discount.js
@@ -153,17 +153,17 @@ const RemoveButton = styled.button`
 export default function ApplyDiscount({
   renewCouponApplied,
   setRenewCouponApplied,
-  loveCode,
-  setLoveCode,
+  promoteCode,
+  setPromoteCode,
 }) {
   const handleInputChange = (event) => {
     const value = event.target.value
     if (/^[0-9]*$/.test(value) && value.length <= 8) {
-      setLoveCode(value)
+      setPromoteCode(value)
     }
   }
 
-  const isInputValid = loveCode?.length === 8
+  const isInputValid = promoteCode?.length === 8
 
   const handleConfirmClick = (e) => {
     e.preventDefault()
@@ -174,7 +174,7 @@ export default function ApplyDiscount({
 
   const handleRemoveClick = () => {
     setRenewCouponApplied(false)
-    setLoveCode('')
+    setPromoteCode('')
   }
 
   return (
@@ -189,7 +189,7 @@ export default function ApplyDiscount({
           <label>MR</label>
           <input
             placeholder="12345678"
-            value={loveCode}
+            value={promoteCode}
             onChange={handleInputChange}
             disabled={renewCouponApplied}
           />

--- a/packages/mirror-media-next/components/papermag/form-detail/custom-dropdown.js
+++ b/packages/mirror-media-next/components/papermag/form-detail/custom-dropdown.js
@@ -121,13 +121,13 @@ export default function CustomDropdown({
   return (
     <CustomDropdownContainer ref={containerRef}>
       <DropdownButton isOpen={isOpen} onClick={toggleDropdown}>
-        {selectedOption ? selectedOption : defaultText}
+        {selectedOption ? selectedOption.name : defaultText}
       </DropdownButton>
       {isOpen && (
         <OptionsList>
           {options.map((option, index) => (
             <Option key={index} onClick={() => selectOption(option)}>
-              {option}
+              {option.name}
             </Option>
           ))}
         </OptionsList>

--- a/packages/mirror-media-next/components/papermag/form-detail/receipt.js
+++ b/packages/mirror-media-next/components/papermag/form-detail/receipt.js
@@ -60,14 +60,33 @@ export default function Receipt({
   }
 
   const donateOptions = [
-    '財團法人台灣兒童暨家庭扶助基金會',
-    '財團法人創世社會福利基金會',
-    '財團法人台灣癌症基金會',
-    '財團法人伊甸社會福利基金會',
-    '財團法人門諾社會福利慈善事業基金會',
+    {
+      name: '財團法人台灣兒童暨家庭扶助基金會',
+      code: 8585,
+    },
+    {
+      name: '財團法人創世社會福利基金會',
+      code: 919,
+    },
+    {
+      name: '財團法人台灣癌症基金會',
+      code: 1799,
+    },
+    {
+      name: '財團法人伊甸社會福利基金會',
+      code: 25585,
+    },
+    {
+      name: '財團法人門諾社會福利慈善事業基金會',
+      code: 5260,
+    },
   ]
 
-  const invoiceWithCarrierOptions = ['電子發票載具', '手機條碼', '自然人憑證']
+  const invoiceWithCarrierOptions = [
+    { id: 0, name: '手機條碼' },
+    { id: 1, name: '自然人憑證' },
+    { id: 2, name: '電子發票載具' },
+  ]
 
   const [showDetails, setShowDetails] = useState(false)
 
@@ -108,23 +127,24 @@ export default function Receipt({
   // Initialize the receipt data object using useMemo
   const receiptData = useMemo(() => {
     let data = {}
+
     if (receiptOption === 'donate') {
       data = {
         name: '捐贈發票',
         value: selectedDonateOption,
       }
     } else if (receiptOption === 'invoiceWithCarrier') {
-      if (selectedInvoiceCarrierOption === '電子發票載具') {
+      if (selectedInvoiceCarrierOption?.name === '電子發票載具') {
         data = {
           name: '二聯式發票（含載具）- 電子發票載具',
           value: selectedInvoiceCarrierOption,
         }
-      } else if (selectedInvoiceCarrierOption === '手機條碼') {
+      } else if (selectedInvoiceCarrierOption?.name === '手機條碼') {
         data = {
           name: '二聯式發票（含載具）- 手機條碼',
           value: barcodeValue,
         }
-      } else if (selectedInvoiceCarrierOption === '自然人憑證') {
+      } else if (selectedInvoiceCarrierOption?.name === '自然人憑證') {
         data = {
           name: '二聯式發票（含載具）- 自然人憑證',
           value: certificateValue,
@@ -192,7 +212,7 @@ export default function Receipt({
                 options={invoiceWithCarrierOptions}
                 onSelect={handleInvoiceCarrierOptionSelect}
               />
-              {selectedInvoiceCarrierOption === '手機條碼' && (
+              {selectedInvoiceCarrierOption?.name === '手機條碼' && (
                 <FormInput
                   name="barcode"
                   type="text"
@@ -205,7 +225,7 @@ export default function Receipt({
                   style={{ marginTop: '-16px' }}
                 />
               )}
-              {selectedInvoiceCarrierOption === '自然人憑證' && (
+              {selectedInvoiceCarrierOption?.name === '自然人憑證' && (
                 <FormInput
                   name="certificate"
                   type="text"

--- a/packages/mirror-media-next/components/papermag/subscribe-papermag-form.js
+++ b/packages/mirror-media-next/components/papermag/subscribe-papermag-form.js
@@ -49,11 +49,12 @@ const RightWrapper = styled.div`
 `
 
 export default function SubscribePaperMagForm({ plan }) {
+  const router = useRouter()
+
   const [count, setCount] = useState(1)
   const [renewCouponApplied, setRenewCouponApplied] = useState(false)
   const [shouldCountFreight, setShouldCountFreight] = useState(false)
   const [loveCode, setLoveCode] = useState(null)
-  const router = useRouter()
 
   const [ordererValues, setOrdererValues] = useState({
     username: '',
@@ -85,6 +86,7 @@ export default function SubscribePaperMagForm({ plan }) {
 
   //show a warning message if the isAcceptedConditions is true but the receiptOption is null
   const [showWarning, setShowWarning] = useState(false)
+
   useEffect(() => {
     if (isAcceptedConditions && receiptOption === null) {
       setShowWarning(true)
@@ -97,7 +99,8 @@ export default function SubscribePaperMagForm({ plan }) {
   const [receiptData, setReceiptData] = useState({})
   const handleSubmit = async (event) => {
     event.preventDefault()
-    // Check for form validity
+
+    // TODO: Check form validity again
 
     // If everything is valid, proceed with submitting the form data
     // Make an API request or update the state here
@@ -109,25 +112,42 @@ export default function SubscribePaperMagForm({ plan }) {
 
     const requestBody = {
       data: {
-        desc: 'mock_desc',
-        comment: 'mock_comment',
+        desc: 'desc', //訂單描述 //name || itemDest
+        comment: '', //約定事項
+
+        //商品名稱
         merchandise: {
           connect: {
             code,
           },
         },
-        itemCount: count,
-        purchaseDatetime: new Date(),
-        purchaseName: ordererValues.username,
-        purchaseAddress: ordererValues.address,
-        purchaseEmail: ordererValues.email,
-        receiveName: recipientValues.username,
-        receiveAddress: recipientValues.address,
-        category: 'B2C',
-        purchaseMobile: ordererValues.cellphone,
-        receiveMobile: recipientValues.cellphone,
-        loveCode,
-        carrierType: receiptData,
+
+        itemCount: count, //商品數量
+        purchaseDatetime: new Date(), // 訂購時間
+
+        // 訂購者資訊
+        purchaseName: ordererValues.username, //購買者姓名
+        purchaseAddress: ordererValues.address, //購買者地址
+        purchaseEmail: ordererValues.email, //購買者信箱
+        purchaseMobile: ordererValues.cellphone, //購買者手機
+        purchasePhone: `${ordererValues.phone} ${ordererValues.phoneExt}`, //購買者電話
+
+        // 收件者資訊
+        receiveName: recipientValues.username, //收件者姓名
+        receiveAddress: recipientValues.address, //收件者地址
+        receiveMobile: recipientValues.cellphone, //收件者手機
+        receivePhone: `${recipientValues.phone} ${recipientValues.phoneExt}`, //收件者電話
+
+        //發票種類
+        category: receiptData.name === '三聯式發票' ? 'B2B' : 'B2C',
+
+        // 捐贈碼
+        loveCode: 2222, //parseInt(this.receiptData.donateOrganization),
+
+        //載具類別
+        carrierType: receiptData, // 2
+        carrierNum, //載具編號
+        promoteCode: loveCode, //使用優惠碼
         returnUrl: `${window.location.origin}/papermag/return`,
       },
     }
@@ -199,6 +219,7 @@ export default function SubscribePaperMagForm({ plan }) {
           />
         </RightWrapper>
       </Form>
+
       <NewebpayForm
         merchantId={paymentPayload.MerchantID}
         tradeInfo={paymentPayload.TradeInfo}

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -71,9 +71,7 @@ switch (ENV) {
     URL_STATIC_LATEST_NEWS_IN_CERTAIN_SECTION = `https://${STATIC_FILE_DOMAIN}/files/json/sections`
     URL_STATIC_PODCAST_LIST = `https://${STATIC_FILE_DOMAIN}/json/podcast_list.json`
 
-    NEWEBPAY_PAPERMAG_API_URL =
-      process.env.NEWEBPAY_PAPERMAG_API_URL ||
-      'https://core.newebpay.com/MPG/mpg_gateway'
+    NEWEBPAY_PAPERMAG_API_URL = 'https://core.newebpay.com/MPG/mpg_gateway'
     ACCESS_SUBSCRIBE_FEATURE_TOGGLE = 'off'
     ACCESS_PAPERMAG_FEATURE_TOGGLE = 'off'
     GCP_LOGGING_FEATURE_TOGGLE = 'on'
@@ -122,9 +120,7 @@ switch (ENV) {
     URL_STATIC_LATEST_NEWS_IN_CERTAIN_SECTION = `https://${STATIC_FILE_DOMAIN}/files/json/sections`
     URL_STATIC_PODCAST_LIST = `https://v3-statics.mirrormedia.mg/json/podcast_list.json`
 
-    NEWEBPAY_PAPERMAG_API_URL =
-      process.env.NEWEBPAY_PAPERMAG_API_URL ||
-      'https://ccore.newebpay.com/MPG/mpg_gateway'
+    NEWEBPAY_PAPERMAG_API_URL = 'https://ccore.newebpay.com/MPG/mpg_gateway'
 
     ACCESS_SUBSCRIBE_FEATURE_TOGGLE = 'off'
     ACCESS_PAPERMAG_FEATURE_TOGGLE = 'off'
@@ -170,9 +166,7 @@ switch (ENV) {
     URL_STATIC_LATEST_NEWS_IN_CERTAIN_SECTION = `https://${STATIC_FILE_DOMAIN}/files/json/sections`
     URL_STATIC_PODCAST_LIST = `https://${STATIC_FILE_DOMAIN}/json/podcast_list.json`
 
-    NEWEBPAY_PAPERMAG_API_URL =
-      process.env.NEWEBPAY_PAPERMAG_API_URL ||
-      'https://ccore.newebpay.com/MPG/mpg_gateway'
+    NEWEBPAY_PAPERMAG_API_URL = 'https://ccore.newebpay.com/MPG/mpg_gateway'
 
     DONATION_PAGE_URL = 'https://mirrormedia.testing.oen.tw/'
     GA_MEASUREMENT_ID = 'G-36HYH6NF6P'
@@ -209,9 +203,7 @@ switch (ENV) {
     WEEKLY_API_SERVER_YOUTUBE_ENDPOINT = `http://api-dev.mirrormedia.mg:8080/youtube`
     STATIC_FILE_DOMAIN = 'v3-statics-dev.mirrormedia.mg'
 
-    NEWEBPAY_PAPERMAG_API_URL =
-      process.env.NEWEBPAY_PAPERMAG_API_URL ||
-      'https://ccore.newebpay.com/MPG/mpg_gateway'
+    NEWEBPAY_PAPERMAG_API_URL = 'https://ccore.newebpay.com/MPG/mpg_gateway'
     ACCESS_SUBSCRIBE_FEATURE_TOGGLE = 'on'
     ACCESS_PAPERMAG_FEATURE_TOGGLE = 'on'
     GCP_LOGGING_FEATURE_TOGGLE = 'on'

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -8,6 +8,7 @@ const NEWEBPAY_PAPERMAG_KEY =
   process.env.NEWEBPAY_PAPERMAG_KEY || 'newebpay-papermag-key'
 const NEWEBPAY_PAPERMAG_IV =
   process.env.NEWEBPAY_PAPERMAG_IV || 'newebpay-papermag-iv'
+const ISRAFEL_ORIGIN = process.env.ISRAFEL_ORIGIN || 'israfel-origin'
 
 // should be applied in preview mode
 const SITE_BASE_PATH = IS_PREVIEW_MODE ? '/preview-server' : ''
@@ -263,6 +264,7 @@ export {
   NEWEBPAY_PAPERMAG_API_URL,
   NEWEBPAY_PAPERMAG_IV,
   NEWEBPAY_PAPERMAG_KEY,
+  ISRAFEL_ORIGIN,
   PREVIEW_SERVER_ORIGIN,
   SEARCH_URL,
   SITE_BASE_PATH,

--- a/packages/mirror-media-next/pages/api/papermag.js
+++ b/packages/mirror-media-next/pages/api/papermag.js
@@ -1,41 +1,71 @@
+import axios from 'axios'
 import NewebPay from '@mirrormedia/newebpay-node'
 import {
   NEWEBPAY_PAPERMAG_KEY,
   NEWEBPAY_PAPERMAG_IV,
+  ISRAFEL_ORIGIN,
+  SITE_URL,
+  ENV,
 } from '../../config/index.mjs'
 
-function getRandomMerchantOrderNo() {
-  const min = 1000000000
-  const max = 9999999999
-  const randomTenDigitNumber = Math.floor(Math.random() * (max - min + 1)) + min
-  return 'P' + randomTenDigitNumber
+const apiUrl = `${ISRAFEL_ORIGIN}/api/graphql`
+
+// TODO: Add JSDocs
+async function fireGqlRequest(query, variables, apiUrl) {
+  const { data: result } = await axios({
+    url: apiUrl,
+    method: 'post',
+    data: {
+      query,
+      variables,
+    },
+    headers: {
+      'content-type': 'application/json',
+      'Cache-Control': 'no-cache',
+    },
+  })
+  if (result.errors) {
+    throw new Error(result.errors)
+  }
+  return result
 }
 
-async function getPaymentDataOfPapermagSubscription(gateWayPayload) {
-  const data = {
-    MerchantID: 'MS323443601',
-    RespondType: 'JSON',
-    TimeStamp: '1694018103',
-    Version: '1.6',
-    MerchantOrderNo: getRandomMerchantOrderNo(),
-    Amt: 7280,
-    ItemDesc: '一年鏡週刊 52 期加掛號運費',
-    LoginType: 0,
-    Email: 'test@ww.ww',
-    TradeLimit: 900,
-    NotifyURL:
-      'https://mm-subscription-webhooks-publishers-dev-ufaummkd5q-de.a.run.app/newebpay/magazine',
-    ReturnURL: gateWayPayload.returnUrl,
+async function getPaymentDataOfMagazineOrders(gateWayPayload) {
+  const fetchPaymentDataOfPapermag = `mutation fetchPaymentDataOfPapermag(
+    $data: createNewebpayTradeInfoForMagazineOrderInput!
+  ) {
+    createNewebpayTradeInfoForMagazineOrder(data: $data) {
+      MerchantID
+      RespondType
+      TimeStamp
+      Version
+      MerchantOrderNo
+      Amt
+      ItemDesc
+      LoginType
+      Email
+      TradeLimit
+      NotifyURL
+    }
   }
+  `
+  const { data } = await fireGqlRequest(
+    fetchPaymentDataOfPapermag,
+    gateWayPayload,
+    apiUrl
+  )
+  data.createNewebpayTradeInfoForMagazineOrder.ReturnURL =
+    ENV === 'local'
+      ? `http://localhost:3000/papermag/return`
+      : `https://${SITE_URL}/papermag/return`
+
   return data
 }
 
 export default async function EncryptInfo(req, res) {
   const tradeInfo = req.body
   try {
-    const infoForNewebpay = await getPaymentDataOfPapermagSubscription(
-      tradeInfo.data
-    )
+    const infoForNewebpay = await getPaymentDataOfMagazineOrders(tradeInfo.data)
 
     const newebpay = new NewebPay(NEWEBPAY_PAPERMAG_KEY, NEWEBPAY_PAPERMAG_IV)
     const encryptPostData = await newebpay.getEncryptedFormPostData(

--- a/packages/mirror-media-next/pages/api/papermag.js
+++ b/packages/mirror-media-next/pages/api/papermag.js
@@ -3,12 +3,12 @@ import NewebPay from '@mirrormedia/newebpay-node'
 import {
   NEWEBPAY_PAPERMAG_KEY,
   NEWEBPAY_PAPERMAG_IV,
-  ISRAFEL_ORIGIN,
+  // ISRAFEL_ORIGIN,
   SITE_URL,
   ENV,
 } from '../../config/index.mjs'
 
-const apiUrl = `${ISRAFEL_ORIGIN}/api/graphql`
+const apiUrl = `https://dev-israfel-gql.mirrormedia.mg/api/graphql`
 
 // TODO: Add JSDocs
 async function fireGqlRequest(query, variables, apiUrl) {


### PR DESCRIPTION
## Notable Changes 

### ENV 調整
- 新增 `ENV`：`ISRAFEL_ORIGIN`，提供紙本雜誌訂閱資料寫入 Israfel 使用。
- 移除 `ENV`：`NEWEBPAY_PAPERMAG_API_URL`。原因：非機敏資料、GCS 環境變數也未設定該資料。

### API 調整
- 新增 gql：`fetchPaymentDataOfPapermag`，用來將使用者填寫的資訊，寫入 Israfel - Magazine Orders 表中 。
- 其他：移除 mock data、調整 function name。

### PaperMag 確認訂購調整
- 調整 `handleSubmit()`，移除 mock data 並針對送入藍新金流的 data 作商業邏輯上的資料處理。 

### 其他
- 調整 `donateOptions` 資料，新增各組織對應的代碼（code）。