### PR TITLE
refactor(mm): skip canonical link in layout custom head

### DIFF
--- a/packages/mirror-media-next/components/shared/custom-head.js
+++ b/packages/mirror-media-next/components/shared/custom-head.js
@@ -30,12 +30,6 @@ import { useRouter } from 'next/router'
  * @return {null | JSX.Element}
  */
 const createCanonicalLink = (routerAsPath) => {
-  const isStoryPage = routerAsPath.startsWith('/story/')
-
-  if (isStoryPage) {
-    return null
-  }
-
   const url = new URL(routerAsPath, 'https://' + SITE_URL)
   url.search = '' //remove query params in url
 
@@ -47,20 +41,30 @@ const createCanonicalLink = (routerAsPath) => {
  * @property {string} [title] - head title used to setup title other title related meta
  * @property {string} [description] - head description used to setup description related meta
  * @property {string} [imageUrl] - image url used to setup image related meta
+ * @property {boolean} [skipCanonical] - flag to indicates whether the canonical should be added here
  */
 
 /**
  * @param {HeadProps} props
  * @returns
  */
-export default function CustomHead(props) {
+export default function CustomHead({
+  skipCanonical = false,
+  title,
+  description,
+  imageUrl,
+}) {
   const router = useRouter()
-  const canonicalLink = createCanonicalLink(router.asPath)
+  const canonicalLink = skipCanonical ? (
+    <></>
+  ) : (
+    createCanonicalLink(router.asPath)
+  )
   /** @type {OGProperties} */
   const siteInformation = {
-    title: props.title ? `${props.title} - ${SITE_TITLE}` : SITE_TITLE,
+    title: title ? `${title} - ${SITE_TITLE}` : SITE_TITLE,
     description:
-      props.description ??
+      description ??
       '鏡傳媒以台灣為基地，是一跨平台綜合媒體，包含《鏡週刊》以及下設五大分眾內容的《鏡傳媒》網站，刊載時事、財經、人物、國際、文化、娛樂、美食旅遊、精品鐘錶等深入報導及影音內容。我們以「鏡」為名，務求反映事實、時代與人性。',
     site_name: SITE_TITLE,
     url: SITE_URL + router.asPath,
@@ -69,8 +73,7 @@ export default function CustomHead(props) {
       width: '1200',
       height: '630',
       type: 'image/png',
-      url:
-        props.imageUrl ?? `https://${SITE_URL}/images-next/default-og-img.png`,
+      url: imageUrl ?? `https://${SITE_URL}/images-next/default-og-img.png`,
     },
     card: 'summary_large_image',
     fbAppId: FB_APP_ID,

--- a/packages/mirror-media-next/components/shared/layout.js
+++ b/packages/mirror-media-next/components/shared/layout.js
@@ -29,6 +29,7 @@ export default function Layout({ head, header, footer, children }) {
         title={head?.title}
         description={head?.description}
         imageUrl={head?.imageUrl}
+        skipCanonical={head?.skipCanonical}
       />
       <ShareHeader pageLayoutType={header.type} headerData={header.data} />
       {children}

--- a/packages/mirror-media-next/pages/external/amp/[slug].js
+++ b/packages/mirror-media-next/pages/external/amp/[slug].js
@@ -66,6 +66,7 @@ export default function External({ external }) {
           title,
           description: brief,
           imageUrl: thumb,
+          skipCanonical: true,
         }}
         header={{ type: 'empty' }}
         footer={{ type: 'empty' }}

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -252,6 +252,7 @@ export default function Story({ postData, headerData, storyLayoutType }) {
           imageUrl:
             getResizedUrl(postData.og_image?.resized) ||
             getResizedUrl(postData.heroImage?.resized),
+          skipCanonical: true,
         }}
         header={{ type: 'empty' }}
         footer={{ type: 'empty' }}

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -119,6 +119,7 @@ function StoryAmpPage({ postData }) {
           imageUrl:
             getResizedUrl(postData.og_image?.resized) ||
             getResizedUrl(postData.heroImage?.resized),
+          skipCanonical: true,
         }}
         header={{ type: 'empty' }}
         footer={{ type: 'empty' }}


### PR DESCRIPTION
# Notable Change

修改 shared Layout CustomHead 中的 canonical 排除 /story 相關頁面的邏輯，改由從 layout 傳入 skipCanonical 的方式由外部來決定是否不需要 CustomHead 來添加 canonical，同時把以下頁面的 Layout 修改為 skipCanonical

- /story/
- /story/amp/
- /external/amp/