### PR TITLE
feat(mm-next): add google sheet api 

### DIFF
--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -33,6 +33,7 @@
     "dom-serializer": "^2.0.0",
     "express": "^4.18.2",
     "firebase": "^9.22.0",
+    "google-spreadsheet": "^4.1.1",
     "googleapis": "^126.0.1",
     "graphql": "^16.6.0",
     "htmlparser2": "^9.1.0",

--- a/packages/mirror-media-next/pages/api/googlesheet.js
+++ b/packages/mirror-media-next/pages/api/googlesheet.js
@@ -1,0 +1,160 @@
+import { GoogleSpreadsheet } from 'google-spreadsheet'
+import { JWT } from 'google-auth-library'
+import Cors from 'cors'
+
+/**
+ * @typedef {import("next").NextApiRequest} NextApiRequest
+ * @typedef {import("next").NextApiResponse} NextApiResponse
+ *
+ * @typedef {Object} ErrorWithStatus
+ * @property {string} message - error message
+ * @property {number} status - http status
+ *
+ * @typedef {Object} GooglSheetParam
+ * @property {string} id - google sheet id
+ * @property {string} title - google sheet title
+ * @property {object} row - google sheet row, different structure on different sheet
+ */
+
+/**
+ *
+ * @param {string} message - error message
+ * @param {number} status - http status
+ * @returns {ErrorWithStatus}
+ */
+function errorWithStatus(message, status) {
+  const error = new Error(message)
+  /** @type {ErrorWithStatus} */
+  const customError = {
+    message: error.message,
+    status,
+  }
+  return customError
+}
+
+// Initializing the cors middleware
+// You can read more about the available options here: https://github.com/expressjs/cors#configuration-options
+const cors = Cors({
+  methods: ['POST'],
+})
+
+/**
+ * @param {GooglSheetParam} googleSheet
+ * @throws {ErrorWithStatus}
+ */
+async function addRowToGoogleSheet(googleSheet) {
+  try {
+    if (!googleSheet) {
+      throw new Error('without google sheet param')
+    }
+    const { id, title, row } = googleSheet
+    if (!id) {
+      throw new Error('without google sheet id')
+    }
+    if (!title) {
+      throw new Error('without google sheet title')
+    }
+    if (!row) {
+      throw new Error('without new row data')
+    }
+
+    const GOOGLE_SHEETS_PRIVATE_KEY = process.env.GOOGLE_SHEETS_PRIVATE_KEY
+    const GOOGLE_SHEETS_CLIENT_EMAIL = process.env.GOOGLE_SHEETS_CLIENT_EMAIL
+
+    const serviceAccountAuth = new JWT({
+      email: GOOGLE_SHEETS_CLIENT_EMAIL,
+      key: GOOGLE_SHEETS_PRIVATE_KEY,
+      scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+    })
+
+    const doc = new GoogleSpreadsheet(id, serviceAccountAuth)
+
+    await doc.loadInfo()
+
+    const sheet = doc.sheetsByTitle[title]
+
+    await sheet.addRow(row)
+  } catch (e) {
+    if (e.message.startsWith('without')) {
+      throw errorWithStatus(e.message, 400)
+    }
+    throw errorWithStatus(e.message, 500)
+  }
+}
+
+/**
+ *
+ * @param {NextApiRequest} req
+ * @param {NextApiResponse} res
+ * @param {Function} fn
+ */
+function runMiddleware(req, res, fn) {
+  return new Promise((resolve, reject) => {
+    fn(req, res, async (result) => {
+      if (result instanceof Error) {
+        return reject(result)
+      }
+
+      try {
+        const { googleSheet } = req.body
+        await addRowToGoogleSheet(googleSheet)
+      } catch (e) {
+        reject(e)
+      }
+
+      return resolve(result)
+    })
+  })
+}
+
+/**
+ * google sheet api to add row to specific google spreadsheet
+ * To balance security and experience of development, allow cors in dev and local environment.
+ * @param {NextApiRequest} req
+ * @param {NextApiResponse} res
+ */
+export default async function handler(req, res) {
+  try {
+    const { googleSheet } = req.body
+
+    if (
+      process.env.NEXT_PUBLIC_ENV === 'dev' ||
+      process.env.NEXT_PUBLIC_ENV === 'local'
+    ) {
+      // only dev and local env support CORS
+      await runMiddleware(req, res, cors)
+    } else {
+      await addRowToGoogleSheet(googleSheet)
+    }
+
+    console.log(
+      JSON.stringify({
+        severity: 'INFO',
+        message:
+          '[INFO] Adding row to google sheet successed: ' +
+          JSON.stringify(googleSheet),
+      })
+    )
+    res.send({
+      status: 'success',
+    })
+  } catch (e) {
+    const wrappedMessage =
+      '[ERROR] Adding row to google sheet failed: ' + e.message
+    console.log(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: wrappedMessage,
+      })
+    )
+    if (e.status) {
+      res.status(e.status).send({
+        error: wrappedMessage,
+      })
+    } else {
+      res.status(500).send({
+        error: wrappedMessage,
+      })
+    }
+  }
+}

--- a/packages/mirror-media-next/pages/api/googlesheet.js
+++ b/packages/mirror-media-next/pages/api/googlesheet.js
@@ -13,7 +13,7 @@ import Cors from 'cors'
  * @typedef {Object} GooglSheetParam
  * @property {string} id - google sheet id
  * @property {string} title - google sheet title
- * @property {object} row - google sheet row, different structure on different sheet
+ * @property {Object} row - google sheet row, different structure on different sheet
  */
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2266,6 +2266,15 @@ axios@^1.2.1:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
+axios@^1.4.0:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
+  integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==
+  dependencies:
+    follow-redirects "^1.15.4"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -3490,6 +3499,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.9, follow-redirects@^1.15.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+follow-redirects@^1.15.4:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
+  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -3703,6 +3717,14 @@ google-gax@^4.0.3:
     proto3-json-serializer "^2.0.0"
     protobufjs "7.2.5"
     retry-request "^7.0.0"
+
+google-spreadsheet@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/google-spreadsheet/-/google-spreadsheet-4.1.1.tgz#56c422c86b51a2ea9dad21c40cd69bccbd58591f"
+  integrity sha512-Npk/xAMTgxEt/m/X9EXIqdY6CEYGiqUHrSuiLnNSKli5H+wiOQLSLsnfMxcdNPH6aSh6GttZm6QJhrnsxjwpZQ==
+  dependencies:
+    axios "^1.4.0"
+    lodash "^4.17.21"
 
 googleapis-common@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
# Feature

新增 googlesheet 到 mm-next api route 中，支援針對 google sheet 新增 row。

## API doc
因開發時程較趕，先在此 PR 簡述 api 使用方法，後續會再補上正式文件到 README 中。

param
/*
 * @typedef {Object} GooglSheetParam
 * @property {string} id - google sheet id
 * @property {string} title - google sheet title
 * @property {object} row - google sheet row, different structure on different sheet
 */

output
200: 新增成功
400: 缺少必備資料
500: 操作新增 row 失敗

## google sheet api
這邊使用了 [google-spreadsheet](https://www.npmjs.com/package/google-spreadsheet) 這個套件並依照文件中的使用方式，搭配 google-auth-library 使用 service account 來驗證。

to-do: 因 mm-next 在 cloud run 中有設定對應到 mm-next 這個 service account，但目前尚未研究出如何取得 cloud run 中的 service account 的 json 檔 (目的是拿取 private key 和 email)，因此先採用環境變數的方式取得，之後有時間再改成直接拿取環境中的 json 檔內資訊。