### PR TITLE
refactor(mm-next): separate topic post gql schema

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -72,6 +72,45 @@ export const asideListingPost = gql`
 `
 
 /**
+ * @typedef {Object} TopicPost
+ * @property {string} id - unique id of post
+ * @property {string} slug - post slug
+ * @property {string} title - post title
+ * @property {string} publishedDate - post published date
+ * @property {Draft} brief - post brief
+ * @property {Pick<Category, 'id' | 'name' | 'slug' | 'state'>[]} categories - which categories does this post belong to
+ * @property {Pick<Section, 'id' | 'name' | 'slug' | 'state'>[]} sections - which sections does this post belong to
+ * @property {Pick<HeroImage, 'imageFile' | 'resized' | 'resizedWebp'> | null} heroImage
+ * @property {Tag[] } tags - tags of the post
+ */
+
+export const topicPost = gql`
+  ${section}
+  ${category}
+  ${heroImage}
+  ${tag}
+  fragment topicPost on Post {
+    id
+    slug
+    title
+    publishedDate
+    brief
+    categories(where: { state: { equals: "active" } }) {
+      ...category
+    }
+    sections(where: { state: { equals: "active" } }) {
+      ...section
+    }
+    heroImage {
+      ...heroImage
+    }
+    tags {
+      ...tag
+    }
+  }
+`
+
+/**
  * @typedef {'published' | 'draft' | 'scheduled' | 'archived' | 'invisible'} PostState
  */
 

--- a/packages/mirror-media-next/apollo/fragments/topic.js
+++ b/packages/mirror-media-next/apollo/fragments/topic.js
@@ -1,6 +1,6 @@
 import { gql } from '@apollo/client'
 import { heroImage, slideshowImage } from './photo'
-import { post } from './post'
+import { topicPost } from './post'
 import { tag } from './tag'
 
 /**
@@ -22,7 +22,7 @@ import { tag } from './tag'
  * @property {string} style
  * @property {number} postsCount
  * @property {number} featuredPostsCount
- * @property {import('./post').Post[]} posts
+ * @property {import('./post').TopicPost[]} posts
  * @property {import('./tag').Tag[]} tags
  * @property {string} og_description
  * @property {import('./photo').Photo} og_image
@@ -51,7 +51,7 @@ export const simpleTopic = gql`
 export const topic = gql`
   ${slideshowImage}
   ${heroImage}
-  ${post}
+  ${topicPost}
   ${tag}
   fragment topic on Topic {
     id
@@ -73,7 +73,7 @@ export const topic = gql`
       take: $postsTake
       skip: $postsSkip
     ) {
-      ...post
+      ...topicPost
       isFeatured
     }
     tags {


### PR DESCRIPTION
# Notable Change

topic 頁需要拿取的 post 資料因為和文章頁公用 post 的 gql fragment，導致多拿了許多 topic 頁不需要的資料，這個 PR 將 topic 中的 post fragment 獨立出來，只拿取頁面必要的資料。

getServerSideProps props 大小
1.1 MB -> 270 kB