### PR TITLE
fix(mm-next): disable next button while handling 3rd party login result

### DIFF
--- a/packages/mirror-media-next/components/login/main-form-login-with-password.js
+++ b/packages/mirror-media-next/components/login/main-form-login-with-password.js
@@ -115,7 +115,16 @@ export default function MainFormLoginWithPassword() {
         </PrimaryButton>
         <DefaultButton onClick={handleBack}>回上一步</DefaultButton>
       </ControlGroup>
-      <TextButton href="/recover-password">忘記密碼？</TextButton>
+      <TextButton
+        href={{
+          pathname: 'recoverPassword',
+          query: {
+            email,
+          },
+        }}
+      >
+        忘記密碼？
+      </TextButton>
     </>
   )
 }

--- a/packages/mirror-media-next/components/login/main-form-start.js
+++ b/packages/mirror-media-next/components/login/main-form-start.js
@@ -8,6 +8,7 @@ import {
   loginPrevAuthMethod,
   loginShouldShowHintOfExitenceOfDifferentAuthMethod,
   loginActions,
+  loginIsFederatedRedirectResultLoading,
   AuthMethod,
 } from '../../slice/login-slice'
 import { isValidEmail } from '../../utils'
@@ -73,11 +74,15 @@ export default function MainFormStart() {
   const dispatch = useAppDispatch()
   const email = useAppSelector(loginEmail)
   const prevAuthMethod = useAppSelector(loginPrevAuthMethod)
+  const isFederatedRedirectResultLoading = useAppSelector(
+    loginIsFederatedRedirectResultLoading
+  )
   const shouldShowHintOfExitenceOfDifferentAuthMethod = useAppSelector(
     loginShouldShowHintOfExitenceOfDifferentAuthMethod
   )
   const hint = `由於您曾以 ${prevAuthMethod} 帳號登入，請點擊上方「使用 ${prevAuthMethod} 帳號繼續」重試。`
-  const allowToContinue = isValidEmail(email)
+  const allowToContinue =
+    isValidEmail(email) && isFederatedRedirectResultLoading === false
 
   const handleOnClick = async () => {
     if (!allowToContinue || isLoading) return


### PR DESCRIPTION
## Notable Change
* 修正「第三方登入返回登入頁，進行結果的處理過程中，使用者能夠操作下一頁按鈕」的問題
* 修正忘記密碼連結資訊，使其能夠先導向至 2.0 的網址