### PR TITLE
feat(papermag): add second verification before Newebpay

### DIFF
--- a/packages/mirror-media-next/components/papermag/subscribe-papermag-form.js
+++ b/packages/mirror-media-next/components/papermag/subscribe-papermag-form.js
@@ -101,7 +101,7 @@ export default function SubscribePaperMagForm({ plan }) {
   const checkValidation = () => {
     let recipient = recipientValues //收件者資料
     if (sameAsOrderer) {
-      recipient = { ...ordererValues }
+      recipient = { ...ordererValues } //收件者同訂購人資訊
     }
 
     if (
@@ -178,7 +178,7 @@ export default function SubscribePaperMagForm({ plan }) {
   const handleSubmit = async (event) => {
     event.preventDefault()
 
-    // Check form validity again, if invalid redirect to return page
+    // Check form validity again: if invalid, redirect to return fail page
     if (!checkValidation()) {
       router.push(`/papermag/return?order-fail=true`)
     }

--- a/packages/mirror-media-next/components/papermag/subscribe-papermag-form.js
+++ b/packages/mirror-media-next/components/papermag/subscribe-papermag-form.js
@@ -11,6 +11,7 @@ import CheckoutBtn from './form-detail/checkout-btn'
 import Orderer from './form-detail/orderer'
 import Recipient from './form-detail/recipient'
 import NewebpayForm from './form-detail/newebpay-form'
+import { checkOrdererValues, checkRecipientValues } from '../../utils/papermag'
 
 import { NEWEBPAY_PAPERMAG_API_URL } from '../../config/index.mjs'
 import { useRouter } from 'next/router'
@@ -97,11 +98,25 @@ export default function SubscribePaperMagForm({ plan }) {
 
   const [receiptData, setReceiptData] = useState(null) // update the receiptData state
 
-  const handleSubmit = async (event) => {
-    event.preventDefault()
+  const checkValidation = () => {
+    let recipient = recipientValues //收件者資料
+    if (sameAsOrderer) {
+      recipient = { ...ordererValues }
+    }
 
-    // TODO: Check form validity again
+    if (
+      checkOrdererValues(ordererValues) &&
+      checkRecipientValues(recipient) &&
+      isAcceptedConditions &&
+      receiptOption !== null
+    ) {
+      return true
+    } else {
+      return false
+    }
+  }
 
+  const formateOrderPayload = () => {
     const merchandiseName = `magazine_${plan === 2 ? 'two' : 'one'}_year${
       shouldCountFreight ? '_with_shipping_fee' : ''
     }`
@@ -146,10 +161,43 @@ export default function SubscribePaperMagForm({ plan }) {
       }
     }
 
-    // If everything is valid, proceed with submitting the form data
-    // Make an API request or update the state here
-    // carry encrypted paymentPayload and submit to newebpay
+    return {
+      merchandiseName,
+      orderDesc,
+      promoteCodeStr,
+      loveCode,
+      receiptType,
+      buyerName,
+      buyerUBN,
+      carrierNum,
+      carrierType,
+      recipient,
+    }
+  }
 
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+
+    // Check form validity again, if invalid redirect to return page
+    if (!checkValidation()) {
+      router.push(`/papermag/return?order-fail=true`)
+    }
+
+    const {
+      merchandiseName,
+      orderDesc,
+      promoteCodeStr,
+      loveCode,
+      receiptType,
+      buyerName,
+      buyerUBN,
+      carrierNum,
+      carrierType,
+      recipient,
+    } = formateOrderPayload()
+
+    // If everything is valid, proceed with submitting the form data
+    // carry encrypted paymentPayload and submit to newebpay
     const requestBody = {
       data: {
         desc: orderDesc, //訂單描述

--- a/packages/mirror-media-next/utils/papermag.js
+++ b/packages/mirror-media-next/utils/papermag.js
@@ -35,4 +35,25 @@ function getMerchandiseAndShippingFeeInfo(merchandiseCode) {
   return plan
 }
 
-export { getMerchandiseAndShippingFeeInfo }
+function checkOrdererValues(orderItem) {
+  return !(
+    orderItem.username === '' ||
+    orderItem.cellphone === '' ||
+    orderItem.address === '' ||
+    orderItem.email === ''
+  )
+}
+
+function checkRecipientValues(recipientItem) {
+  return !(
+    recipientItem.username === '' ||
+    recipientItem.cellphone === '' ||
+    recipientItem.address === ''
+  )
+}
+
+export {
+  getMerchandiseAndShippingFeeInfo,
+  checkOrdererValues,
+  checkRecipientValues,
+}


### PR DESCRIPTION
### Notable Changes
- 實作：「確認訂購」點擊後至藍新金流前的表格內容二次驗證
   - 訂購人資訊：檢查 `username`、`cellphone`、`address`、`email` 是否有資料。
   - 收件人資訊：檢查 `username`、`cellphone`、`address` 是否有資料。
   - 電子發票：檢查是否有選擇發票類型。
   - 已閱讀並同意：檢查是否有勾選。
- 上述條件只要一項條件不符合，即不送資料進藍新，直接 redirect 到 `/papermag/return?order-fail=true` 頁面。