### PR TITLE
refactor(mm-next): update server-side data fetching

### DIFF
--- a/packages/mirror-media-next/components/ads/gpt/gpt-ad.js
+++ b/packages/mirror-media-next/components/ads/gpt/gpt-ad.js
@@ -145,15 +145,19 @@ const GPTAdRoot = ({
       })
 
       return () => {
-        const pubads = window.googletag.pubads()
+        const pubads =
+          'pubads' in window.googletag &&
+          typeof window.googletag.pubads === 'function'
+            ? window.googletag?.pubads()
+            : undefined
 
-        window.googletag.cmd.push(() => {
-          window.googletag.destroySlots([adSlot])
+        window.googletag?.cmd.push(() => {
+          window.googletag?.destroySlots([adSlot])
           if (onSlotRenderEnded) {
-            pubads.removeEventListener('slotRequested', handleOnSlotRequested)
+            pubads?.removeEventListener('slotRequested', handleOnSlotRequested)
           }
           if (onSlotRenderEnded) {
-            pubads.removeEventListener(
+            pubads?.removeEventListener(
               'slotRenderEnded',
               handleOnSlotRenderEnded
             )

--- a/packages/mirror-media-next/components/externals/partner-articles.js
+++ b/packages/mirror-media-next/components/externals/partner-articles.js
@@ -57,7 +57,11 @@ export default function ExternalArticles({
       renderAmount={renderPageSize}
       fetchCount={Math.ceil(externalsCount / renderPageSize)}
       fetchListInPage={(page) =>
-        fetchExternalsFunction(page, renderPageSize, partnerSlug)
+        fetchExternalsFunction(page, renderPageSize, partnerSlug).then(
+          (gqlData) => {
+            return gqlData?.data?.externals
+          }
+        )
       }
       loader={loader}
     >

--- a/packages/mirror-media-next/hooks/use-membership-required.js
+++ b/packages/mirror-media-next/hooks/use-membership-required.js
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import { useMembership } from '../context/membership'
 import { useRouter } from 'next/router'
+import { getLoginHref } from '../utils'
 
 /**
  * @callback MembershipValidator
@@ -25,12 +26,8 @@ export default function useMembershipRequired(validator) {
 
   useEffect(() => {
     if (isLogInProcessFinished && (!isLoggedIn || !isValidMember)) {
-      router.push({
-        pathname: '/login',
-        query: {
-          destination: '/magazine',
-        },
-      })
+      const redirectionTarget = getLoginHref(router)
+      router.push(redirectionTarget)
     }
   }, [router, isLogInProcessFinished, isLoggedIn, isValidMember])
 }

--- a/packages/mirror-media-next/hooks/use-membership-required.js
+++ b/packages/mirror-media-next/hooks/use-membership-required.js
@@ -1,0 +1,36 @@
+import { useEffect, useMemo } from 'react'
+import { useMembership } from '../context/membership'
+import { useRouter } from 'next/router'
+
+/**
+ * @callback MembershipValidator
+ * @param {import('../context/membership').MemberInfo | undefined} memberInfo
+ * @returns {boolean}
+ */
+
+/**
+ * Client-side authenication handle.
+ * It is useful when membership state changed but page didn't reloaded.
+ *
+ * @param {MembershipValidator} [validator]
+ */
+export default function useMembershipRequired(validator) {
+  const router = useRouter()
+  const { isLoggedIn, memberInfo, isLogInProcessFinished } = useMembership()
+
+  const isValidMember = useMemo(
+    () => (typeof validator === 'function' ? validator(memberInfo) : true),
+    [memberInfo, validator]
+  )
+
+  useEffect(() => {
+    if (isLogInProcessFinished && (!isLoggedIn || !isValidMember)) {
+      router.push({
+        pathname: '/login',
+        query: {
+          destination: '/magazine',
+        },
+      })
+    }
+  }, [router, isLogInProcessFinished, isLoggedIn, isValidMember])
+}

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -6,8 +6,8 @@ import { ENV } from '../../config/index.mjs'
 import {
   fetchHeaderDataInDefaultPageLayout,
   getPostsAndPostscountFromGqlData,
-  getSectionAndTopicFromDefaultHeaderData,
 } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { setPageCache } from '../../utils/cache-setting'
 
 import Layout from '../../components/shared/layout'

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -175,7 +175,7 @@ export async function getServerSideProps({ query, req, res }) {
   const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
-    'Error occurs while getting header data in author page',
+    `Error occurs while getting header data in author page (authorId: ${authorId})`,
     globalLogFields
   )
 
@@ -185,7 +185,7 @@ export async function getServerSideProps({ query, req, res }) {
     (gqlData) => {
       return gqlData?.data
     },
-    'Error occurs while getting author data in author page',
+    `Error occurs while getting author data in author page (authorId: ${authorId})`,
     globalLogFields
   )
 
@@ -217,7 +217,7 @@ export async function getServerSideProps({ query, req, res }) {
   const [postsCount, posts] = handleGqlResponse(
     responses[2],
     dataHandler,
-    'Error occurs while getting post data in author page',
+    `Error occurs while getting post data in author page (authorId: ${authorId})`,
     globalLogFields
   )
 

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -24,11 +24,8 @@ import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 import { useCallback, useState } from 'react'
-import {
-  getLogTraceObject,
-  handelAxiosResponse,
-  handleGqlResponse,
-} from '../../utils'
+import { getLogTraceObject, handleGqlResponse } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 
 const AuthorContainer = styled.main`
   width: 320px;
@@ -172,7 +169,7 @@ export async function getServerSideProps({ query, req, res }) {
   ])
 
   //handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in author page',

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -24,8 +24,11 @@ import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 import { useCallback, useState } from 'react'
-import { getLogTraceObject, handleGqlResponse } from '../../utils'
-import { handleAxiosResponse } from '../../utils/response-handle'
+import { getLogTraceObject } from '../../utils'
+import {
+  handleAxiosResponse,
+  handleGqlResponse,
+} from '../../utils/response-handle'
 
 const AuthorContainer = styled.main`
   width: 320px;

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -3,11 +3,11 @@ import dynamic from 'next/dynamic'
 
 import AuthorArticles from '../../components/author/author-articles'
 import { ENV } from '../../config/index.mjs'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import {
-  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
   getPostsAndPostscountFromGqlData,
-} from '../../utils/api'
-import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
+} from '../../utils/data-process'
 import { setPageCache } from '../../utils/cache-setting'
 
 import Layout from '../../components/shared/layout'

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -182,7 +182,7 @@ export async function getServerSideProps({ query, req, res }) {
       return gqlData?.data
     },
     'Error occurs while getting author data in author page',
-    req
+    globalLogFields
   )
 
   if (!authorData) {
@@ -214,7 +214,7 @@ export async function getServerSideProps({ query, req, res }) {
     responses[2],
     dataHandler,
     'Error occurs while getting post data in author page',
-    req
+    globalLogFields
   )
 
   const props = {

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -7,9 +7,9 @@ import {
   fetchHeaderDataInDefaultPageLayout,
   fetchHeaderDataInPremiumPageLayout,
   getPostsAndPostscountFromGqlData,
-  getSectionAndTopicFromDefaultHeaderData,
   getSectionFromPremiumHeaderData,
 } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { Z_INDEX } from '../../constants/index'

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -22,9 +22,9 @@ import { useDisplayAd } from '../../hooks/useDisplayAd'
 import {
   getCategoryOfWineSlug,
   getLogTraceObject,
-  handelAxiosResponse,
   handleGqlResponse,
 } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import { getSectionGPTPageKey } from '../../utils/ad'
 import WineWarning from '../../components/shared/wine-warning'
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
@@ -331,7 +331,7 @@ export async function getServerSideProps({ query, req, res }) {
     ])
 
     // handle header data
-    sectionsData = handelAxiosResponse(
+    sectionsData = handleAxiosResponse(
       responses[0],
       getSectionFromPremiumHeaderData,
       'Error occurs while getting premium header data in category page',
@@ -358,7 +358,7 @@ export async function getServerSideProps({ query, req, res }) {
     ])
 
     // handle header data
-    ;[sectionsData, topicsData] = handelAxiosResponse(
+    ;[sectionsData, topicsData] = handleAxiosResponse(
       responses[0],
       getSectionAndTopicFromDefaultHeaderData,
       'Error occurs while getting header data in category page',

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -7,9 +7,11 @@ import {
   fetchHeaderDataInDefaultPageLayout,
   fetchHeaderDataInPremiumPageLayout,
   getPostsAndPostscountFromGqlData,
-  getSectionFromPremiumHeaderData,
 } from '../../utils/api'
-import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
+import {
+  getSectionAndTopicFromDefaultHeaderData,
+  getSectionFromPremiumHeaderData,
+} from '../../utils/data-process'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { Z_INDEX } from '../../constants/index'

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -6,11 +6,11 @@ import { ENV } from '../../config/index.mjs'
 import {
   fetchHeaderDataInDefaultPageLayout,
   fetchHeaderDataInPremiumPageLayout,
-  getPostsAndPostscountFromGqlData,
 } from '../../utils/api'
 import {
   getSectionAndTopicFromDefaultHeaderData,
   getSectionFromPremiumHeaderData,
+  getPostsAndPostscountFromGqlData,
 } from '../../utils/data-process'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -19,12 +19,11 @@ import {
   fetchPremiumPostsByCategorySlug,
 } from '../../utils/api/category'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
+import { getCategoryOfWineSlug, getLogTraceObject } from '../../utils'
 import {
-  getCategoryOfWineSlug,
-  getLogTraceObject,
+  handleAxiosResponse,
   handleGqlResponse,
-} from '../../utils'
-import { handleAxiosResponse } from '../../utils/response-handle'
+} from '../../utils/response-handle'
 import { getSectionGPTPageKey } from '../../utils/ad'
 import WineWarning from '../../components/shared/wine-warning'
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -296,7 +296,7 @@ export async function getServerSideProps({ query, req, res }) {
   } catch (error) {
     logGqlError(
       error,
-      'Error occurs while getting category data in category page',
+      `Error occurs while getting category data in category page (${categorySlug})`,
       globalLogFields
     )
   }
@@ -335,7 +335,7 @@ export async function getServerSideProps({ query, req, res }) {
     sectionsData = handleAxiosResponse(
       responses[0],
       getSectionFromPremiumHeaderData,
-      'Error occurs while getting premium header data in category page',
+      `Error occurs while getting premium header data in category page (categorySlug: ${categorySlug})`,
       globalLogFields
     )
 
@@ -349,7 +349,7 @@ export async function getServerSideProps({ query, req, res }) {
     ;[postsCount, posts] = handleGqlResponse(
       responses[1],
       dataHandler,
-      'Error occurs while getting premium post data in category page',
+      `Error occurs while getting premium post data in category page (categorySlug: ${categorySlug})`,
       globalLogFields
     )
   } else {
@@ -362,7 +362,7 @@ export async function getServerSideProps({ query, req, res }) {
     ;[sectionsData, topicsData] = handleAxiosResponse(
       responses[0],
       getSectionAndTopicFromDefaultHeaderData,
-      'Error occurs while getting header data in category page',
+      `Error occurs while getting header data in category page (categorySlug: ${categorySlug})`,
       globalLogFields
     )
 
@@ -376,7 +376,7 @@ export async function getServerSideProps({ query, req, res }) {
     ;[postsCount, posts] = handleGqlResponse(
       responses[1],
       dataHandler,
-      'Error occurs while getting post data in category page',
+      `Error occurs while getting post data in category page (categorySlug: ${categorySlug})`,
       globalLogFields
     )
   }

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -24,7 +24,6 @@ import {
   getLogTraceObject,
   handelAxiosResponse,
   handleGqlResponse,
-  logGqlError,
 } from '../../utils'
 import { getSectionGPTPageKey } from '../../utils/ad'
 import WineWarning from '../../components/shared/wine-warning'
@@ -35,6 +34,7 @@ import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 import { useCallback, useState } from 'react'
+import { logGqlError } from '../../utils/log/shared'
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme

--- a/packages/mirror-media-next/pages/email-handler.js
+++ b/packages/mirror-media-next/pages/email-handler.js
@@ -8,10 +8,8 @@ import { setPageCache } from '../utils/cache-setting'
 import LayoutFull from '../components/shared/layout-full'
 import BodyPasswordReset from '../components/email-handler/body-password-reset'
 import BodyEmailVerification from '../components/email-handler/body-email-verification'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../utils/data-process'
 import { getLogTraceObject, getSearchParamFromApiKeyUrl } from '../utils'
 import { handleAxiosResponse } from '../utils/response-handle'
 

--- a/packages/mirror-media-next/pages/email-handler.js
+++ b/packages/mirror-media-next/pages/email-handler.js
@@ -12,11 +12,8 @@ import {
   fetchHeaderDataInDefaultPageLayout,
   getSectionAndTopicFromDefaultHeaderData,
 } from '../utils/api'
-import {
-  getLogTraceObject,
-  getSearchParamFromApiKeyUrl,
-  handelAxiosResponse,
-} from '../utils'
+import { getLogTraceObject, getSearchParamFromApiKeyUrl } from '../utils'
+import { handleAxiosResponse } from '../utils/response-handle'
 
 const RESET_PASSWORD = 'resetPassword'
 const RECOVER_EMAIL = 'recoverEmail'
@@ -96,7 +93,7 @@ export const getServerSideProps = async ({ req, res, query }) => {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in email-handler',

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -10,8 +10,11 @@ import FullScreenAds from '../../components/ads/full-screen-ads'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
 import JsonLdsScripts from '../../components/externals/shared/json-lds-scripts'
-import { getLogTraceObject, handleGqlResponse } from '../../utils'
-import { handleAxiosResponse } from '../../utils/response-handle'
+import { getLogTraceObject } from '../../utils'
+import {
+  handleAxiosResponse,
+  handleGqlResponse,
+} from '../../utils/response-handle'
 import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api'
 
 /**

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -10,11 +10,8 @@ import FullScreenAds from '../../components/ads/full-screen-ads'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
 import JsonLdsScripts from '../../components/externals/shared/json-lds-scripts'
-import {
-  getLogTraceObject,
-  handelAxiosResponse,
-  handleGqlResponse,
-} from '../../utils'
+import { getLogTraceObject, handleGqlResponse } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api'
 
 /**
@@ -86,7 +83,7 @@ export async function getServerSideProps({ params, req, res }) {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in external post page',

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -15,7 +15,7 @@ import {
   handleAxiosResponse,
   handleGqlResponse,
 } from '../../utils/response-handle'
-import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 
 /**
  * @typedef {import('../../apollo/fragments/external').External} External

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -89,7 +89,7 @@ export async function getServerSideProps({ params, req, res }) {
   const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
-    'Error occurs while getting header data in external post page',
+    `Error occurs while getting header data in external post page (slug: ${slug})`,
     globalLogFields
   )
 
@@ -103,7 +103,7 @@ export async function getServerSideProps({ params, req, res }) {
         return gqlData.data?.externals[0] || {}
       }
     },
-    'Error occurs while getting data in external post page',
+    `Error occurs while getting data in external post page (slug: ${slug})`,
     globalLogFields
   )
 

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -1,7 +1,6 @@
 //TODO: add component to add html head dynamically, not jus write head in every pag
 import client from '../../apollo/apollo-client'
-import errors from '@twreporter/errors'
-import { GCP_PROJECT_ID, ENV, SITE_URL } from '../../config/index.mjs'
+import { ENV, SITE_URL } from '../../config/index.mjs'
 import { setPageCache } from '../../utils/cache-setting'
 import { fetchExternalBySlug } from '../../apollo/query/externals'
 import ExternalNormalStyle from '../../components/external/external-normal-style'
@@ -11,6 +10,12 @@ import FullScreenAds from '../../components/ads/full-screen-ads'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
 import JsonLdsScripts from '../../components/externals/shared/json-lds-scripts'
+import {
+  getLogTraceObject,
+  handelAxiosResponse,
+  handleGqlResponse,
+} from '../../utils'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api'
 
 /**
  * @typedef {import('../../apollo/fragments/external').External} External
@@ -69,14 +74,8 @@ export async function getServerSideProps({ params, req, res }) {
   }
 
   const { slug } = params
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+
+  const globalLogFields = getLogTraceObject(req)
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(), //fetch header data
@@ -86,60 +85,27 @@ export async function getServerSideProps({ params, req, res }) {
     }),
   ])
 
-  const handledResponses = responses.map((response) => {
-    if (response.status === 'fulfilled') {
-      return response.value
-    } else if (response.status === 'rejected') {
-      const { graphQLErrors, clientErrors, networkError } = response.reason
-      const annotatingError = errors.helpers.wrap(
-        response.reason,
-        'UnhandledError',
-        'Error occurs while getting section page data'
-      )
-
-      console.log(
-        JSON.stringify({
-          severity: 'ERROR',
-          message: errors.helpers.printAll(
-            annotatingError,
-            {
-              withStack: true,
-              withPayload: true,
-            },
-            0,
-            0
-          ),
-          debugPayload: {
-            graphQLErrors,
-            clientErrors,
-            networkError,
-          },
-          ...globalLogFields,
-        })
-      )
-      return
-    }
-  })
-
-  const headerData =
-    'sectionsData' in handledResponses[0]
-      ? handledResponses[0]
-      : {
-          sectionsData: [],
-          topicsData: [],
-        }
-  const sectionsData = Array.isArray(headerData.sectionsData)
-    ? headerData.sectionsData
-    : []
-  const topicsData = Array.isArray(headerData.topicsData)
-    ? headerData.topicsData
-    : []
+  // handle header data
+  const [sectionsData, topicsData] = handelAxiosResponse(
+    responses[0],
+    getSectionAndTopicFromDefaultHeaderData,
+    'Error occurs while getting header data in external post page',
+    globalLogFields
+  )
 
   /** @type {External} */
-  const external =
-    'data' in handledResponses[1]
-      ? handledResponses[1]?.data?.externals[0] || {}
-      : {}
+  const external = handleGqlResponse(
+    responses[1],
+    (gqlData) => {
+      if (!gqlData) {
+        return {}
+      } else {
+        return gqlData.data?.externals[0] || {}
+      }
+    },
+    'Error occurs while getting data in external post page',
+    globalLogFields
+  )
 
   if (!Object.keys(external).length) {
     return { notFound: true }

--- a/packages/mirror-media-next/pages/external/amp/[slug].js
+++ b/packages/mirror-media-next/pages/external/amp/[slug].js
@@ -151,7 +151,7 @@ export async function getServerSideProps({ params, req, res, resolvedUrl }) {
         return gqlData.data?.externals[0] || {}
       }
     },
-    'Error occurs while getting data in external post amp page',
+    `Error occurs while getting data in external post amp page (slug: ${slug})`,
     globalLogFields
   )
 

--- a/packages/mirror-media-next/pages/external/amp/[slug].js
+++ b/packages/mirror-media-next/pages/external/amp/[slug].js
@@ -15,7 +15,8 @@ import AmpMain from '../../../components/amp/external/amp-main'
 import { transformHtmlIntoAmpHtml } from '../../../utils/amp-html'
 import Script from 'next/script'
 import JsonLdsScripts from '../../../components/externals/shared/json-lds-scripts'
-import { getLogTraceObject, handleGqlResponse } from '../../../utils'
+import { getLogTraceObject } from '../../../utils'
+import { handleGqlResponse } from '../../../utils/response-handle'
 
 export const config = { amp: true }
 

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -21,11 +21,8 @@ import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 import { useCallback, useState } from 'react'
-import {
-  getLogTraceObject,
-  handelAxiosResponse,
-  handleGqlResponse,
-} from '../../utils'
+import { getLogTraceObject, handleGqlResponse } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
@@ -195,7 +192,7 @@ export async function getServerSideProps({ params, req, res }) {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in externals partner page',

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -26,7 +26,7 @@ import {
   handleAxiosResponse,
   handleGqlResponse,
 } from '../../utils/response-handle'
-import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -198,7 +198,7 @@ export async function getServerSideProps({ params, req, res }) {
   const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
-    'Error occurs while getting header data in externals partner page',
+    `Error occurs while getting header data in externals partner page (partnerSlug: ${partnerSlug})`,
     globalLogFields
   )
 
@@ -210,7 +210,7 @@ export async function getServerSideProps({ params, req, res }) {
     ) => {
       return gqlData?.data?.externals || []
     },
-    'Error occurs while getting external posts in externals partner page',
+    `Error occurs while getting external posts in externals partner page (partnerSlug: ${partnerSlug})`,
     globalLogFields
   )
 
@@ -222,7 +222,7 @@ export async function getServerSideProps({ params, req, res }) {
     ) => {
       return gqlData?.data?.externalsCount || 0
     },
-    'Error occurs while getting externalsCount in externals partner page',
+    `Error occurs while getting externalsCount in externals partner page (partnerSlug: ${partnerSlug})`,
     globalLogFields
   )
 
@@ -232,7 +232,7 @@ export async function getServerSideProps({ params, req, res }) {
     (gqlData) => {
       return gqlData?.data?.partners?.[0] ?? {}
     },
-    'Error occurs while getting partners data in externals partner page',
+    `Error occurs while getting partners data in externals partner page (partnerSlug: ${partnerSlug})`,
     globalLogFields
   )
 

--- a/packages/mirror-media-next/pages/externals/[partnerSlug].js
+++ b/packages/mirror-media-next/pages/externals/[partnerSlug].js
@@ -21,8 +21,11 @@ import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 import { useCallback, useState } from 'react'
-import { getLogTraceObject, handleGqlResponse } from '../../utils'
-import { handleAxiosResponse } from '../../utils/response-handle'
+import { getLogTraceObject } from '../../utils'
+import {
+  handleAxiosResponse,
+  handleGqlResponse,
+} from '../../utils/response-handle'
 import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -18,11 +18,8 @@ import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 import { useCallback, useState } from 'react'
-import {
-  getLogTraceObject,
-  handelAxiosResponse,
-  handleGqlResponse,
-} from '../../utils'
+import { getLogTraceObject, handleGqlResponse } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
@@ -178,7 +175,7 @@ export async function getServerSideProps({ req, res }) {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in externals warmlife page',

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -23,7 +23,7 @@ import {
   handleAxiosResponse,
   handleGqlResponse,
 } from '../../utils/response-handle'
-import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,

--- a/packages/mirror-media-next/pages/externals/warmlife.js
+++ b/packages/mirror-media-next/pages/externals/warmlife.js
@@ -18,8 +18,11 @@ import FullScreenAds from '../../components/ads/full-screen-ads'
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 import { useCallback, useState } from 'react'
-import { getLogTraceObject, handleGqlResponse } from '../../utils'
-import { handleAxiosResponse } from '../../utils/response-handle'
+import { getLogTraceObject } from '../../utils'
+import {
+  handleAxiosResponse,
+  handleGqlResponse,
+} from '../../utils/response-handle'
 import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import styled from 'styled-components'
 import axios from 'axios'
 import errors from '@twreporter/errors'
@@ -20,9 +20,9 @@ import {
   getSectionSlugGql,
   getArticleHref,
   getLogTraceObject,
-  handelAxiosResponse,
   handleGqlResponse,
 } from '../utils'
+import { handleAxiosResponse } from '../utils/response-handle'
 import { setPageCache } from '../utils/cache-setting'
 import EditorChoice from '../components/index/editor-choice'
 import LatestNews from '../components/index/latest-news'
@@ -245,7 +245,7 @@ export async function getServerSideProps({ res, req }) {
       fetchModEventsInDesc(),
     ])
 
-    flashNewsData = handelAxiosResponse(
+    flashNewsData = handleAxiosResponse(
       responses[0],
       (/** @type {AxiosResponse} */ axiosData) => {
         return axiosData?.data?.posts ?? []
@@ -255,7 +255,7 @@ export async function getServerSideProps({ res, req }) {
     )
 
     // handle header data
-    ;[sectionsData, topicsData] = handelAxiosResponse(
+    ;[sectionsData, topicsData] = handleAxiosResponse(
       responses[1],
       getSectionAndTopicFromDefaultHeaderData,
       'Error occurs while getting header data in index page',

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -11,10 +11,8 @@ import {
 } from '../config/index.mjs'
 
 import { fetchModEventsInDesc } from '../utils/api/event'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../utils/data-process'
 import {
   getSectionNameGql,
   getSectionSlugGql,

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -20,9 +20,11 @@ import {
   getSectionSlugGql,
   getArticleHref,
   getLogTraceObject,
-  handleGqlResponse,
 } from '../utils'
-import { handleAxiosResponse } from '../utils/response-handle'
+import {
+  handleAxiosResponse,
+  handleGqlResponse,
+} from '../utils/response-handle'
 import { setPageCache } from '../utils/cache-setting'
 import EditorChoice from '../components/index/editor-choice'
 import LatestNews from '../components/index/latest-news'

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -8,12 +8,21 @@ import {
   API_TIMEOUT,
   URL_STATIC_POST_FLASH_NEWS,
   URL_STATIC_POST_EXTERNAL,
-  GCP_PROJECT_ID,
 } from '../config/index.mjs'
 
 import { fetchModEventsInDesc } from '../utils/api/event'
-import { fetchHeaderDataInDefaultPageLayout } from '../utils/api'
-import { getSectionNameGql, getSectionSlugGql, getArticleHref } from '../utils'
+import {
+  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
+} from '../utils/api'
+import {
+  getSectionNameGql,
+  getSectionSlugGql,
+  getArticleHref,
+  getLogTraceObject,
+  handelAxiosResponse,
+  handleGqlResponse,
+} from '../utils'
 import { setPageCache } from '../utils/cache-setting'
 import EditorChoice from '../components/index/editor-choice'
 import LatestNews from '../components/index/latest-news'
@@ -196,23 +205,18 @@ export async function getServerSideProps({ res, req }) {
     setPageCache(res, { cachePolicy: 'no-store' }, req.url)
   }
 
-  const headers = req?.headers
-  const traceHeader = headers?.['x-cloud-trace-context']
+  const globalLogFields = getLogTraceObject(req)
 
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
-
+  /** @type {import('../utils/api').HeadersData} */
+  let sectionsData = []
+  /** @type {import('../utils/api').Topics} */
   let topicsData = []
+  /** @type {FlashNewsData} */
   let flashNewsData = []
   let editorChoicesData = []
   let latestNewsData = []
-  let sectionsData = []
   let eventsData = []
+
   try {
     const postResponse = await axios({
       method: 'get',
@@ -237,63 +241,31 @@ export async function getServerSideProps({ res, req }) {
       fetchModEventsInDesc(),
     ])
 
-    responses.forEach((response, index) => {
-      if (response.status === 'fulfilled') {
-        //TODO: because `fetchHeaderDataInDefaultPageLayout` will not return `value` which contain `request?.res?.responseUrl`,
-        //so we temporarily comment the console to prevent error.
-        // console.log(
-        //   JSON.stringify({
-        //     severity: 'INFO',
-        //     message: `Successfully fetch data on ${response.value?.request?.res?.responseUrl}`,
-        //   })
-        // )
-      } else {
-        const rejectedReason = response.reason
-        const annotatingAxiosError =
-          errors.helpers.annotateAxiosError(rejectedReason)
-        const errorMessage = errors.helpers.printAll(
-          annotatingAxiosError,
-          {
-            withStack: true,
-            withPayload: false,
-          },
-          0,
-          0
-        )
-        console.error(
-          index,
-          JSON.stringify({
-            severity: 'ERROR',
-            message: errorMessage,
-            ...globalLogFields,
-          })
-        )
-      }
-    })
+    flashNewsData = handelAxiosResponse(
+      responses[0],
+      (/** @type {AxiosResponse} */ axiosData) => {
+        return axiosData?.data?.posts ?? []
+      },
+      'Error occurs while getting flash news in index page',
+      globalLogFields
+    )
 
-    /** @type {PromiseFulfilledResult<AxiosResponse>} */
-    const flashNewsResponse =
-      responses[0].status === 'fulfilled' && responses[0]
+    // handle header data
+    ;[sectionsData, topicsData] = handelAxiosResponse(
+      responses[1],
+      getSectionAndTopicFromDefaultHeaderData,
+      'Error occurs while getting header data in index page',
+      globalLogFields
+    )
 
-    const headerDataResponse =
-      responses[1].status === 'fulfilled' && responses[1]
-
-    const eventsResponse = responses[2].status === 'fulfilled' && responses[2]
-
-    flashNewsData = Array.isArray(flashNewsResponse.value?.data?.posts)
-      ? flashNewsResponse.value?.data?.posts
-      : []
-
-    sectionsData = Array.isArray(headerDataResponse.value?.sectionsData)
-      ? headerDataResponse.value?.sectionsData
-      : []
-    topicsData = Array.isArray(headerDataResponse.value?.topicsData)
-      ? headerDataResponse.value?.topicsData
-      : []
-
-    eventsData = Array.isArray(eventsResponse.value?.data?.events)
-      ? eventsResponse.value?.data?.events
-      : []
+    eventsData = handleGqlResponse(
+      responses[2],
+      (gqlData) => {
+        return gqlData?.data?.events || []
+      },
+      'Error occurs while getting event data in index page',
+      globalLogFields
+    )
 
     const eventData =
       eventsData.find((event) =>
@@ -327,7 +299,7 @@ export async function getServerSideProps({ res, req }) {
     const annotatingError = errors.helpers.wrap(
       err,
       'UnhandledError',
-      'Error occurs while getting index page data'
+      'Error occurs while getting data in index page'
     )
     const errorMessage = errors.helpers.printAll(
       annotatingError,
@@ -338,7 +310,7 @@ export async function getServerSideProps({ res, req }) {
       0,
       0
     )
-    console.log(
+    console.error(
       JSON.stringify({
         severity: 'ERROR',
         message: errorMessage,

--- a/packages/mirror-media-next/pages/login/index.js
+++ b/packages/mirror-media-next/pages/login/index.js
@@ -27,10 +27,8 @@ import { FirebaseError } from 'firebase/app'
 import { setPageCache } from '../../utils/cache-setting'
 import LayoutFull from '../../components/shared/layout-full'
 import { FirebaseAuthError } from '../../constants/firebase'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { getLogTraceObject } from '../../utils'
 import { handleAxiosResponse } from '../../utils/response-handle'
 import redirectToDestinationWhileAuthed from '../../utils/redirect-to-destination-while-authed'

--- a/packages/mirror-media-next/pages/login/index.js
+++ b/packages/mirror-media-next/pages/login/index.js
@@ -25,9 +25,13 @@ import {
 import { auth } from '../../firebase'
 import { FirebaseError } from 'firebase/app'
 import { setPageCache } from '../../utils/cache-setting'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import LayoutFull from '../../components/shared/layout-full'
 import { FirebaseAuthError } from '../../constants/firebase'
+import {
+  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
+} from '../../utils/api'
+import { getLogTraceObject, handelAxiosResponse } from '../../utils'
 import redirectToDestinationWhileAuthed from '../../utils/redirect-to-destination-while-authed'
 
 const Container = styled.div`
@@ -39,7 +43,17 @@ const Container = styled.div`
   }
 `
 
-export default function Login() {
+/**
+ * @typedef {Object} PageProps
+ * @property {Object} headerData
+ * @property {import('../../utils/api').HeadersData} headerData.sectionsData
+ * @property {import('../../utils/api').Topics} headerData.topicsData
+ */
+
+/**
+ * @param {PageProps} props
+ */
+export default function Login({ headerData }) {
   const dispatch = useAppDispatch()
   const { accessToken, isLogInProcessFinished, userEmail } = useMembership()
   const loginFormState = useAppSelector(loginState)
@@ -128,29 +142,40 @@ export default function Login() {
   const jsx = getBodyByState()
 
   return (
-    <LayoutFull header={{ type: 'default' }} footer={{ type: 'default' }}>
+    <LayoutFull
+      header={{ type: 'default', data: headerData }}
+      footer={{ type: 'default' }}
+    >
       <Container>{jsx}</Container>
     </LayoutFull>
   )
 }
 
 /**
- * @type {import('next').GetServerSideProps}
+ * @type {import('next').GetServerSideProps<PageProps>}
  */
 export const getServerSideProps = redirectToDestinationWhileAuthed()(
   async ({ req, res }) => {
     setPageCache(res, { cachePolicy: 'no-store' }, req.url)
-    const traceHeader = req.headers?.['x-cloud-trace-context']
-    let globalLogFields = {}
-    if (traceHeader && !Array.isArray(traceHeader)) {
-      const [trace] = traceHeader.split('/')
-      globalLogFields[
-        'logging.googleapis.com/trace'
-      ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-    }
+
+    const globalLogFields = getLogTraceObject(req)
+
+    const responses = await Promise.allSettled([
+      fetchHeaderDataInDefaultPageLayout(),
+    ])
+
+    // handle header data
+    const [sectionsData, topicsData] = handelAxiosResponse(
+      responses[0],
+      getSectionAndTopicFromDefaultHeaderData,
+      'Error occurs while getting header data in login page',
+      globalLogFields
+    )
 
     return {
-      props: {},
+      props: {
+        headerData: { sectionsData, topicsData },
+      },
     }
   }
 )

--- a/packages/mirror-media-next/pages/login/index.js
+++ b/packages/mirror-media-next/pages/login/index.js
@@ -31,7 +31,8 @@ import {
   fetchHeaderDataInDefaultPageLayout,
   getSectionAndTopicFromDefaultHeaderData,
 } from '../../utils/api'
-import { getLogTraceObject, handelAxiosResponse } from '../../utils'
+import { getLogTraceObject } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import redirectToDestinationWhileAuthed from '../../utils/redirect-to-destination-while-authed'
 
 const Container = styled.div`
@@ -165,7 +166,7 @@ export const getServerSideProps = redirectToDestinationWhileAuthed()(
     ])
 
     // handle header data
-    const [sectionsData, topicsData] = handelAxiosResponse(
+    const [sectionsData, topicsData] = handleAxiosResponse(
       responses[0],
       getSectionAndTopicFromDefaultHeaderData,
       'Error occurs while getting header data in login page',

--- a/packages/mirror-media-next/pages/magazine/[book]/[issue].js
+++ b/packages/mirror-media-next/pages/magazine/[book]/[issue].js
@@ -60,10 +60,11 @@ export default function BookBIssuePublish({ weeklys }) {
  * @type {import('next').GetServerSideProps}
  */
 export const getServerSideProps = redirectToLoginWhileUnauthed()(
-  async ({ req, res }) => {
+  async ({ params, req, res }) => {
     setPageCache(res, { cachePolicy: 'no-store' }, req.url)
 
     const globalLogFields = getLogTraceObject(req)
+    const { issue } = params
 
     const responses = await Promise.allSettled([
       client.query({
@@ -78,7 +79,7 @@ export const getServerSideProps = redirectToLoginWhileUnauthed()(
       ) => {
         return gqlData?.data?.magazines || []
       },
-      'Error occurs while getting data in magazine page',
+      `Error occurs while getting data in magazine page (issue: ${issue})`,
       globalLogFields
     )
 

--- a/packages/mirror-media-next/pages/magazine/[book]/[issue].js
+++ b/packages/mirror-media-next/pages/magazine/[book]/[issue].js
@@ -1,13 +1,13 @@
-import errors from '@twreporter/errors'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import styled from 'styled-components'
 
 import client from '../../../apollo/apollo-client'
-import { GCP_PROJECT_ID } from '../../../config/index.mjs'
 import { setPageCache } from '../../../utils/cache-setting'
 import { fetchWeeklys } from '../../../apollo/query/magazines'
 import Layout from '../../../components/shared/layout'
+import { getLogTraceObject, handleGqlResponse } from '../../../utils'
+import redirectToLoginWhileUnauthed from '../../../utils/redirect-to-login-while-unauthed'
 
 const Page = styled.div`
   padding: 0;
@@ -58,64 +58,33 @@ export default function BookBIssuePublish({ weeklys }) {
 /**
  * @type {import('next').GetServerSideProps}
  */
-export async function getServerSideProps({ req, res }) {
-  setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+export const getServerSideProps = redirectToLoginWhileUnauthed()(
+  async ({ req, res }) => {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+    const globalLogFields = getLogTraceObject(req)
 
-  const responses = await Promise.allSettled([
-    client.query({
-      query: fetchWeeklys,
-    }),
-  ])
+    const responses = await Promise.allSettled([
+      client.query({
+        query: fetchWeeklys,
+      }),
+    ])
 
-  const handledResponses = responses.map((response) => {
-    if (response.status === 'fulfilled') {
-      return response.value.data
-    } else if (response.status === 'rejected') {
-      const { graphQLErrors, clientErrors, networkError } = response.reason
-      const annotatingError = errors.helpers.wrap(
-        response.reason,
-        'UnhandledError',
-        'Error occurs while getting magazine issue page data'
-      )
+    const weeklys = handleGqlResponse(
+      responses[0],
+      (
+        /** @type {import('@apollo/client').ApolloQueryResult<any> | undefined} */ gqlData
+      ) => {
+        return gqlData?.data?.magazines || []
+      },
+      'Error occurs while getting data in magazine page',
+      globalLogFields
+    )
 
-      console.log(
-        JSON.stringify({
-          severity: 'ERROR',
-          message: errors.helpers.printAll(
-            annotatingError,
-            {
-              withStack: true,
-              withPayload: true,
-            },
-            0,
-            0
-          ),
-          debugPayload: {
-            graphQLErrors,
-            clientErrors,
-            networkError,
-          },
-          ...globalLogFields,
-        })
-      )
-      return
+    return {
+      props: {
+        weeklys,
+      },
     }
-  })
-
-  const weeklys = handledResponses[0]?.magazines || []
-
-  return {
-    props: {
-      weeklys,
-    },
   }
-}
+)

--- a/packages/mirror-media-next/pages/magazine/[book]/[issue].js
+++ b/packages/mirror-media-next/pages/magazine/[book]/[issue].js
@@ -6,7 +6,8 @@ import client from '../../../apollo/apollo-client'
 import { setPageCache } from '../../../utils/cache-setting'
 import { fetchWeeklys } from '../../../apollo/query/magazines'
 import Layout from '../../../components/shared/layout'
-import { getLogTraceObject, handleGqlResponse } from '../../../utils'
+import { getLogTraceObject } from '../../../utils'
+import { handleGqlResponse } from '../../../utils/response-handle'
 import redirectToLoginWhileUnauthed from '../../../utils/redirect-to-login-while-unauthed'
 
 const Page = styled.div`

--- a/packages/mirror-media-next/pages/magazine/index.js
+++ b/packages/mirror-media-next/pages/magazine/index.js
@@ -16,8 +16,11 @@ import MagazineWeeklys from '../../components/magazine/magazine-weeklys'
 import MagazineFeatures from '../../components/magazine/magazine-featured-weeklys'
 import Layout from '../../components/shared/layout'
 import JoinPremiumMember from '../../components/magazine/ui-join-premium-member'
-import { getLogTraceObject, handleGqlResponse } from '../../utils'
-import { handleAxiosResponse } from '../../utils/response-handle'
+import { getLogTraceObject } from '../../utils'
+import {
+  handleAxiosResponse,
+  handleGqlResponse,
+} from '../../utils/response-handle'
 import redirectToLoginWhileUnauthed from '../../utils/redirect-to-login-while-unauthed'
 import useMembershipRequired from '../../hooks/use-membership-required'
 

--- a/packages/mirror-media-next/pages/magazine/index.js
+++ b/packages/mirror-media-next/pages/magazine/index.js
@@ -1,12 +1,12 @@
-import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
-import errors from '@twreporter/errors'
 import styled from 'styled-components'
 
 import client from '../../apollo/apollo-client'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { fetchSpecials, fetchWeeklys } from '../../apollo/query/magazines'
-import { fetchHeaderDataInPremiumPageLayout } from '../../utils/api'
+import {
+  fetchHeaderDataInPremiumPageLayout,
+  getSectionFromPremiumHeaderData,
+} from '../../utils/api'
 import { useMembership } from '../../context/membership'
 import { setPageCache } from '../../utils/cache-setting'
 
@@ -16,6 +16,12 @@ import MagazineWeeklys from '../../components/magazine/magazine-weeklys'
 import MagazineFeatures from '../../components/magazine/magazine-featured-weeklys'
 import Layout from '../../components/shared/layout'
 import JoinPremiumMember from '../../components/magazine/ui-join-premium-member'
+import {
+  getLogTraceObject,
+  handelAxiosResponse,
+  handleGqlResponse,
+} from '../../utils'
+import redirectToLoginWhileUnauthed from '../../utils/redirect-to-login-while-unauthed'
 
 const Section = styled.div`
   padding: 48px 0;
@@ -53,25 +59,23 @@ const Title = styled.h2`
   }
 `
 
-export default function Magazine({ sectionsData = [] }) {
-  const router = useRouter()
+/**
+ * @typedef {Object} PageProps
+ * @property {import('../../utils/api').HeadersData} sectionsData
+ */
 
+/**
+ * @param {PageProps} props
+ */
+export default function Magazine({ sectionsData = [] }) {
   const [specials, setSpecials] = useState([])
   const [weeklys, setWeeklys] = useState([])
 
-  const { isLoggedIn, memberInfo, isLogInProcessFinished } = useMembership()
+  const { memberInfo } = useMembership()
   const { memberType } = memberInfo
 
   const isPremiumMember =
     memberType.includes('premium') || memberType.includes('staff')
-
-  // Redirect to '/login' if the user is not logged in
-  useEffect(() => {
-    if (isLogInProcessFinished && !isLoggedIn) {
-      const destination = encodeURIComponent('/magazine')
-      router.push(`/login?destination=${destination}`)
-    }
-  }, [isLogInProcessFinished, isLoggedIn, router])
 
   // Fetch Magazines Data only for Premium Member
   useEffect(() => {
@@ -89,43 +93,21 @@ export default function Magazine({ sectionsData = [] }) {
             }),
           ])
 
-          const handledResponses = responses.map((response) => {
-            if (response.status === 'fulfilled') {
-              return response.value.data
-            } else if (response.status === 'rejected') {
-              const { graphQLErrors, clientErrors, networkError } =
-                response.reason
-              const annotatingError = errors.helpers.wrap(
-                response.reason,
-                'UnhandledError',
-                'Error occurs while getting magazine page data'
-              )
+          const fetchedSpecials = handleGqlResponse(
+            responses[0],
+            (gqlData) => {
+              return gqlData?.data?.magazines || []
+            },
+            'Error occurs while getting special magazine in magazine list page'
+          )
 
-              console.log(
-                JSON.stringify({
-                  severity: 'ERROR',
-                  message: errors.helpers.printAll(
-                    annotatingError,
-                    {
-                      withStack: true,
-                      withPayload: true,
-                    },
-                    0,
-                    0
-                  ),
-                  debugPayload: {
-                    graphQLErrors,
-                    clientErrors,
-                    networkError,
-                  },
-                })
-              )
-              return
-            }
-          })
-
-          const fetchedSpecials = handledResponses[0]?.magazines || []
-          const fetchedWeeklys = handledResponses[1]?.magazines || []
+          const fetchedWeeklys = handleGqlResponse(
+            responses[1],
+            (gqlData) => {
+              return gqlData?.data?.magazines || []
+            },
+            'Error occurs while getting weekly magazine in magazine list page'
+          )
 
           setSpecials(fetchedSpecials)
           setWeeklys(fetchedWeeklys)
@@ -157,11 +139,6 @@ export default function Magazine({ sectionsData = [] }) {
         return 0
       })
     : []
-
-  // Render different content based on the user's login status
-  if (!isLoggedIn) {
-    return null // Render nothing until the redirect happens
-  }
 
   return (
     <Layout
@@ -212,43 +189,30 @@ export default function Magazine({ sectionsData = [] }) {
 }
 
 /**
- * @type {import('next').GetServerSideProps}
+ * @type {import('next').GetServerSideProps<PageProps>}
  */
-export async function getServerSideProps({ req, res }) {
-  setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+export const getServerSideProps = redirectToLoginWhileUnauthed()(
+  async ({ req, res }) => {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+    const globalLogFields = getLogTraceObject(req)
 
-  // Fetch header data
-  let sectionsData = []
+    // Fetch header data
+    const responses = await Promise.allSettled([
+      fetchHeaderDataInPremiumPageLayout(),
+    ])
 
-  try {
-    const headerData = await fetchHeaderDataInPremiumPageLayout()
-    sectionsData = headerData.sectionsData
-  } catch (err) {
-    const annotatingAxiosError = errors.helpers.annotateAxiosError(err)
-    console.error(
-      JSON.stringify({
-        severity: 'ERROR',
-        message: errors.helpers.printAll(annotatingAxiosError, {
-          withStack: true,
-          withPayload: true,
-        }),
-        ...globalLogFields,
-      })
+    const sectionsData = handelAxiosResponse(
+      responses[0],
+      getSectionFromPremiumHeaderData,
+      'Error occurs while getting premium header data in magazine list page',
+      globalLogFields
     )
-  }
 
-  return {
-    props: {
-      sectionsData,
-    },
+    return {
+      props: {
+        sectionsData,
+      },
+    }
   }
-}
+)

--- a/packages/mirror-media-next/pages/magazine/index.js
+++ b/packages/mirror-media-next/pages/magazine/index.js
@@ -16,11 +16,8 @@ import MagazineWeeklys from '../../components/magazine/magazine-weeklys'
 import MagazineFeatures from '../../components/magazine/magazine-featured-weeklys'
 import Layout from '../../components/shared/layout'
 import JoinPremiumMember from '../../components/magazine/ui-join-premium-member'
-import {
-  getLogTraceObject,
-  handelAxiosResponse,
-  handleGqlResponse,
-} from '../../utils'
+import { getLogTraceObject, handleGqlResponse } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import redirectToLoginWhileUnauthed from '../../utils/redirect-to-login-while-unauthed'
 import useMembershipRequired from '../../hooks/use-membership-required'
 
@@ -204,7 +201,7 @@ export const getServerSideProps = redirectToLoginWhileUnauthed()(
       fetchHeaderDataInPremiumPageLayout(),
     ])
 
-    const sectionsData = handelAxiosResponse(
+    const sectionsData = handleAxiosResponse(
       responses[0],
       getSectionFromPremiumHeaderData,
       'Error occurs while getting premium header data in magazine list page',

--- a/packages/mirror-media-next/pages/magazine/index.js
+++ b/packages/mirror-media-next/pages/magazine/index.js
@@ -22,6 +22,7 @@ import {
   handleGqlResponse,
 } from '../../utils'
 import redirectToLoginWhileUnauthed from '../../utils/redirect-to-login-while-unauthed'
+import useMembershipRequired from '../../hooks/use-membership-required'
 
 const Section = styled.div`
   padding: 48px 0;
@@ -68,6 +69,7 @@ const Title = styled.h2`
  * @param {PageProps} props
  */
 export default function Magazine({ sectionsData = [] }) {
+  useMembershipRequired()
   const [specials, setSpecials] = useState([])
   const [weeklys, setWeeklys] = useState([])
 

--- a/packages/mirror-media-next/pages/magazine/index.js
+++ b/packages/mirror-media-next/pages/magazine/index.js
@@ -3,10 +3,8 @@ import styled from 'styled-components'
 
 import client from '../../apollo/apollo-client'
 import { fetchSpecials, fetchWeeklys } from '../../apollo/query/magazines'
-import {
-  fetchHeaderDataInPremiumPageLayout,
-  getSectionFromPremiumHeaderData,
-} from '../../utils/api'
+import { fetchHeaderDataInPremiumPageLayout } from '../../utils/api'
+import { getSectionFromPremiumHeaderData } from '../../utils/data-process'
 import { useMembership } from '../../context/membership'
 import { setPageCache } from '../../utils/cache-setting'
 

--- a/packages/mirror-media-next/pages/marketing/index.js
+++ b/packages/mirror-media-next/pages/marketing/index.js
@@ -9,7 +9,8 @@ import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import BlankCard from '../../components/subscribe/blank-card'
 import PrimaryBlueBtn from '../../components/subscribe/primary-blue-btn'
-import { getLogTraceObject, handelAxiosResponse } from '../../utils'
+import { getLogTraceObject } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 
 const PageWrapper = styled.section`
   min-height: 70vh;
@@ -86,7 +87,7 @@ export async function getServerSideProps({ req, res }) {
     fetchHeaderDataInDefaultPageLayout(),
   ])
 
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in marketing page',

--- a/packages/mirror-media-next/pages/marketing/index.js
+++ b/packages/mirror-media-next/pages/marketing/index.js
@@ -1,10 +1,8 @@
 // TODO: add handle-forbid-to-marketing middleware
 
 import styled from 'styled-components'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import BlankCard from '../../components/subscribe/blank-card'

--- a/packages/mirror-media-next/pages/papermag/1.js
+++ b/packages/mirror-media-next/pages/papermag/1.js
@@ -1,7 +1,9 @@
 import styled from 'styled-components'
-import errors from '@twreporter/errors'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
-import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import {
+  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
+} from '../../utils/api'
+import { getLogTraceObject, handelAxiosResponse } from '../../utils'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import Steps from '../../components/subscribe-steps'
@@ -50,15 +52,6 @@ export default OneYearSubscription
 export async function getServerSideProps({ req, res }) {
   setPageCache(res, { cachePolicy: 'no-store' }, req.url)
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
-
   if (ACCESS_PAPERMAG_FEATURE_TOGGLE !== 'on') {
     return {
       redirect: {
@@ -68,31 +61,19 @@ export async function getServerSideProps({ req, res }) {
     }
   }
 
-  // Fetch header data
-  let sectionsData = []
-  let topicsData = []
+  const globalLogFields = getLogTraceObject(req)
 
-  try {
-    const headerData = await fetchHeaderDataInDefaultPageLayout()
-    if (Array.isArray(headerData.sectionsData)) {
-      sectionsData = headerData.sectionsData
-    }
-    if (Array.isArray(headerData.topicsData)) {
-      topicsData = headerData.topicsData
-    }
-  } catch (err) {
-    const annotatingAxiosError = errors.helpers.annotateAxiosError(err)
-    console.error(
-      JSON.stringify({
-        severity: 'ERROR',
-        message: errors.helpers.printAll(annotatingAxiosError, {
-          withStack: true,
-          withPayload: true,
-        }),
-        ...globalLogFields,
-      })
-    )
-  }
+  // Fetch header data
+  const responses = await Promise.allSettled([
+    fetchHeaderDataInDefaultPageLayout(),
+  ])
+
+  const [sectionsData, topicsData] = handelAxiosResponse(
+    responses[0],
+    getSectionAndTopicFromDefaultHeaderData,
+    'Error occurs while getting header data in papermag/1 page',
+    globalLogFields
+  )
 
   return {
     props: {

--- a/packages/mirror-media-next/pages/papermag/1.js
+++ b/packages/mirror-media-next/pages/papermag/1.js
@@ -3,7 +3,8 @@ import {
   fetchHeaderDataInDefaultPageLayout,
   getSectionAndTopicFromDefaultHeaderData,
 } from '../../utils/api'
-import { getLogTraceObject, handelAxiosResponse } from '../../utils'
+import { getLogTraceObject } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import Steps from '../../components/subscribe-steps'
@@ -68,7 +69,7 @@ export async function getServerSideProps({ req, res }) {
     fetchHeaderDataInDefaultPageLayout(),
   ])
 
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in papermag/1 page',

--- a/packages/mirror-media-next/pages/papermag/1.js
+++ b/packages/mirror-media-next/pages/papermag/1.js
@@ -1,8 +1,6 @@
 import styled from 'styled-components'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { getLogTraceObject } from '../../utils'
 import { handleAxiosResponse } from '../../utils/response-handle'
 import { setPageCache } from '../../utils/cache-setting'

--- a/packages/mirror-media-next/pages/papermag/2.js
+++ b/packages/mirror-media-next/pages/papermag/2.js
@@ -3,7 +3,8 @@ import {
   fetchHeaderDataInDefaultPageLayout,
   getSectionAndTopicFromDefaultHeaderData,
 } from '../../utils/api'
-import { getLogTraceObject, handelAxiosResponse } from '../../utils'
+import { getLogTraceObject } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import Steps from '../../components/subscribe-steps'
@@ -68,7 +69,7 @@ export async function getServerSideProps({ req, res }) {
     fetchHeaderDataInDefaultPageLayout(),
   ])
 
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in papermag/2 page',

--- a/packages/mirror-media-next/pages/papermag/2.js
+++ b/packages/mirror-media-next/pages/papermag/2.js
@@ -1,7 +1,9 @@
 import styled from 'styled-components'
-import errors from '@twreporter/errors'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
-import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import {
+  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
+} from '../../utils/api'
+import { getLogTraceObject, handelAxiosResponse } from '../../utils'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import Steps from '../../components/subscribe-steps'
@@ -50,15 +52,6 @@ export default TwoYearsSubscription
 export async function getServerSideProps({ req, res }) {
   setPageCache(res, { cachePolicy: 'no-store' }, req.url)
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
-
   if (ACCESS_PAPERMAG_FEATURE_TOGGLE !== 'on') {
     return {
       redirect: {
@@ -68,31 +61,19 @@ export async function getServerSideProps({ req, res }) {
     }
   }
 
-  // Fetch header data
-  let sectionsData = []
-  let topicsData = []
+  const globalLogFields = getLogTraceObject(req)
 
-  try {
-    const headerData = await fetchHeaderDataInDefaultPageLayout()
-    if (Array.isArray(headerData.sectionsData)) {
-      sectionsData = headerData.sectionsData
-    }
-    if (Array.isArray(headerData.topicsData)) {
-      topicsData = headerData.topicsData
-    }
-  } catch (err) {
-    const annotatingAxiosError = errors.helpers.annotateAxiosError(err)
-    console.error(
-      JSON.stringify({
-        severity: 'ERROR',
-        message: errors.helpers.printAll(annotatingAxiosError, {
-          withStack: true,
-          withPayload: true,
-        }),
-        ...globalLogFields,
-      })
-    )
-  }
+  // Fetch header data
+  const responses = await Promise.allSettled([
+    fetchHeaderDataInDefaultPageLayout(),
+  ])
+
+  const [sectionsData, topicsData] = handelAxiosResponse(
+    responses[0],
+    getSectionAndTopicFromDefaultHeaderData,
+    'Error occurs while getting header data in papermag/2 page',
+    globalLogFields
+  )
 
   return {
     props: {

--- a/packages/mirror-media-next/pages/papermag/2.js
+++ b/packages/mirror-media-next/pages/papermag/2.js
@@ -1,8 +1,6 @@
 import styled from 'styled-components'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { getLogTraceObject } from '../../utils'
 import { handleAxiosResponse } from '../../utils/response-handle'
 import { setPageCache } from '../../utils/cache-setting'

--- a/packages/mirror-media-next/pages/papermag/index.js
+++ b/packages/mirror-media-next/pages/papermag/index.js
@@ -1,7 +1,9 @@
 import styled from 'styled-components'
-import errors from '@twreporter/errors'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
-import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import {
+  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
+} from '../../utils/api'
+import { getLogTraceObject, handelAxiosResponse } from '../../utils'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import Steps from '../../components/subscribe-steps'
@@ -45,15 +47,6 @@ export default PaperMag
 export async function getServerSideProps({ req, res }) {
   setPageCache(res, { cachePolicy: 'no-store' }, req.url)
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
-
   if (ACCESS_PAPERMAG_FEATURE_TOGGLE !== 'on') {
     return {
       redirect: {
@@ -63,31 +56,19 @@ export async function getServerSideProps({ req, res }) {
     }
   }
 
-  // Fetch header data
-  let sectionsData = []
-  let topicsData = []
+  const globalLogFields = getLogTraceObject(req)
 
-  try {
-    const headerData = await fetchHeaderDataInDefaultPageLayout()
-    if (Array.isArray(headerData.sectionsData)) {
-      sectionsData = headerData.sectionsData
-    }
-    if (Array.isArray(headerData.topicsData)) {
-      topicsData = headerData.topicsData
-    }
-  } catch (err) {
-    const annotatingAxiosError = errors.helpers.annotateAxiosError(err)
-    console.error(
-      JSON.stringify({
-        severity: 'ERROR',
-        message: errors.helpers.printAll(annotatingAxiosError, {
-          withStack: true,
-          withPayload: true,
-        }),
-        ...globalLogFields,
-      })
-    )
-  }
+  // Fetch header data
+  const responses = await Promise.allSettled([
+    fetchHeaderDataInDefaultPageLayout(),
+  ])
+
+  const [sectionsData, topicsData] = handelAxiosResponse(
+    responses[0],
+    getSectionAndTopicFromDefaultHeaderData,
+    'Error occurs while getting header data in papermag page',
+    globalLogFields
+  )
 
   return {
     props: {

--- a/packages/mirror-media-next/pages/papermag/index.js
+++ b/packages/mirror-media-next/pages/papermag/index.js
@@ -3,7 +3,8 @@ import {
   fetchHeaderDataInDefaultPageLayout,
   getSectionAndTopicFromDefaultHeaderData,
 } from '../../utils/api'
-import { getLogTraceObject, handelAxiosResponse } from '../../utils'
+import { getLogTraceObject } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import Steps from '../../components/subscribe-steps'
@@ -63,7 +64,7 @@ export async function getServerSideProps({ req, res }) {
     fetchHeaderDataInDefaultPageLayout(),
   ])
 
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in papermag page',

--- a/packages/mirror-media-next/pages/papermag/index.js
+++ b/packages/mirror-media-next/pages/papermag/index.js
@@ -1,8 +1,6 @@
 import styled from 'styled-components'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { getLogTraceObject } from '../../utils'
 import { handleAxiosResponse } from '../../utils/response-handle'
 import { setPageCache } from '../../utils/cache-setting'

--- a/packages/mirror-media-next/pages/papermag/return.js
+++ b/packages/mirror-media-next/pages/papermag/return.js
@@ -1,9 +1,7 @@
 import styled from 'styled-components'
 import errors from '@twreporter/errors'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import Steps from '../../components/subscribe-steps'

--- a/packages/mirror-media-next/pages/papermag/return.js
+++ b/packages/mirror-media-next/pages/papermag/return.js
@@ -21,11 +21,8 @@ import { getMerchandiseAndShippingFeeInfo } from '../../utils/papermag'
 import { ACCESS_PAPERMAG_FEATURE_TOGGLE } from '../../config/index.mjs'
 import client from '../../apollo/apollo-client'
 import { fetchAllMemberByOrderNo } from '../../apollo/query/magazine-orders'
-import {
-  transformTimeData,
-  handelAxiosResponse,
-  getLogTraceObject,
-} from '../../utils/index'
+import { transformTimeData, getLogTraceObject } from '../../utils/index'
+import { handleAxiosResponse } from '../../utils/response-handle'
 
 const Wrapper = styled.main`
   min-height: 50vh;
@@ -100,7 +97,7 @@ export async function getServerSideProps({ query, req, res }) {
     fetchHeaderDataInDefaultPageLayout(),
   ])
 
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in papermag/return page',

--- a/packages/mirror-media-next/pages/papermag/return.js
+++ b/packages/mirror-media-next/pages/papermag/return.js
@@ -1,7 +1,9 @@
 import styled from 'styled-components'
 import errors from '@twreporter/errors'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
-import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import {
+  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
+} from '../../utils/api'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import Steps from '../../components/subscribe-steps'
@@ -19,7 +21,11 @@ import { getMerchandiseAndShippingFeeInfo } from '../../utils/papermag'
 import { ACCESS_PAPERMAG_FEATURE_TOGGLE } from '../../config/index.mjs'
 import client from '../../apollo/apollo-client'
 import { fetchAllMemberByOrderNo } from '../../apollo/query/magazine-orders'
-import { transformTimeData } from '../../utils/index'
+import {
+  transformTimeData,
+  handelAxiosResponse,
+  getLogTraceObject,
+} from '../../utils/index'
 
 const Wrapper = styled.main`
   min-height: 50vh;
@@ -78,14 +84,7 @@ export default function Return({
 export async function getServerSideProps({ query, req, res }) {
   setPageCache(res, { cachePolicy: 'no-store' }, req.url)
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+  const globalLogFields = getLogTraceObject(req)
 
   if (ACCESS_PAPERMAG_FEATURE_TOGGLE !== 'on') {
     return {
@@ -97,30 +96,16 @@ export async function getServerSideProps({ query, req, res }) {
   }
 
   // Fetch header data
-  let sectionsData = []
-  let topicsData = []
+  const responses = await Promise.allSettled([
+    fetchHeaderDataInDefaultPageLayout(),
+  ])
 
-  try {
-    const headerData = await fetchHeaderDataInDefaultPageLayout()
-    if (Array.isArray(headerData.sectionsData)) {
-      sectionsData = headerData.sectionsData
-    }
-    if (Array.isArray(headerData.topicsData)) {
-      topicsData = headerData.topicsData
-    }
-  } catch (err) {
-    const annotatingAxiosError = errors.helpers.annotateAxiosError(err)
-    console.error(
-      JSON.stringify({
-        severity: 'ERROR',
-        message: errors.helpers.printAll(annotatingAxiosError, {
-          withStack: true,
-          withPayload: true,
-        }),
-        ...globalLogFields,
-      })
-    )
-  }
+  const [sectionsData, topicsData] = handelAxiosResponse(
+    responses[0],
+    getSectionAndTopicFromDefaultHeaderData,
+    'Error occurs while getting header data in papermag/return page',
+    globalLogFields
+  )
 
   let orderData = {}
   let orderStatus = 'fail'

--- a/packages/mirror-media-next/pages/password-change-fail.js
+++ b/packages/mirror-media-next/pages/password-change-fail.js
@@ -6,10 +6,8 @@ import { setPageCache } from '../utils/cache-setting'
 import { ENV } from '../config/index.mjs'
 import { getLogTraceObject } from '../utils'
 import { handleAxiosResponse } from '../utils/response-handle'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../utils/data-process'
 
 const Container = styled.div`
   flex-grow: 1;

--- a/packages/mirror-media-next/pages/password-change-fail.js
+++ b/packages/mirror-media-next/pages/password-change-fail.js
@@ -4,7 +4,8 @@ import GenericFailed from '../components/login/generic-failed'
 import { useRouter } from 'next/router'
 import { setPageCache } from '../utils/cache-setting'
 import { ENV } from '../config/index.mjs'
-import { getLogTraceObject, handelAxiosResponse } from '../utils'
+import { getLogTraceObject } from '../utils'
+import { handleAxiosResponse } from '../utils/response-handle'
 import {
   fetchHeaderDataInDefaultPageLayout,
   getSectionAndTopicFromDefaultHeaderData,
@@ -68,7 +69,7 @@ export async function getServerSideProps({ req, res }) {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in password change failed page',

--- a/packages/mirror-media-next/pages/password-change-success.js
+++ b/packages/mirror-media-next/pages/password-change-success.js
@@ -5,6 +5,13 @@ import LayoutFull from '../components/shared/layout-full'
 import FormWrapper from '../components/login/form-wrapper'
 import { useRouter } from 'next/router'
 import { logout } from '../context/membership'
+import { setPageCache } from '../utils/cache-setting'
+import { ENV } from '../config/index.mjs'
+import { getLogTraceObject, handelAxiosResponse } from '../utils'
+import {
+  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
+} from '../utils/api'
 
 const REDIRECTION_DELAY = 3 // 秒
 
@@ -39,7 +46,17 @@ const SecondaryText = styled.p`
   margin-top: 32px;
 `
 
-export default function PasswordChangeSuccess() {
+/**
+ * @typedef {Object} PageProps
+ * @property {Object} headerData
+ * @property {import('../utils/api').HeadersData} headerData.sectionsData
+ * @property {import('../utils/api').Topics} headerData.topicsData
+ */
+
+/**
+ * @param {PageProps} props
+ */
+export default function PasswordChangeSuccess({ headerData }) {
   const router = useRouter()
 
   useEffect(() => {
@@ -59,7 +76,10 @@ export default function PasswordChangeSuccess() {
   }, [router])
 
   return (
-    <LayoutFull header={{ type: 'default' }} footer={{ type: 'default' }}>
+    <LayoutFull
+      header={{ type: 'default', data: headerData }}
+      footer={{ type: 'default' }}
+    >
       <Container>
         <Main>
           <FormWrapper>
@@ -76,4 +96,35 @@ export default function PasswordChangeSuccess() {
       </Container>
     </LayoutFull>
   )
+}
+
+/**
+ * @type {import('next').GetServerSideProps<PageProps>}
+ */
+export async function getServerSideProps({ req, res }) {
+  if (ENV === 'prod') {
+    setPageCache(res, { cachePolicy: 'max-age', cacheTime: 900 }, req.url)
+  } else {
+    setPageCache(res, { cachePolicy: 'no-store' }, req.url)
+  }
+
+  const globalLogFields = getLogTraceObject(req)
+
+  const responses = await Promise.allSettled([
+    fetchHeaderDataInDefaultPageLayout(),
+  ])
+
+  // handle header data
+  const [sectionsData, topicsData] = handelAxiosResponse(
+    responses[0],
+    getSectionAndTopicFromDefaultHeaderData,
+    'Error occurs while getting header data in password change success page',
+    globalLogFields
+  )
+
+  return {
+    props: {
+      headerData: { sectionsData, topicsData },
+    },
+  }
 }

--- a/packages/mirror-media-next/pages/password-change-success.js
+++ b/packages/mirror-media-next/pages/password-change-success.js
@@ -7,7 +7,8 @@ import { useRouter } from 'next/router'
 import { logout } from '../context/membership'
 import { setPageCache } from '../utils/cache-setting'
 import { ENV } from '../config/index.mjs'
-import { getLogTraceObject, handelAxiosResponse } from '../utils'
+import { getLogTraceObject } from '../utils'
+import { handleAxiosResponse } from '../utils/response-handle'
 import {
   fetchHeaderDataInDefaultPageLayout,
   getSectionAndTopicFromDefaultHeaderData,
@@ -115,7 +116,7 @@ export async function getServerSideProps({ req, res }) {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in password change success page',

--- a/packages/mirror-media-next/pages/password-change-success.js
+++ b/packages/mirror-media-next/pages/password-change-success.js
@@ -9,10 +9,8 @@ import { setPageCache } from '../utils/cache-setting'
 import { ENV } from '../config/index.mjs'
 import { getLogTraceObject } from '../utils'
 import { handleAxiosResponse } from '../utils/response-handle'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../utils/data-process'
 
 const REDIRECTION_DELAY = 3 // 秒
 

--- a/packages/mirror-media-next/pages/podcasts/index.js
+++ b/packages/mirror-media-next/pages/podcasts/index.js
@@ -11,7 +11,8 @@ import {
   getSectionAndTopicFromDefaultHeaderData,
 } from '../../utils/api'
 import { setPageCache } from '../../utils/cache-setting'
-import { getLogTraceObject, handelAxiosResponse } from '../../utils'
+import { getLogTraceObject } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 
 /**
  * @typedef {import('../../components/header/share-header').HeaderData} HeaderData
@@ -188,7 +189,7 @@ export async function getServerSideProps({ req, res }) {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in podcasts page',
@@ -197,7 +198,7 @@ export async function getServerSideProps({ req, res }) {
 
   // Extracting podcast list data
   /** @type {PodcastData[]} */
-  const podcastListData = handelAxiosResponse(
+  const podcastListData = handleAxiosResponse(
     responses[1],
     (
       /** @type {Awaited<ReturnType<typeof fetchPodcastList>> | undefined} */ axiosData

--- a/packages/mirror-media-next/pages/podcasts/index.js
+++ b/packages/mirror-media-next/pages/podcasts/index.js
@@ -8,8 +8,8 @@ import { ENV } from '../../config/index.mjs'
 import {
   fetchHeaderDataInDefaultPageLayout,
   fetchPodcastList,
-  getSectionAndTopicFromDefaultHeaderData,
 } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { setPageCache } from '../../utils/cache-setting'
 import { getLogTraceObject } from '../../utils'
 import { handleAxiosResponse } from '../../utils/response-handle'

--- a/packages/mirror-media-next/pages/podcasts/index.js
+++ b/packages/mirror-media-next/pages/podcasts/index.js
@@ -1,16 +1,17 @@
-import errors from '@twreporter/errors'
 import { useState } from 'react'
 import styled from 'styled-components'
 import AudioPlayer from '../../components/podcast/audio-player'
 import Dropdown from '../../components/podcast/author-select-dropdown'
 import PodcastList from '../../components/podcast/podcast-list'
 import Layout from '../../components/shared/layout'
-import { ENV, GCP_PROJECT_ID } from '../../config/index.mjs'
+import { ENV } from '../../config/index.mjs'
 import {
   fetchHeaderDataInDefaultPageLayout,
   fetchPodcastList,
+  getSectionAndTopicFromDefaultHeaderData,
 } from '../../utils/api'
 import { setPageCache } from '../../utils/cache-setting'
+import { getLogTraceObject, handelAxiosResponse } from '../../utils'
 
 /**
  * @typedef {import('../../components/header/share-header').HeaderData} HeaderData
@@ -179,78 +180,39 @@ export async function getServerSideProps({ req, res }) {
     setPageCache(res, { cachePolicy: 'no-store' }, req.url)
   }
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+  const globalLogFields = getLogTraceObject(req)
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
     fetchPodcastList(),
   ])
 
-  const handledResponses = responses.map((response, index) => {
-    if (response.status === 'fulfilled') {
-      return response.value
-    } else if (response.status === 'rejected') {
-      const statusCode = response.reason.response?.status
-
-      const annotatingError = errors.helpers.wrap(
-        response.reason,
-        'UnhandledError',
-        'Error occurs while getting podcast list data'
-      )
-
-      console.log(
-        JSON.stringify({
-          severity: 'ERROR',
-          message: errors.helpers.printAll(
-            annotatingError,
-            {
-              withStack: true,
-              withPayload: true,
-            },
-            0,
-            0
-          ),
-          ...globalLogFields,
-        })
-      )
-      if (index === 1) {
-        if (statusCode === 404) {
-          // leave undefined to be checked and redirect to 404
-          return
-        } else {
-          // fetch key data (posts) failed, redirect to 500
-          throw new Error('fetch podcast list failed')
-        }
-      }
-      return
-    }
-  })
-
   // handle header data
-  const headerData =
-    handledResponses[0] && 'sectionsData' in handledResponses[0]
-      ? handledResponses[0]
-      : {
-          sectionsData: [],
-          topicsData: [],
-        }
-  const sectionsData = Array.isArray(headerData.sectionsData)
-    ? headerData.sectionsData
-    : []
-  const topicsData = Array.isArray(headerData.topicsData)
-    ? headerData.topicsData
-    : []
+  const [sectionsData, topicsData] = handelAxiosResponse(
+    responses[0],
+    getSectionAndTopicFromDefaultHeaderData,
+    'Error occurs while getting header data in podcasts page',
+    globalLogFields
+  )
 
   // Extracting podcast list data
-  const podcastListData =
-    responses[1].status === 'fulfilled' ? responses[1].value.data || [] : []
+  /** @type {PodcastData[]} */
+  const podcastListData = handelAxiosResponse(
+    responses[1],
+    (
+      /** @type {Awaited<ReturnType<typeof fetchPodcastList>> | undefined} */ axiosData
+    ) => {
+      return axiosData?.data ?? []
+    },
+    'Error occurs while getting podcast list in podcasts page',
+    globalLogFields
+  )
+
+  if (podcastListData.length === 0) {
+    return {
+      notFound: true,
+    }
+  }
 
   const props = {
     headerData: { sectionsData, topicsData },

--- a/packages/mirror-media-next/pages/premiumsection/[slug].js
+++ b/packages/mirror-media-next/pages/premiumsection/[slug].js
@@ -8,11 +8,11 @@ import {
   handleAxiosResponse,
   handleGqlResponse,
 } from '../../utils/response-handle'
+import { fetchHeaderDataInPremiumPageLayout } from '../../utils/api'
 import {
-  fetchHeaderDataInPremiumPageLayout,
+  getSectionFromPremiumHeaderData,
   getPostsAndPostscountFromGqlData,
-} from '../../utils/api'
-import { getSectionFromPremiumHeaderData } from '../../utils/data-process'
+} from '../../utils/data-process'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import {

--- a/packages/mirror-media-next/pages/premiumsection/[slug].js
+++ b/packages/mirror-media-next/pages/premiumsection/[slug].js
@@ -199,7 +199,7 @@ export async function getServerSideProps({ query, req, res }) {
   const sectionsData = handleAxiosResponse(
     responses[0],
     getSectionFromPremiumHeaderData,
-    'Error occurs while getting premium header data in premiumsection page',
+    `Error occurs while getting premium header data in premiumsection page (sectionSlug: ${sectionSlug})`,
     globalLogFields
   )
 
@@ -214,7 +214,7 @@ export async function getServerSideProps({ query, req, res }) {
   const [postsCount, posts] = handleGqlResponse(
     responses[1],
     dataHandler,
-    'Error occurs while getting posts in premiumsection page',
+    `Error occurs while getting posts in premiumsection page (sectionSlug: ${sectionSlug})`,
     globalLogFields
   )
 
@@ -236,7 +236,7 @@ export async function getServerSideProps({ query, req, res }) {
     (gqlData) => {
       return gqlData?.data?.section || { slug: sectionSlug }
     },
-    'Error occurs while getting sectoin data in premiumsection page',
+    `Error occurs while getting sectoin data in premiumsection page (sectionSlug: ${sectionSlug})`,
     globalLogFields
   )
 

--- a/packages/mirror-media-next/pages/premiumsection/[slug].js
+++ b/packages/mirror-media-next/pages/premiumsection/[slug].js
@@ -3,8 +3,11 @@ import dynamic from 'next/dynamic'
 
 import SectionArticles from '../../components/shared/section-articles'
 import { ENV } from '../../config/index.mjs'
-import { getLogTraceObject, handleGqlResponse } from '../../utils'
-import { handleAxiosResponse } from '../../utils/response-handle'
+import { getLogTraceObject } from '../../utils'
+import {
+  handleAxiosResponse,
+  handleGqlResponse,
+} from '../../utils/response-handle'
 import {
   fetchHeaderDataInPremiumPageLayout,
   getPostsAndPostscountFromGqlData,

--- a/packages/mirror-media-next/pages/premiumsection/[slug].js
+++ b/packages/mirror-media-next/pages/premiumsection/[slug].js
@@ -3,11 +3,8 @@ import dynamic from 'next/dynamic'
 
 import SectionArticles from '../../components/shared/section-articles'
 import { ENV } from '../../config/index.mjs'
-import {
-  getLogTraceObject,
-  handelAxiosResponse,
-  handleGqlResponse,
-} from '../../utils'
+import { getLogTraceObject, handleGqlResponse } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import {
   fetchHeaderDataInPremiumPageLayout,
   getPostsAndPostscountFromGqlData,
@@ -196,7 +193,7 @@ export async function getServerSideProps({ query, req, res }) {
   ])
 
   // handle header data
-  const sectionsData = handelAxiosResponse(
+  const sectionsData = handleAxiosResponse(
     responses[0],
     getSectionFromPremiumHeaderData,
     'Error occurs while getting premium header data in premiumsection page',

--- a/packages/mirror-media-next/pages/premiumsection/[slug].js
+++ b/packages/mirror-media-next/pages/premiumsection/[slug].js
@@ -11,8 +11,8 @@ import {
 import {
   fetchHeaderDataInPremiumPageLayout,
   getPostsAndPostscountFromGqlData,
-  getSectionFromPremiumHeaderData,
 } from '../../utils/api'
+import { getSectionFromPremiumHeaderData } from '../../utils/data-process'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import {

--- a/packages/mirror-media-next/pages/premiumsection/[slug].js
+++ b/packages/mirror-media-next/pages/premiumsection/[slug].js
@@ -1,10 +1,18 @@
-import errors from '@twreporter/errors'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
 import SectionArticles from '../../components/shared/section-articles'
-import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
-import { fetchHeaderDataInPremiumPageLayout } from '../../utils/api'
+import { ENV } from '../../config/index.mjs'
+import {
+  getLogTraceObject,
+  handelAxiosResponse,
+  handleGqlResponse,
+} from '../../utils'
+import {
+  fetchHeaderDataInPremiumPageLayout,
+  getPostsAndPostscountFromGqlData,
+  getSectionFromPremiumHeaderData,
+} from '../../utils/api'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import {
@@ -175,14 +183,7 @@ export async function getServerSideProps({ query, req, res }) {
   }
   const sectionSlug = Array.isArray(query.slug) ? query.slug[0] : query.slug
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+  const globalLogFields = getLogTraceObject(req)
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInPremiumPageLayout(),
@@ -190,60 +191,30 @@ export async function getServerSideProps({ query, req, res }) {
     fetchSectionBySectionSlug(sectionSlug),
   ])
 
-  const handledResponses = responses.map((response, index) => {
-    if (response.status === 'fulfilled') {
-      if ('data' in response.value) {
-        // handle gql requests
-        return response.value.data
-      }
-      return response.value
-    } else if (response.status === 'rejected') {
-      const { graphQLErrors, clientErrors, networkError } = response.reason
-      const annotatingError = errors.helpers.wrap(
-        response.reason,
-        'UnhandledError',
-        'Error occurs while getting premiumsection page data'
-      )
-
-      console.log(
-        JSON.stringify({
-          severity: 'ERROR',
-          message: errors.helpers.printAll(
-            annotatingError,
-            {
-              withStack: true,
-              withPayload: true,
-            },
-            0,
-            0
-          ),
-          debugPayload: {
-            graphQLErrors,
-            clientErrors,
-            networkError,
-          },
-          ...globalLogFields,
-        })
-      )
-      if (index === 1) {
-        // fetch key data (posts) failed, redirect to 500
-        throw new Error('fetch premiumsection posts failed')
-      }
-      return
-    }
-  })
-
   // handle header data
-  const headerData =
-    handledResponses[0] && 'sectionsData' in handledResponses[0]
-      ? handledResponses[0]
-      : { sectionsData: [] }
-
-  const sectionsData = headerData.sectionsData || []
+  const sectionsData = handelAxiosResponse(
+    responses[0],
+    getSectionFromPremiumHeaderData,
+    'Error occurs while getting premium header data in premiumsection page',
+    globalLogFields
+  )
 
   // handle fetch post data
-  if (handledResponses[1]?.posts?.length === 0) {
-    // fetchPost return empty array -> wrong authorId -> 404
+  /**
+   * @template {Article} T
+   * @type {typeof getPostsAndPostscountFromGqlData<T>}
+   */
+  const dataHandler = getPostsAndPostscountFromGqlData
+
+  /** @type {[number, Article[]]} */
+  const [postsCount, posts] = handleGqlResponse(
+    responses[1],
+    dataHandler,
+    'Error occurs while getting posts in premiumsection page',
+    globalLogFields
+  )
+
+  if (posts.length === 0) {
     console.log(
       JSON.stringify({
         severity: 'WARNING',
@@ -253,14 +224,17 @@ export async function getServerSideProps({ query, req, res }) {
     )
     return { notFound: true }
   }
-  /** @type {number} postsCount */
-  const postsCount = handledResponses[1]?.postsCount || 0
-  /** @type {Article[]} */
-  const posts = handledResponses[1]?.posts || []
 
   // handle fetch section data
   /** @type {Section} */
-  const section = handledResponses[2]?.section || { slug: sectionSlug }
+  const section = handleGqlResponse(
+    responses[2],
+    (gqlData) => {
+      return gqlData?.data?.section || { slug: sectionSlug }
+    },
+    'Error occurs while getting sectoin data in premiumsection page',
+    globalLogFields
+  )
 
   const props = {
     postsCount,

--- a/packages/mirror-media-next/pages/recover-password.js
+++ b/packages/mirror-media-next/pages/recover-password.js
@@ -19,10 +19,8 @@ import { sendErrorLog } from '../utils/log/send-log'
 import { SECOND } from '../constants/time-unit'
 import Hints, { HINT_STATE } from '../components/recover-password/hints'
 import { FirebaseAuthError } from '../constants/firebase'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../utils/data-process'
 
 // following comments is required since these variables are used by comments but not codes.
 /* eslint-disable-next-line no-unused-vars */

--- a/packages/mirror-media-next/pages/recover-password.js
+++ b/packages/mirror-media-next/pages/recover-password.js
@@ -8,7 +8,8 @@ import FormWrapper from '../components/login/form-wrapper'
 import GenericTextInput from '../components/shared/inputs/generic-text-input'
 import PrimaryButton from '../components/shared/buttons/primary-button'
 import TextButton from '../components/login/text-button'
-import { getLogTraceObject, isValidEmail, handelAxiosResponse } from '../utils'
+import { getLogTraceObject, isValidEmail } from '../utils'
+import { handleAxiosResponse } from '../utils/response-handle'
 import redirectToDestinationWhileAuthed from '../utils/redirect-to-destination-while-authed'
 import { auth } from '../firebase'
 import { FirebaseError } from 'firebase/app'
@@ -257,7 +258,7 @@ export const getServerSideProps = redirectToDestinationWhileAuthed()(
     ])
 
     // handle header data
-    const [sectionsData, topicsData] = handelAxiosResponse(
+    const [sectionsData, topicsData] = handleAxiosResponse(
       responses[0],
       getSectionAndTopicFromDefaultHeaderData,
       'Error occurs while getting header data in recover password page',

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -5,9 +5,9 @@ import SectionArticles from '../../components/shared/section-articles'
 import { ENV } from '../../config/index.mjs'
 import {
   fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
   getPostsAndPostscountFromGqlData,
 } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { getLogTraceObject } from '../../utils'
 import {
   handleAxiosResponse,

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -3,11 +3,11 @@ import dynamic from 'next/dynamic'
 
 import SectionArticles from '../../components/shared/section-articles'
 import { ENV } from '../../config/index.mjs'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import {
-  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
   getPostsAndPostscountFromGqlData,
-} from '../../utils/api'
-import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
+} from '../../utils/data-process'
 import { getLogTraceObject } from '../../utils'
 import {
   handleAxiosResponse,

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -8,11 +8,8 @@ import {
   getSectionAndTopicFromDefaultHeaderData,
   getPostsAndPostscountFromGqlData,
 } from '../../utils/api'
-import {
-  getLogTraceObject,
-  handelAxiosResponse,
-  handleGqlResponse,
-} from '../../utils'
+import { getLogTraceObject, handleGqlResponse } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { Z_INDEX } from '../../constants/index'
@@ -181,7 +178,7 @@ export async function getServerSideProps({ query, req, res }) {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in section page',

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -1,10 +1,18 @@
-import errors from '@twreporter/errors'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
 import SectionArticles from '../../components/shared/section-articles'
-import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
-import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { ENV } from '../../config/index.mjs'
+import {
+  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
+  getPostsAndPostscountFromGqlData,
+} from '../../utils/api'
+import {
+  getLogTraceObject,
+  handelAxiosResponse,
+  handleGqlResponse,
+} from '../../utils'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { Z_INDEX } from '../../constants/index'
@@ -160,14 +168,7 @@ export async function getServerSideProps({ query, req, res }) {
   }
   const sectionSlug = Array.isArray(query.slug) ? query.slug[0] : query.slug
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+  const globalLogFields = getLogTraceObject(req)
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
@@ -175,66 +176,30 @@ export async function getServerSideProps({ query, req, res }) {
     fetchSectionBySectionSlug(sectionSlug),
   ])
 
-  const handledResponses = responses.map((response, index) => {
-    if (response.status === 'fulfilled') {
-      if ('data' in response.value) {
-        // handle gql requests
-        return response.value.data
-      }
-      return response.value
-    } else if (response.status === 'rejected') {
-      const { graphQLErrors, clientErrors, networkError } = response.reason
-      const annotatingError = errors.helpers.wrap(
-        response.reason,
-        'UnhandledError',
-        'Error occurs while getting section page data'
-      )
-
-      console.log(
-        JSON.stringify({
-          severity: 'ERROR',
-          message: errors.helpers.printAll(
-            annotatingError,
-            {
-              withStack: true,
-              withPayload: true,
-            },
-            0,
-            0
-          ),
-          debugPayload: {
-            graphQLErrors,
-            clientErrors,
-            networkError,
-          },
-          ...globalLogFields,
-        })
-      )
-      if (index === 1) {
-        // fetch key data (posts) failed, redirect to 500
-        throw new Error('fetch section posts failed')
-      }
-      return
-    }
-  })
-
   // handle header data
-  const headerData =
-    handledResponses[0] && 'sectionsData' in handledResponses[0]
-      ? handledResponses[0]
-      : {
-          sectionsData: [],
-          topicsData: [],
-        }
-  const sectionsData = Array.isArray(headerData.sectionsData)
-    ? headerData.sectionsData
-    : []
-  const topicsData = Array.isArray(headerData.topicsData)
-    ? headerData.topicsData
-    : []
+  const [sectionsData, topicsData] = handelAxiosResponse(
+    responses[0],
+    getSectionAndTopicFromDefaultHeaderData,
+    'Error occurs while getting header data in section page',
+    globalLogFields
+  )
 
   // handle fetch post data
-  if (handledResponses[1]?.posts?.length === 0) {
+  /**
+   * @template {Article} T
+   * @type {typeof getPostsAndPostscountFromGqlData<T>}
+   */
+  const dataHandler = getPostsAndPostscountFromGqlData
+
+  /** @type {[number, Article[]]} */
+  const [postsCount, posts] = handleGqlResponse(
+    responses[1],
+    dataHandler,
+    'Error occurs while getting posts in section page',
+    globalLogFields
+  )
+
+  if (posts.length === 0) {
     // fetchPost return empty array -> wrong authorId -> 404
     console.log(
       JSON.stringify({
@@ -245,14 +210,17 @@ export async function getServerSideProps({ query, req, res }) {
     )
     return { notFound: true }
   }
-  /** @type {number} postsCount */
-  const postsCount = handledResponses[1]?.postsCount || 0
-  /** @type {Article[]} */
-  const posts = handledResponses[1]?.posts || []
 
   // handle fetch section data
   /** @type {Section} */
-  const section = handledResponses[2]?.section || { slug: sectionSlug }
+  const section = handleGqlResponse(
+    responses[2],
+    (gqlData) => {
+      return gqlData?.data?.section || { slug: sectionSlug }
+    },
+    'Error occurs while getting section data in section page',
+    globalLogFields
+  )
 
   // handle section state, if `inactive` -> redirect to 404
   if (section.state !== 'active') {

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -8,8 +8,11 @@ import {
   getSectionAndTopicFromDefaultHeaderData,
   getPostsAndPostscountFromGqlData,
 } from '../../utils/api'
-import { getLogTraceObject, handleGqlResponse } from '../../utils'
-import { handleAxiosResponse } from '../../utils/response-handle'
+import { getLogTraceObject } from '../../utils'
+import {
+  handleAxiosResponse,
+  handleGqlResponse,
+} from '../../utils/response-handle'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { Z_INDEX } from '../../constants/index'

--- a/packages/mirror-media-next/pages/section/[slug].js
+++ b/packages/mirror-media-next/pages/section/[slug].js
@@ -184,7 +184,7 @@ export async function getServerSideProps({ query, req, res }) {
   const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
-    'Error occurs while getting header data in section page',
+    `Error occurs while getting header data in section page (sectionSlug: ${sectionSlug})`,
     globalLogFields
   )
 
@@ -199,7 +199,7 @@ export async function getServerSideProps({ query, req, res }) {
   const [postsCount, posts] = handleGqlResponse(
     responses[1],
     dataHandler,
-    'Error occurs while getting posts in section page',
+    `Error occurs while getting posts in section page (sectionSlug: ${sectionSlug})`,
     globalLogFields
   )
 
@@ -222,7 +222,7 @@ export async function getServerSideProps({ query, req, res }) {
     (gqlData) => {
       return gqlData?.data?.section || { slug: sectionSlug }
     },
-    'Error occurs while getting section data in section page',
+    `Error occurs while getting section data in section page (sectionSlug: ${sectionSlug})`,
     globalLogFields
   )
 

--- a/packages/mirror-media-next/pages/section/topic.js
+++ b/packages/mirror-media-next/pages/section/topic.js
@@ -7,11 +7,8 @@ import {
   fetchHeaderDataInDefaultPageLayout,
   getSectionAndTopicFromDefaultHeaderData,
 } from '../../utils/api'
-import {
-  getLogTraceObject,
-  handelAxiosResponse,
-  handleGqlResponse,
-} from '../../utils'
+import { getLogTraceObject, handleGqlResponse } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { fetchTopicList } from '../../utils/api/section-topic'
@@ -156,7 +153,7 @@ export async function getServerSideProps({ req, res }) {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in section/topic page',

--- a/packages/mirror-media-next/pages/section/topic.js
+++ b/packages/mirror-media-next/pages/section/topic.js
@@ -1,10 +1,17 @@
-import errors from '@twreporter/errors'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
 import SectionTopics from '../../components/section/topic/section-topics'
-import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
-import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { ENV } from '../../config/index.mjs'
+import {
+  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
+} from '../../utils/api'
+import {
+  getLogTraceObject,
+  handelAxiosResponse,
+  handleGqlResponse,
+} from '../../utils'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { fetchTopicList } from '../../utils/api/section-topic'
@@ -137,77 +144,37 @@ export async function getServerSideProps({ req, res }) {
     setPageCache(res, { cachePolicy: 'no-store' }, req.url)
   }
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+  let globalLogFields = getLogTraceObject(req)
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
     fetchTopicList(RENDER_PAGE_SIZE * 2, 0),
   ])
 
-  const handledResponses = responses.map((response, index) => {
-    if (response.status === 'fulfilled') {
-      if ('data' in response.value) {
-        // handle gql requests
-        return response.value.data
-      }
-      return response.value
-    } else if (response.status === 'rejected') {
-      const { graphQLErrors, clientErrors, networkError } = response.reason
-      const annotatingError = errors.helpers.wrap(
-        response.reason,
-        'UnhandledError',
-        'Error occurs while getting section/topic page data'
-      )
-
-      console.log(
-        JSON.stringify({
-          severity: 'ERROR',
-          message: errors.helpers.printAll(
-            annotatingError,
-            {
-              withStack: true,
-              withPayload: true,
-            },
-            0,
-            0
-          ),
-          debugPayload: {
-            graphQLErrors,
-            clientErrors,
-            networkError,
-          },
-          ...globalLogFields,
-        })
-      )
-      if (index === 1) {
-        // fetch key data (topics) failed, redirect to 500
-        throw new Error('fetch topics failed')
-      }
-      return
-    }
-  })
-
-  // handle fetch header data
-  const headerData =
-    handledResponses[0] && 'sectionsData' in handledResponses[0]
-      ? handledResponses[0]
-      : { sectionsData: [], topicsData: [] }
-  const sectionsData = Array.isArray(headerData.sectionsData)
-    ? headerData.sectionsData
-    : []
-  const topicsData = Array.isArray(headerData.topicsData)
-    ? headerData.topicsData
-    : []
+  // handle header data
+  const [sectionsData, topicsData] = handelAxiosResponse(
+    responses[0],
+    getSectionAndTopicFromDefaultHeaderData,
+    'Error occurs while getting header data in section/topic page',
+    globalLogFields
+  )
 
   // handle fetch topics
-  if (handledResponses[1]?.topics?.length === 0) {
+  const [topicsCount, topics] = handleGqlResponse(
+    responses[1],
+    (gqlData) => {
+      if (!gqlData) return [0, []]
+
+      const data = gqlData.data
+      const topicsCount = data?.topicsCount || 0
+      const topics = data?.topics || []
+      return [topicsCount, topics]
+    },
+    'Error occurs while getting posts in section/topic page',
+    req
+  )
+
+  if (topics.length === 0) {
     // fetchTopic return empty array -> something wrong -> 404
     console.log(
       JSON.stringify({
@@ -218,10 +185,6 @@ export async function getServerSideProps({ req, res }) {
     )
     return { notFound: true }
   }
-  /** @type {number} */
-  const topicsCount = handledResponses[1]?.topicsCount || 0
-  /** @type {Topic[]} */
-  const topics = handledResponses[1]?.topics || []
 
   const props = {
     topics,

--- a/packages/mirror-media-next/pages/section/topic.js
+++ b/packages/mirror-media-next/pages/section/topic.js
@@ -7,8 +7,11 @@ import {
   fetchHeaderDataInDefaultPageLayout,
   getSectionAndTopicFromDefaultHeaderData,
 } from '../../utils/api'
-import { getLogTraceObject, handleGqlResponse } from '../../utils'
-import { handleAxiosResponse } from '../../utils/response-handle'
+import { getLogTraceObject } from '../../utils'
+import {
+  handleAxiosResponse,
+  handleGqlResponse,
+} from '../../utils/response-handle'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { fetchTopicList } from '../../utils/api/section-topic'

--- a/packages/mirror-media-next/pages/section/topic.js
+++ b/packages/mirror-media-next/pages/section/topic.js
@@ -3,10 +3,8 @@ import dynamic from 'next/dynamic'
 
 import SectionTopics from '../../components/section/topic/section-topics'
 import { ENV } from '../../config/index.mjs'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { getLogTraceObject } from '../../utils'
 import {
   handleAxiosResponse,

--- a/packages/mirror-media-next/pages/section/videohub.js
+++ b/packages/mirror-media-next/pages/section/videohub.js
@@ -28,11 +28,8 @@ import {
   GPT_Placeholder_Desktop,
   GPT_Placeholder_MobileAndTablet,
 } from '../../components/ads/gpt/gpt-placeholder'
-import {
-  getLogTraceObject,
-  handelAxiosResponse,
-  handleGqlResponse,
-} from '../../utils'
+import { getLogTraceObject, handleGqlResponse } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api/index.js'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
@@ -197,7 +194,7 @@ export async function getServerSideProps({ req, res }) {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in section/videohub page',
@@ -209,7 +206,7 @@ export async function getServerSideProps({ req, res }) {
    * 1. get fetch statistics for 50 videos to get the most viewed video (熱門影片)
    * 2. slice the first 4 videos for the front-end to render (最新影片)
    */
-  const [latestVideos, latest50VideoIds] = handelAxiosResponse(
+  const [latestVideos, latest50VideoIds] = handleAxiosResponse(
     responses[1],
     (
       /** @type {Awaited<ReturnType<typeof fetchYoutubeLatestVideos>>} */ axiosData
@@ -251,7 +248,7 @@ export async function getServerSideProps({ req, res }) {
     ),
   ])
 
-  const highestViewCountVideo = handelAxiosResponse(
+  const highestViewCountVideo = handleAxiosResponse(
     playlistResponses[0],
     (
       /** @type {Awaited<ReturnType<typeof fetchYoutubeVideosWithStatistics>>} */ axiosData
@@ -279,7 +276,7 @@ export async function getServerSideProps({ req, res }) {
     let items
 
     if (response) {
-      items = handelAxiosResponse(
+      items = handleAxiosResponse(
         response,
         (
           /** @type {Awaited<ReturnType<typeof fetchYoutubePlaylistByChannelId>>} */ axiosData

--- a/packages/mirror-media-next/pages/section/videohub.js
+++ b/packages/mirror-media-next/pages/section/videohub.js
@@ -33,7 +33,7 @@ import {
   handleAxiosResponse,
   handleGqlResponse,
 } from '../../utils/response-handle'
-import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api/index.js'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,

--- a/packages/mirror-media-next/pages/section/videohub.js
+++ b/packages/mirror-media-next/pages/section/videohub.js
@@ -28,8 +28,11 @@ import {
   GPT_Placeholder_Desktop,
   GPT_Placeholder_MobileAndTablet,
 } from '../../components/ads/gpt/gpt-placeholder'
-import { getLogTraceObject, handleGqlResponse } from '../../utils'
-import { handleAxiosResponse } from '../../utils/response-handle'
+import { getLogTraceObject } from '../../utils'
+import {
+  handleAxiosResponse,
+  handleGqlResponse,
+} from '../../utils/response-handle'
 import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api/index.js'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {

--- a/packages/mirror-media-next/pages/section/videohub.js
+++ b/packages/mirror-media-next/pages/section/videohub.js
@@ -1,7 +1,6 @@
-import errors from '@twreporter/errors'
 import dynamic from 'next/dynamic'
 
-import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
+import { ENV } from '../../config/index.mjs'
 import { VIDEOHUB_CATEGORIES_PLAYLIST_MAPPING } from '../../constants'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api/index.js'
 import { setPageCache } from '../../utils/cache-setting'
@@ -29,6 +28,12 @@ import {
   GPT_Placeholder_Desktop,
   GPT_Placeholder_MobileAndTablet,
 } from '../../components/ads/gpt/gpt-placeholder'
+import {
+  getLogTraceObject,
+  handelAxiosResponse,
+  handleGqlResponse,
+} from '../../utils'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/api/index.js'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -183,14 +188,7 @@ export async function getServerSideProps({ req, res }) {
     setPageCache(res, { cachePolicy: 'no-store' }, req.url)
   }
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+  const globalLogFields = getLogTraceObject(req)
 
   let responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
@@ -198,64 +196,49 @@ export async function getServerSideProps({ req, res }) {
     fetchVideohubSection(),
   ])
 
-  let handledResponses = responses.map((response) => {
-    if (response.status === 'fulfilled') {
-      if ('data' in response.value) {
-        // retrieve data for simple axios and gql request
-        return response.value.data
-      }
-      return response.value
-    } else if (response.status === 'rejected') {
-      const annotatingError = errors.helpers.wrap(
-        response.reason,
-        'UnhandledError',
-        'Error occurs white getting video category page data'
-      )
-
-      console.log(
-        JSON.stringify({
-          severity: 'ERROR',
-          message: errors.helpers.printAll(
-            annotatingError,
-            {
-              withStack: true,
-              withPayload: true,
-            },
-            0,
-            0
-          ),
-          ...globalLogFields,
-        })
-      )
-      return
-    }
-  })
-
-  const headerData =
-    handledResponses[0] && 'sectionsData' in handledResponses[0]
-      ? handledResponses[0]
-      : { sectionsData: [], topicsData: [] }
-  const sectionsData = Array.isArray(headerData.sectionsData)
-    ? headerData.sectionsData
-    : []
-  const topicsData = Array.isArray(headerData.topicsData)
-    ? headerData.topicsData
-    : []
+  // handle header data
+  const [sectionsData, topicsData] = handelAxiosResponse(
+    responses[0],
+    getSectionAndTopicFromDefaultHeaderData,
+    'Error occurs while getting header data in section/videohub page',
+    globalLogFields
+  )
 
   /**
    * fetch 50 latest videos for two usage:
    * 1. get fetch statistics for 50 videos to get the most viewed video (熱門影片)
    * 2. slice the first 4 videos for the front-end to render (最新影片)
    */
-  const latest50Videos = handledResponses[1]?.items
-    ? simplifyYoutubeSearchedVideo(handledResponses[1]?.items)
-    : []
-  const latestVideos = latest50Videos.slice(0, 4)
-  const latest50VideoIds = latest50Videos.map((video) => video.id).join(',')
+  const [latestVideos, latest50VideoIds] = handelAxiosResponse(
+    responses[1],
+    (
+      /** @type {Awaited<ReturnType<typeof fetchYoutubeLatestVideos>>} */ axiosData
+    ) => {
+      if (!axiosData) return [[], '']
 
-  const categories = handledResponses[2]?.section?.categories
-    ? handledResponses[2]?.section?.categories
-    : []
+      const data = axiosData.data
+      const latest50Videos = data?.items
+        ? simplifyYoutubeSearchedVideo(data?.items)
+        : []
+      const latestVideos = latest50Videos.slice(0, 4)
+      const latest50VideoIds = latest50Videos.map((video) => video.id).join(',')
+
+      return [latestVideos, latest50VideoIds]
+    },
+    'Error occurs while getting video data in section/videohub page',
+    globalLogFields
+  )
+
+  const categories = handleGqlResponse(
+    responses[2],
+    (gqlData) => {
+      if (!gqlData) return []
+
+      return gqlData?.data?.section?.categories || []
+    },
+    'Error occurs while getting categories in section/videohub page',
+    globalLogFields
+  )
 
   const channelIds = categories.map(
     (category) => VIDEOHUB_CATEGORIES_PLAYLIST_MAPPING[category.slug]
@@ -267,59 +250,58 @@ export async function getServerSideProps({ req, res }) {
       fetchYoutubePlaylistByChannelId(channelId)
     ),
   ])
-  const handledPlaylistResponses = playlistResponses.map((response) => {
-    if (response.status === 'fulfilled') {
-      return response.value.data
-    } else if (response.status === 'rejected') {
-      const annotatingError = errors.helpers.wrap(
-        response.reason,
-        'UnhandledError',
-        'Error occurs white getting video category page data'
-      )
 
-      console.log(
-        JSON.stringify({
-          severity: 'ERROR',
-          message: errors.helpers.printAll(
-            annotatingError,
-            {
-              withStack: true,
-              withPayload: true,
-            },
-            0,
-            0
-          ),
-          ...globalLogFields,
-        })
+  const highestViewCountVideo = handelAxiosResponse(
+    playlistResponses[0],
+    (
+      /** @type {Awaited<ReturnType<typeof fetchYoutubeVideosWithStatistics>>} */ axiosData
+    ) => {
+      if (!axiosData) return null
+
+      const latest50VideosWithStatistics = axiosData?.data?.items
+      const highestViewCountRawVideo = latest50VideosWithStatistics.reduce(
+        (popularVideo, video) => {
+          return Number(popularVideo?.statistics?.viewCount) >
+            Number(video.statistics?.viewCount)
+            ? popularVideo
+            : video
+        },
+        null
       )
-      return
+      return simplifyYoutubeVideo([highestViewCountRawVideo])[0]
+    },
+    'Error occurs while getting latest 50 videos in section/videohub page',
+    globalLogFields
+  )
+
+  const playlistsVideos = categories.map((category, index) => {
+    const response = playlistResponses[index + 1]
+    let items
+
+    if (response) {
+      items = handelAxiosResponse(
+        response,
+        (
+          /** @type {Awaited<ReturnType<typeof fetchYoutubePlaylistByChannelId>>} */ axiosData
+        ) => {
+          return (
+            axiosData?.data?.items?.filter(
+              (item) => item.status.privacyStatus === 'public'
+            ) || []
+          )
+        },
+        `Error occurs while getting playlist(${category?.name}) in section/videohub page`,
+        globalLogFields
+      )
+    } else {
+      items = []
+    }
+
+    return {
+      ...category,
+      items: simplifyYoutubePlaylistVideo(items),
     }
   })
-
-  const latest50VideosWithStatistics = handledPlaylistResponses[0]?.items
-  const highestViewCountRawVideo = latest50VideosWithStatistics.reduce(
-    (popularVideo, video) => {
-      return Number(popularVideo?.statistics?.viewCount) >
-        Number(video.statistics?.viewCount)
-        ? popularVideo
-        : video
-    },
-    null
-  )
-  const highestViewCountVideo = simplifyYoutubeVideo([
-    highestViewCountRawVideo,
-  ])[0]
-
-  const playlistsVideos = categories.map((category, index) => ({
-    ...category,
-    items: simplifyYoutubePlaylistVideo(
-      handledPlaylistResponses[index + 1]?.items
-        ? handledPlaylistResponses[index + 1].items
-            ?.filter((item) => item.status.privacyStatus === 'public')
-            .slice(0, 4)
-        : []
-    ),
-  }))
 
   const props = {
     highestViewCountVideo,

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -368,7 +368,7 @@ export async function getServerSideProps({ params, req, res }) {
         headerData = { sectionsData: [], topicsData: [] }
         logAxiosError(
           err,
-          'Error occurs while getting header data in story page',
+          `Error occurs while getting header data in story page (slug: ${slug})`,
           globalLogFields
         )
       }
@@ -379,7 +379,7 @@ export async function getServerSideProps({ params, req, res }) {
         headerData = { sectionsData: [] }
         logAxiosError(
           err,
-          'Error occurs while getting premium header data in story page',
+          `Error occurs while getting premium header data in story page (slug: ${slug})`,
           globalLogFields
         )
       }
@@ -395,9 +395,11 @@ export async function getServerSideProps({ params, req, res }) {
   } catch (err) {
     logGqlError(
       err,
-      'Error occurs while getting data in story page',
+      `Error occurs while getting data in story page (slug: ${slug})`,
       globalLogFields
     )
-    throw new Error('Error occurs while getting data in story page')
+    throw new Error(
+      `Error occurs while getting data in story page (slug: ${slug})`
+    )
   }
 }

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -22,9 +22,9 @@ import {
   getResizedUrl,
   getCategoryOfWineSlug,
   getLogTraceObject,
-  logAxiosError,
   logGqlError,
 } from '../../utils'
+import { logAxiosError } from '../../utils/log/shared'
 import { handleStoryPageRedirect } from '../../utils/story'
 import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -2,14 +2,9 @@
 import React, { useState, useEffect, useMemo } from 'react'
 
 import client from '../../apollo/apollo-client'
-import errors from '@twreporter/errors'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
-import {
-  GCP_PROJECT_ID,
-  ENV,
-  TEST_GPT_AD_FEATURE_TOGGLE,
-} from '../../config/index.mjs'
+import { ENV, TEST_GPT_AD_FEATURE_TOGGLE } from '../../config/index.mjs'
 import WineWarning from '../../components/shared/wine-warning'
 import AdultOnlyWarning from '../../components/story/shared/adult-only-warning'
 import { useMembership } from '../../context/membership'
@@ -26,6 +21,9 @@ import {
   convertDraftToText,
   getResizedUrl,
   getCategoryOfWineSlug,
+  getLogTraceObject,
+  logAxiosError,
+  logGqlError,
 } from '../../utils'
 import { handleStoryPageRedirect } from '../../utils/story'
 import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
@@ -303,14 +301,8 @@ export async function getServerSideProps({ params, req, res }) {
   }
 
   const { slug } = params
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+  const globalLogFields = getLogTraceObject(req)
+
   try {
     const result = await client.query({
       query: fetchPostBySlug,
@@ -375,21 +367,10 @@ export async function getServerSideProps({ params, req, res }) {
         headerData = await fetchHeaderDataInDefaultPageLayout()
       } catch (err) {
         headerData = { sectionsData: [], topicsData: [] }
-        const errorMessage = errors.helpers.printAll(
+        logAxiosError(
           err,
-          {
-            withStack: true,
-            withPayload: false,
-          },
-          0,
-          0
-        )
-        console.log(
-          JSON.stringify({
-            severity: 'ERROR',
-            message: errorMessage,
-            ...globalLogFields,
-          })
+          'Error occurs while getting header data in story page',
+          globalLogFields
         )
       }
     } else if (shouldFetchPremiumHeaderData) {
@@ -397,21 +378,10 @@ export async function getServerSideProps({ params, req, res }) {
         headerData = await fetchHeaderDataInPremiumPageLayout()
       } catch (err) {
         headerData = { sectionsData: [] }
-        const errorMessage = errors.helpers.printAll(
+        logAxiosError(
           err,
-          {
-            withStack: true,
-            withPayload: false,
-          },
-          0,
-          0
-        )
-        console.log(
-          JSON.stringify({
-            severity: 'ERROR',
-            message: errorMessage,
-            ...globalLogFields,
-          })
+          'Error occurs while getting premium header data in story page',
+          globalLogFields
         )
       }
     }
@@ -424,34 +394,11 @@ export async function getServerSideProps({ params, req, res }) {
       },
     }
   } catch (err) {
-    const { graphQLErrors, clientErrors, networkError } = err
-    const annotatingError = errors.helpers.wrap(
+    logGqlError(
       err,
-      'UnhandledError',
-      'Error occurs while getting story page data'
+      'Error occurs while getting data in story page',
+      globalLogFields
     )
-
-    const errorMessage = errors.helpers.printAll(
-      annotatingError,
-      {
-        withStack: true,
-        withPayload: true,
-      },
-      0,
-      0
-    )
-    console.log(
-      JSON.stringify({
-        severity: 'ERROR',
-        message: errorMessage,
-        debugPayload: {
-          graphQLErrors,
-          clientErrors,
-          networkError,
-        },
-        ...globalLogFields,
-      })
-    )
-    throw new Error(errorMessage)
+    throw new Error('Error occurs while getting data in story page')
   }
 }

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -22,9 +22,8 @@ import {
   getResizedUrl,
   getCategoryOfWineSlug,
   getLogTraceObject,
-  logGqlError,
 } from '../../utils'
-import { logAxiosError } from '../../utils/log/shared'
+import { logAxiosError, logGqlError } from '../../utils/log/shared'
 import { handleStoryPageRedirect } from '../../utils/story'
 import { MirrorMedia } from '@mirrormedia/lilith-draft-renderer'
 import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -1,6 +1,5 @@
 import Head from 'next/head'
 
-import errors from '@twreporter/errors'
 import client from '../../../apollo/apollo-client'
 import Layout from '../../../components/shared/layout'
 import AmpHeader from '../../../components/amp/amp-header'
@@ -12,17 +11,14 @@ import {
   convertDraftToText,
   getResizedUrl,
   getActiveOrderSection,
+  getLogTraceObject,
+  logGqlError,
 } from '../../../utils'
 
 import { handleStoryPageRedirect } from '../../../utils/story'
 import { setPageCache } from '../../../utils/cache-setting'
 import { fetchPostBySlug } from '../../../apollo/query/posts'
-import {
-  GCP_PROJECT_ID,
-  ENV,
-  GA_MEASUREMENT_ID,
-  SITE_URL,
-} from '../../../config/index.mjs'
+import { ENV, GA_MEASUREMENT_ID, SITE_URL } from '../../../config/index.mjs'
 import styled from 'styled-components'
 import AdultOnlyWarning from '../../../components/story/shared/adult-only-warning'
 import WineWarning from '../../../components/shared/wine-warning'
@@ -193,14 +189,7 @@ export async function getServerSideProps({ params, req, res }) {
     setPageCache(res, { cachePolicy: 'no-store' }, req.url)
   }
   const { slug } = params
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+  const globalLogFields = getLogTraceObject(req)
 
   try {
     const result = await client.query({
@@ -261,34 +250,12 @@ export async function getServerSideProps({ params, req, res }) {
       },
     }
   } catch (err) {
-    const { graphQLErrors, clientErrors, networkError } = err
-    const annotatingError = errors.helpers.wrap(
+    logGqlError(
       err,
-      'UnhandledError',
-      'Error occurs while getting story page data'
+      'Error occurs while getting data in story amp page',
+      globalLogFields
     )
-    const errorMessage = errors.helpers.printAll(
-      annotatingError,
-      {
-        withStack: true,
-        withPayload: true,
-      },
-      0,
-      0
-    )
-    console.log(
-      JSON.stringify({
-        severity: 'ERROR',
-        message: errorMessage,
-        debugPayload: {
-          graphQLErrors,
-          clientErrors,
-          networkError,
-        },
-        ...globalLogFields,
-      })
-    )
-    throw new Error(errorMessage)
+    throw new Error('Error occurs while getting data in story amp page')
   }
 }
 

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -252,10 +252,12 @@ export async function getServerSideProps({ params, req, res }) {
   } catch (err) {
     logGqlError(
       err,
-      'Error occurs while getting data in story amp page',
+      `Error occurs while getting data in story amp page (slug: ${slug})`,
       globalLogFields
     )
-    throw new Error('Error occurs while getting data in story amp page')
+    throw new Error(
+      `Error occurs while getting data in story amp page (slug: ${slug})`
+    )
   }
 }
 

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -12,7 +12,6 @@ import {
   getResizedUrl,
   getActiveOrderSection,
   getLogTraceObject,
-  logGqlError,
 } from '../../../utils'
 
 import { handleStoryPageRedirect } from '../../../utils/story'
@@ -29,6 +28,7 @@ import AmpGptAd from '../../../components/amp/amp-ads/amp-gpt-ad'
 import AmpGptStickyAd from '../../../components/amp/amp-ads/amp-gpt-sticky-ad'
 import { getAmpGptDataSlotSection } from '../../../utils/ad'
 import JsonLdsScript from '../../../components/story/shared/json-lds-script'
+import { logGqlError } from '../../../utils/log/shared'
 
 export const config = { amp: true }
 

--- a/packages/mirror-media-next/pages/subscribe/index.js
+++ b/packages/mirror-media-next/pages/subscribe/index.js
@@ -15,7 +15,8 @@ import PlanForBasicMember from '../../components/subscribe/plan-basic-member'
 import PlanForMonthlyMember from '../../components/subscribe/plan-monthly-member'
 import PlanForYearlyMember from '../../components/subscribe/plan-yearly-member'
 import { ACCESS_SUBSCRIBE_FEATURE_TOGGLE } from '../../config/index.mjs'
-import { getLogTraceObject, handelAxiosResponse } from '../../utils'
+import { getLogTraceObject } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 
 const Page = styled.main`
   min-height: 70vh;
@@ -123,7 +124,7 @@ export async function getServerSideProps({ req, res }) {
     fetchHeaderDataInDefaultPageLayout(),
   ])
 
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in subscribe page',

--- a/packages/mirror-media-next/pages/subscribe/index.js
+++ b/packages/mirror-media-next/pages/subscribe/index.js
@@ -3,10 +3,8 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
 import styled from 'styled-components'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import Steps from '../../components/subscribe-steps'

--- a/packages/mirror-media-next/pages/subscribe/info.js
+++ b/packages/mirror-media-next/pages/subscribe/info.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
-import { GCP_PROJECT_ID } from '../../config/index.mjs'
 import { setPageCache } from '../../utils/cache-setting'
 import { ACCESS_SUBSCRIBE_FEATURE_TOGGLE } from '../../config/index.mjs'
+import { getLogTraceObject } from '../../utils'
 
 const Page = styled.main`
   min-height: 70vh;
@@ -26,14 +26,8 @@ export default SubscribeInfo
 export async function getServerSideProps({ req, res }) {
   setPageCache(res, { cachePolicy: 'no-store' }, req.url)
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+  /* eslint-disable-next-line no-unused-vars */
+  const globalLogFields = getLogTraceObject(req)
 
   if (ACCESS_SUBSCRIBE_FEATURE_TOGGLE !== 'on') {
     return {

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -3,11 +3,11 @@ import dynamic from 'next/dynamic'
 
 import TagArticles from '../../components/tag/tag-articles'
 import { ENV } from '../../config/index.mjs'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
 import {
-  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
   getPostsAndPostscountFromGqlData,
-} from '../../utils/api'
-import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
+} from '../../utils/data-process'
 import Layout from '../../components/shared/layout'
 import { Z_INDEX } from '../../constants/index'
 import { fetchPostsByTagSlug, fetchTagByTagSlug } from '../../utils/api/tag'

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -184,7 +184,7 @@ export async function getServerSideProps({ query, req, res }) {
   const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
-    'Error occurs while getting header data in tag page',
+    `Error occurs while getting header data in tag page (tagSlug: ${tagSlug})`,
     globalLogFields
   )
 
@@ -195,7 +195,7 @@ export async function getServerSideProps({ query, req, res }) {
     (gqlData) => {
       return gqlData?.data?.tag
     },
-    'Error occurs while getting tag data in tag page',
+    `Error occurs while getting tag data in tag page (tagSlug: ${tagSlug})`,
     globalLogFields
   )
 
@@ -214,7 +214,7 @@ export async function getServerSideProps({ query, req, res }) {
   const [postsCount, posts] = handleGqlResponse(
     responses[2],
     getPostsAndPostscountFromGqlData,
-    'Error occurs while getting post data in tag page',
+    `Error occurs while getting post data in tag page (tagSlug: ${tagSlug})`,
     globalLogFields
   )
 

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -6,8 +6,8 @@ import { ENV } from '../../config/index.mjs'
 import {
   fetchHeaderDataInDefaultPageLayout,
   getPostsAndPostscountFromGqlData,
-  getSectionAndTopicFromDefaultHeaderData,
 } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import Layout from '../../components/shared/layout'
 import { Z_INDEX } from '../../constants/index'
 import { fetchPostsByTagSlug, fetchTagByTagSlug } from '../../utils/api/tag'

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -20,11 +20,8 @@ const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 import { useCallback, useState } from 'react'
-import {
-  getLogTraceObject,
-  handelAxiosResponse,
-  handleGqlResponse,
-} from '../../utils'
+import { getLogTraceObject, handleGqlResponse } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 
 const TagContainer = styled.main`
   width: 320px;
@@ -181,7 +178,7 @@ export async function getServerSideProps({ query, req, res }) {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in tag page',

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -20,8 +20,11 @@ const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
 import GPTMbStAd from '../../components/ads/gpt/gpt-mb-st-ad'
 import GPT_Placeholder from '../../components/ads/gpt/gpt-placeholder'
 import { useCallback, useState } from 'react'
-import { getLogTraceObject, handleGqlResponse } from '../../utils'
-import { handleAxiosResponse } from '../../utils/response-handle'
+import { getLogTraceObject } from '../../utils'
+import {
+  handleAxiosResponse,
+  handleGqlResponse,
+} from '../../utils/response-handle'
 
 const TagContainer = styled.main`
   width: 320px;

--- a/packages/mirror-media-next/pages/topic/[slug].js
+++ b/packages/mirror-media-next/pages/topic/[slug].js
@@ -18,9 +18,9 @@ import {
   sortArrayWithOtherArrayId,
   handelAxiosResponse,
   handleGqlResponse,
-  logGqlError,
 } from '../../utils/index'
 import { fetchTopicByTopicSlug } from '../../utils/api/topic'
+import { logGqlError } from '../../utils/log/shared'
 
 const RENDER_PAGE_SIZE = 12
 const WINE_TOPICS_SLUG = [

--- a/packages/mirror-media-next/pages/topic/[slug].js
+++ b/packages/mirror-media-next/pages/topic/[slug].js
@@ -16,9 +16,11 @@ import {
   getLogTraceObject,
   getResizedUrl,
   sortArrayWithOtherArrayId,
-  handleGqlResponse,
 } from '../../utils/index'
-import { handleAxiosResponse } from '../../utils/response-handle'
+import {
+  handleAxiosResponse,
+  handleGqlResponse,
+} from '../../utils/response-handle'
 import { fetchTopicByTopicSlug } from '../../utils/api/topic'
 import { logGqlError } from '../../utils/log/shared'
 

--- a/packages/mirror-media-next/pages/topic/[slug].js
+++ b/packages/mirror-media-next/pages/topic/[slug].js
@@ -16,9 +16,9 @@ import {
   getLogTraceObject,
   getResizedUrl,
   sortArrayWithOtherArrayId,
-  handelAxiosResponse,
   handleGqlResponse,
 } from '../../utils/index'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import { fetchTopicByTopicSlug } from '../../utils/api/topic'
 import { logGqlError } from '../../utils/log/shared'
 
@@ -128,7 +128,7 @@ export async function getServerSideProps({ query, req, res }) {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in topic page',

--- a/packages/mirror-media-next/pages/topic/[slug].js
+++ b/packages/mirror-media-next/pages/topic/[slug].js
@@ -1,19 +1,24 @@
 // TODO: modify component `<WineWarning>`, no need to props `categories`
 
-import errors from '@twreporter/errors'
-
-import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
+import { ENV } from '../../config/index.mjs'
 import TopicList from '../../components/topic/list/topic-list'
 import TopicGroup from '../../components/topic/group/topic-group'
 import WineWarning from '../../components/shared/wine-warning'
-import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import {
+  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
+} from '../../utils/api'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { parseUrl } from '../../utils/topic'
 import {
   convertDraftToText,
+  getLogTraceObject,
   getResizedUrl,
   sortArrayWithOtherArrayId,
+  handelAxiosResponse,
+  handleGqlResponse,
+  logGqlError,
 } from '../../utils/index'
 import { fetchTopicByTopicSlug } from '../../utils/api/topic'
 
@@ -115,77 +120,34 @@ export async function getServerSideProps({ query, req, res }) {
   }
   const topicSlug = Array.isArray(query.slug) ? query.slug[0] : query.slug
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+  const globalLogFields = getLogTraceObject(req)
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
     fetchTopicByTopicSlug(topicSlug, RENDER_PAGE_SIZE, 0),
   ])
 
-  const handledResponses = responses.map((response, index) => {
-    if (response.status === 'fulfilled') {
-      if ('data' in response.value) {
-        // handle gql requests
-        return response.value.data
-      }
-      return response.value
-    } else if (response.status === 'rejected') {
-      const { graphQLErrors, clientErrors, networkError } = response.reason
-      const annotatingError = errors.helpers.wrap(
-        response.reason,
-        'UnhandledError',
-        'Error occurs while getting topic page data'
-      )
-
-      console.log(
-        JSON.stringify({
-          severity: 'ERROR',
-          message: errors.helpers.printAll(
-            annotatingError,
-            {
-              withStack: true,
-              withPayload: true,
-            },
-            0,
-            0
-          ),
-          debugPayload: {
-            graphQLErrors,
-            clientErrors,
-            networkError,
-          },
-          ...globalLogFields,
-        })
-      )
-      if (index === 1) {
-        // fetch key data (topic) failed, redirect to 500
-        throw new Error('fetch topic failed')
-      }
-      return
-    }
-  })
-
   // handle header data
-  const headerData =
-    handledResponses[0] && 'sectionsData' in handledResponses[0]
-      ? handledResponses[0]
-      : { sectionsData: [], topicsData: [] }
-  const sectionsData = Array.isArray(headerData.sectionsData)
-    ? headerData.sectionsData
-    : []
-  const topicsData = Array.isArray(headerData.topicsData)
-    ? headerData.topicsData
-    : []
+  const [sectionsData, topicsData] = handelAxiosResponse(
+    responses[0],
+    getSectionAndTopicFromDefaultHeaderData,
+    'Error occurs while getting header data in topic page',
+    globalLogFields
+  )
 
   // handle fetch topic data
-  if (handledResponses[1]?.topics?.length === 0) {
+  /** @type {Topic[]} */
+  const topics = handleGqlResponse(
+    responses[1],
+    (gqlData) => {
+      return gqlData?.data?.topics || []
+    },
+    'Error occurs while getting topics in topic page',
+    globalLogFields
+  )
+
+  const topic = topics[0]
+  if (!topic) {
     // fetchTopic return empty array -> wrong authorId -> 404
     console.log(
       JSON.stringify({
@@ -196,8 +158,7 @@ export async function getServerSideProps({ query, req, res }) {
     )
     return { notFound: true }
   }
-  /** @type {Topic} */
-  const topic = handledResponses[1]?.topics?.[0] || {}
+
   /** @type {SlideshowImage[]} */
   let slideshowImages = []
   if (topic.leading === 'slideshow' && topic.slideshow_images) {
@@ -210,6 +171,7 @@ export async function getServerSideProps({ query, req, res }) {
             manualOrderOfSlideshowImages
           )
   }
+
   /**
    * load all group articles at once
    * (potential performance [issue](https://nextjs.org/docs/messages/large-page-data))
@@ -218,6 +180,7 @@ export async function getServerSideProps({ query, req, res }) {
   if (topic.type === 'group' && topic.postsCount > RENDER_PAGE_SIZE) {
     let posts = topic.posts
     while (posts.length < topic.postsCount) {
+      /** @type {typeof posts} */
       let moreTopicPosts
       try {
         const topicData = await fetchTopicByTopicSlug(
@@ -227,32 +190,14 @@ export async function getServerSideProps({ query, req, res }) {
         )
         moreTopicPosts = topicData.data.topics?.[0].posts || []
       } catch (error) {
-        const annotatingError = errors.helpers.wrap(
+        logGqlError(
           error,
-          'GQLError',
-          `Fetch more topic post with topicId ${topicSlug} for group type in getServerSideProps failed`
-        )
-        const { graphQLErrors, clientErrors, networkError } = error
-
-        console.log(
-          JSON.stringify({
-            severity: 'ERROR',
-            message: errors.helpers.printAll(annotatingError, {
-              withStack: true,
-              withPayload: true,
-            }),
-            debugPayload: {
-              graphQLErrors,
-              clientErrors,
-              networkError,
-            },
-            ...globalLogFields,
-          })
+          `Fetch more topic post with topicId ${topicSlug} for group type in topic page failed at server-side`,
+          globalLogFields
         )
         // stop fetching cause there might be infinite loop
         break
       }
-      /** @type {Topic} */
       posts = [...posts, ...moreTopicPosts]
     }
     topic.posts = posts

--- a/packages/mirror-media-next/pages/topic/[slug].js
+++ b/packages/mirror-media-next/pages/topic/[slug].js
@@ -4,10 +4,8 @@ import { ENV } from '../../config/index.mjs'
 import TopicList from '../../components/topic/list/topic-list'
 import TopicGroup from '../../components/topic/group/topic-group'
 import WineWarning from '../../components/shared/wine-warning'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { setPageCache } from '../../utils/cache-setting'
 import Layout from '../../components/shared/layout'
 import { parseUrl } from '../../utils/topic'

--- a/packages/mirror-media-next/pages/topic/[slug].js
+++ b/packages/mirror-media-next/pages/topic/[slug].js
@@ -131,7 +131,7 @@ export async function getServerSideProps({ query, req, res }) {
   const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
-    'Error occurs while getting header data in topic page',
+    `Error occurs while getting header data in topic page (topicSlug: ${topicSlug})`,
     globalLogFields
   )
 
@@ -142,7 +142,7 @@ export async function getServerSideProps({ query, req, res }) {
     (gqlData) => {
       return gqlData?.data?.topics || []
     },
-    'Error occurs while getting topics in topic page',
+    `Error occurs while getting topics in topic page (topicSlug: ${topicSlug})`,
     globalLogFields
   )
 

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -29,11 +29,8 @@ import {
   GPT_Placeholder_MobileAndTablet,
 } from '../../components/ads/gpt/gpt-placeholder'
 import Head from 'next/head'
-import {
-  getLogTraceObject,
-  handelAxiosResponse,
-  logAxiosError,
-} from '../../utils'
+import { getLogTraceObject, handelAxiosResponse } from '../../utils'
+import { logAxiosError } from '../../utils/log/shared'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -1,10 +1,8 @@
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../../utils/api'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { ENV } from '../../config/index.mjs'
 import {
   simplifyYoutubeSearchedVideo,

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -29,7 +29,8 @@ import {
   GPT_Placeholder_MobileAndTablet,
 } from '../../components/ads/gpt/gpt-placeholder'
 import Head from 'next/head'
-import { getLogTraceObject, handelAxiosResponse } from '../../utils'
+import { getLogTraceObject } from '../../utils'
+import { handleAxiosResponse } from '../../utils/response-handle'
 import { logAxiosError } from '../../utils/log/shared'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
@@ -207,7 +208,7 @@ export async function getServerSideProps({ query, req, res }) {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in video page',
@@ -215,7 +216,7 @@ export async function getServerSideProps({ query, req, res }) {
   )
 
   // handle fetch video data
-  const videos = handelAxiosResponse(
+  const videos = handleAxiosResponse(
     responses[1],
     (
       /** @type {Awaited<ReturnType<typeof fetchYoutubeVideoByVideoId>>} */ axiosData

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -209,7 +209,7 @@ export async function getServerSideProps({ query, req, res }) {
   const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
-    'Error occurs while getting header data in video page',
+    `Error occurs while getting header data in video page (videoId: ${videoId})`,
     globalLogFields
   )
 
@@ -221,7 +221,7 @@ export async function getServerSideProps({ query, req, res }) {
     ) => {
       return axiosData ? axiosData.data?.items : []
     },
-    'Error occurs while getting video data in video page',
+    `Error occurs while getting video data in video page (videoId: ${videoId})`,
     globalLogFields
   )
 
@@ -254,7 +254,7 @@ export async function getServerSideProps({ query, req, res }) {
   } catch (error) {
     logAxiosError(
       error,
-      `Error occurs while getting latest videos of channel (${channelId}) in video page`,
+      `Error occurs while getting latest videos of channel (${channelId}) in video page (videoId: ${videoId})`,
       globalLogFields
     )
   }

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -1,9 +1,11 @@
-import errors from '@twreporter/errors'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
-import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api'
-import { GCP_PROJECT_ID, ENV } from '../../config/index.mjs'
+import {
+  fetchHeaderDataInDefaultPageLayout,
+  getSectionAndTopicFromDefaultHeaderData,
+} from '../../utils/api'
+import { ENV } from '../../config/index.mjs'
 import {
   simplifyYoutubeSearchedVideo,
   simplifyYoutubeVideo,
@@ -27,6 +29,11 @@ import {
   GPT_Placeholder_MobileAndTablet,
 } from '../../components/ads/gpt/gpt-placeholder'
 import Head from 'next/head'
+import {
+  getLogTraceObject,
+  handelAxiosResponse,
+  logAxiosError,
+} from '../../utils'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -195,67 +202,34 @@ export async function getServerSideProps({ query, req, res }) {
     })
   )
 
-  const traceHeader = req.headers?.['x-cloud-trace-context']
-  let globalLogFields = {}
-  if (traceHeader && !Array.isArray(traceHeader)) {
-    const [trace] = traceHeader.split('/')
-    globalLogFields[
-      'logging.googleapis.com/trace'
-    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
-  }
+  const globalLogFields = getLogTraceObject(req)
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
     fetchYoutubeVideoByVideoId(videoId),
   ])
 
-  const handledResponses = responses.map((response) => {
-    if (response.status === 'fulfilled') {
-      if ('data' in response.value) {
-        // handle simple axios request
-        return response.value.data
-      }
-      return response.value
-    } else if (response.status === 'rejected') {
-      const annotatingError = errors.helpers.wrap(
-        response.reason,
-        'UnhandledError',
-        'Error occurs white getting video page data'
-      )
-
-      console.log(
-        JSON.stringify({
-          severity: 'ERROR',
-          message: errors.helpers.printAll(
-            annotatingError,
-            {
-              withStack: true,
-              withPayload: true,
-            },
-            0,
-            0
-          ),
-          ...globalLogFields,
-        })
-      )
-      return
-    }
-  })
-
   // handle header data
-  const headerData =
-    handledResponses[0] && 'sectionsData' in handledResponses[0]
-      ? handledResponses[0]
-      : { sectionsData: [], topicsData: [] }
-  const sectionsData = Array.isArray(headerData.sectionsData)
-    ? headerData.sectionsData
-    : []
-  const topicsData = Array.isArray(headerData.topicsData)
-    ? headerData.topicsData
-    : []
+  const [sectionsData, topicsData] = handelAxiosResponse(
+    responses[0],
+    getSectionAndTopicFromDefaultHeaderData,
+    'Error occurs while getting header data in video page',
+    globalLogFields
+  )
 
   // handle fetch video data
-  if (handledResponses[1]?.items?.length === 0) {
+  const videos = handelAxiosResponse(
+    responses[1],
+    (
+      /** @type {Awaited<ReturnType<typeof fetchYoutubeVideoByVideoId>>} */ axiosData
+    ) => {
+      return axiosData ? axiosData.data?.items : []
+    },
+    'Error occurs while getting video data in video page',
+    globalLogFields
+  )
+
+  if (videos.length === 0) {
     console.log(
       JSON.stringify({
         severity: 'ERROR',
@@ -270,30 +244,23 @@ export async function getServerSideProps({ query, req, res }) {
       },
     }
   }
-  const video = handledResponses[1]?.items
-    ? simplifyYoutubeVideo(handledResponses[1]?.items)[0]
-    : { id: videoId, channelId: '' }
-  const channelId = video?.channelId
+
+  const video = simplifyYoutubeVideo(videos)[0]
+
+  const channelId = video.channelId
 
   /** @type {import('../../type/youtube').YoutubeVideo[]} */
   let latestVideos = []
-  if (channelId) {
-    try {
-      const { data } = await fetchYoutubeLatestVideosByChannelId(channelId)
-      latestVideos = simplifyYoutubeSearchedVideo(data.items)
-    } catch (error) {
-      const annotatingAxiosError = errors.helpers.annotateAxiosError(error)
-      console.error(
-        JSON.stringify({
-          severity: 'ERROR',
-          message: errors.helpers.printAll(annotatingAxiosError, {
-            withStack: true,
-            withPayload: true,
-          }),
-          ...globalLogFields,
-        })
-      )
-    }
+
+  try {
+    const { data } = await fetchYoutubeLatestVideosByChannelId(channelId)
+    latestVideos = simplifyYoutubeSearchedVideo(data.items)
+  } catch (error) {
+    logAxiosError(
+      error,
+      `Error occurs while getting latest videos of channel (${channelId}) in video page`,
+      globalLogFields
+    )
   }
 
   const props = {

--- a/packages/mirror-media-next/pages/video_category/[slug].js
+++ b/packages/mirror-media-next/pages/video_category/[slug].js
@@ -174,7 +174,7 @@ export async function getServerSideProps({ query, req, res }) {
   const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
-    'Error occurs while getting header data in video category page',
+    `Error occurs while getting header data in video category page (videoCategorySlug: ${videoCategorySlug})`,
     globalLogFields
   )
 
@@ -199,7 +199,7 @@ export async function getServerSideProps({ query, req, res }) {
 
       return [[], '']
     },
-    'Error occurs while getting playlist data in video category page',
+    `Error occurs while getting playlist data in video category page (videoCategorySlug: ${videoCategorySlug})`,
     globalLogFields
   )
 
@@ -208,7 +208,7 @@ export async function getServerSideProps({ query, req, res }) {
     (gqlData) => {
       return gqlData?.data?.category || { slug: videoCategorySlug }
     },
-    'Error occurs while getting category data in video category page',
+    `Error occurs while getting category data in video category page (videoCategorySlug: ${videoCategorySlug})`,
     globalLogFields
   )
 

--- a/packages/mirror-media-next/pages/video_category/[slug].js
+++ b/packages/mirror-media-next/pages/video_category/[slug].js
@@ -24,8 +24,11 @@ import {
   GPT_Placeholder_Desktop,
   GPT_Placeholder_MobileAndTablet,
 } from '../../components/ads/gpt/gpt-placeholder.js'
-import { getLogTraceObject, handleGqlResponse } from '../../utils/index.js'
-import { handleAxiosResponse } from '../../utils/response-handle.js'
+import { getLogTraceObject } from '../../utils/index.js'
+import {
+  handleAxiosResponse,
+  handleGqlResponse,
+} from '../../utils/response-handle.js'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,

--- a/packages/mirror-media-next/pages/video_category/[slug].js
+++ b/packages/mirror-media-next/pages/video_category/[slug].js
@@ -4,10 +4,8 @@ import { ENV } from '../../config/index.mjs'
 import CategoryVideos from '../../components/video_category/category-videos.js'
 import { VIDEOHUB_CATEGORIES_PLAYLIST_MAPPING } from '../../constants/index.js'
 import styled from 'styled-components'
-import {
-  fetchHeaderDataInDefaultPageLayout,
-  getSectionAndTopicFromDefaultHeaderData,
-} from '../../utils/api/index.js'
+import { fetchHeaderDataInDefaultPageLayout } from '../../utils/api/index.js'
+import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { simplifyYoutubePlaylistVideo } from '../../utils/youtube.js'
 import { setPageCache } from '../../utils/cache-setting.js'
 import LeadingVideo from '../../components/shared/leading-video.js'

--- a/packages/mirror-media-next/pages/video_category/[slug].js
+++ b/packages/mirror-media-next/pages/video_category/[slug].js
@@ -24,11 +24,8 @@ import {
   GPT_Placeholder_Desktop,
   GPT_Placeholder_MobileAndTablet,
 } from '../../components/ads/gpt/gpt-placeholder.js'
-import {
-  getLogTraceObject,
-  handelAxiosResponse,
-  handleGqlResponse,
-} from '../../utils/index.js'
+import { getLogTraceObject, handleGqlResponse } from '../../utils/index.js'
+import { handleAxiosResponse } from '../../utils/response-handle.js'
 
 const GPTAd = dynamic(() => import('../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -173,7 +170,7 @@ export async function getServerSideProps({ query, req, res }) {
   ])
 
   // handle header data
-  const [sectionsData, topicsData] = handelAxiosResponse(
+  const [sectionsData, topicsData] = handleAxiosResponse(
     responses[0],
     getSectionAndTopicFromDefaultHeaderData,
     'Error occurs while getting header data in video category page',
@@ -181,7 +178,7 @@ export async function getServerSideProps({ query, req, res }) {
   )
 
   // handle fetch videos and get nextPageToken for infinite scroll
-  const [videos, ytNextPageToken] = handelAxiosResponse(
+  const [videos, ytNextPageToken] = handleAxiosResponse(
     responses[1],
     (
       /** @type {Awaited<ReturnType<typeof fetchYoutubePlaylistByPlaylistId>>} */ axiosData

--- a/packages/mirror-media-next/service-worker/index.js
+++ b/packages/mirror-media-next/service-worker/index.js
@@ -22,6 +22,8 @@ const ignorePaths = [
   '\u002Fhodo_adject.php',
 ]
 
+const mustNotIgnorePaths = ['\u002F_next\u002Fdata']
+
 importScripts('https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js')
 importScripts('https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js')
 /* eslint-disable-next-line no-undef */
@@ -103,8 +105,19 @@ self.addEventListener('fetch', (event) => {
     return path.test(url.pathname.slice(1))
   })
 
+  const mustNotIgnore = mustNotIgnorePaths.some((path) => {
+    if (typeof path === 'string') {
+      return url.pathname.startsWith(path)
+    }
+
+    return path.test(url.pathname.slice(1))
+  })
+
   // https://github.com/nuxt-community/firebase-module/issues/465
-  if (!expectsHTML || !isSameOrigin || !isHttps || isIgnored) {
+  if (
+    (!expectsHTML || !isSameOrigin || !isHttps || isIgnored) &&
+    !mustNotIgnore
+  ) {
     event.respondWith(fetch(event.request))
 
     return

--- a/packages/mirror-media-next/utils/api/externals.js
+++ b/packages/mirror-media-next/utils/api/externals.js
@@ -14,78 +14,53 @@ import { fetchExternals } from '../../apollo/query/externals'
  * @param {number} page
  * @param {number} renderPageSize
  * @param {string | string[]} [partnerSlug]
- * @returns {Promise<ListingExternal[]>}
+ * @returns {Promise<ExternalsQueryResult>}
  */
 
 /**
  * @callback FetchExternalsWhichPartnerIsNotShowOnIndex
  * @param {number} page
  * @param {number} renderPageSize
- * @returns {Promise<ListingExternal[]>}
+ * @returns {Promise<ExternalsQueryResult>}
  */
 
 /**
  * @type {FetchExternalsByPartnerSlug}
  */
-const fetchExternalsByPartnerSlug = async (
-  page,
-  renderPageSize,
-  partnerSlug
-) => {
+const fetchExternalsByPartnerSlug = (page, renderPageSize, partnerSlug) => {
   const partnerSlugForFetch = Array.isArray(partnerSlug)
     ? partnerSlug[0]
     : partnerSlug
-  try {
-    /**
-     * @type {ExternalsQueryResult}
-     */
-    const response = await client.query({
-      query: fetchExternals,
-      variables: {
-        take: renderPageSize * 2,
-        skip: (page - 1) * renderPageSize * 2,
-        orderBy: { publishedDate: 'desc' },
-        filter: {
-          state: { equals: 'published' },
-          partner: { slug: { equals: partnerSlugForFetch } },
-        },
+  return client.query({
+    query: fetchExternals,
+    variables: {
+      take: renderPageSize * 2,
+      skip: (page - 1) * renderPageSize * 2,
+      orderBy: { publishedDate: 'desc' },
+      filter: {
+        state: { equals: 'published' },
+        partner: { slug: { equals: partnerSlugForFetch } },
       },
-    })
-    return response.data.externals
-  } catch (error) {
-    console.error(error)
-  }
-  return
+    },
+  })
 }
 
 /**
  * @type {FetchExternalsWhichPartnerIsNotShowOnIndex}
  */
-const fetchExternalsWhichPartnerIsNotShowOnIndex = async (
-  page,
-  renderPageSize
-) => {
-  try {
-    /**
-     * @type {ExternalsQueryResult}
-     */
-    const response = await client.query({
-      query: fetchExternals,
-      variables: {
-        take: renderPageSize * 2,
-        skip: (page - 1) * renderPageSize * 2,
-        orderBy: { publishedDate: 'desc' },
-        filter: {
-          state: { equals: 'published' },
-          partner: { showOnIndex: { equals: false } },
-        },
+const fetchExternalsWhichPartnerIsNotShowOnIndex = (page, renderPageSize) => {
+  return client.query({
+    query: fetchExternals,
+    variables: {
+      take: renderPageSize * 2,
+      skip: (page - 1) * renderPageSize * 2,
+      orderBy: { publishedDate: 'desc' },
+      filter: {
+        state: { equals: 'published' },
+        partner: { showOnIndex: { equals: false } },
       },
-    })
-    return response.data.externals
-  } catch (error) {
-    console.error(error)
-  }
-  return
+    },
+  })
 }
 
 export {

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -148,9 +148,27 @@ const getSectionAndTopicFromDefaultHeaderData = (headerData) => {
 
   return [sectionData, topicsData]
 }
+
+/**
+ * @param {Awaited<ReturnType<typeof fetchHeaderDataInPremiumPageLayout>> | undefined} headerData
+ * @returns {HeadersData}
+ */
+const getSectionFromPremiumHeaderData = (headerData) => {
+  /** @type {HeadersData} */
+  let sectionData = []
+
+  if (headerData) {
+    if (Array.isArray(headerData['sectionsData']))
+      sectionData = headerData['sectionsData']
+  }
+
+  return sectionData
+}
+
 export {
   fetchHeaderDataInDefaultPageLayout,
   fetchHeaderDataInPremiumPageLayout,
   fetchPodcastList,
   getSectionAndTopicFromDefaultHeaderData,
+  getSectionFromPremiumHeaderData,
 }

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -165,10 +165,27 @@ const getSectionFromPremiumHeaderData = (headerData) => {
   return sectionData
 }
 
+/**
+ * @template T
+ * @param {import('@apollo/client').ApolloQueryResult<any> | undefined} gqlData
+ * @returns {[number, T[]]}
+ */
+const getPostsAndPostscountFromGqlData = (gqlData) => {
+  if (!gqlData) {
+    return [0, []]
+  }
+
+  const data = gqlData.data
+  const postsCount = data?.postsCount || 0
+  const posts = data?.posts || []
+  return [postsCount, posts]
+}
+
 export {
   fetchHeaderDataInDefaultPageLayout,
   fetchHeaderDataInPremiumPageLayout,
   fetchPodcastList,
   getSectionAndTopicFromDefaultHeaderData,
   getSectionFromPremiumHeaderData,
+  getPostsAndPostscountFromGqlData,
 }

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -130,22 +130,6 @@ const fetchHeaderDataInPremiumPageLayout = async () => {
 }
 
 /**
- * @param {Awaited<ReturnType<typeof fetchHeaderDataInPremiumPageLayout>> | undefined} headerData
- * @returns {HeadersData}
- */
-const getSectionFromPremiumHeaderData = (headerData) => {
-  /** @type {HeadersData} */
-  let sectionData = []
-
-  if (headerData) {
-    if (Array.isArray(headerData['sectionsData']))
-      sectionData = headerData['sectionsData']
-  }
-
-  return sectionData
-}
-
-/**
  * @template T
  * @param {import('@apollo/client').ApolloQueryResult<any> | undefined} gqlData
  * @returns {[number, T[]]}
@@ -165,6 +149,5 @@ export {
   fetchHeaderDataInDefaultPageLayout,
   fetchHeaderDataInPremiumPageLayout,
   fetchPodcastList,
-  getSectionFromPremiumHeaderData,
   getPostsAndPostscountFromGqlData,
 }

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -128,8 +128,29 @@ const fetchHeaderDataInPremiumPageLayout = async () => {
     errorLogger(err)
   }
 }
+
+/**
+ * @param {Awaited<ReturnType<typeof fetchHeaderDataInDefaultPageLayout>> | undefined} headerData
+ * @returns {[HeadersData, Topics]}
+ */
+const getSectionAndTopicFromDefaultHeaderData = (headerData) => {
+  /** @type {HeadersData} */
+  let sectionData = []
+  /** @type {Topics} */
+  let topicsData = []
+
+  if (headerData) {
+    if (Array.isArray(headerData['sectionsData']))
+      sectionData = headerData['sectionsData']
+    if (Array.isArray(headerData['topicsData']))
+      topicsData = headerData['topicsData']
+  }
+
+  return [sectionData, topicsData]
+}
 export {
   fetchHeaderDataInDefaultPageLayout,
   fetchHeaderDataInPremiumPageLayout,
   fetchPodcastList,
+  getSectionAndTopicFromDefaultHeaderData,
 }

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -129,25 +129,8 @@ const fetchHeaderDataInPremiumPageLayout = async () => {
   }
 }
 
-/**
- * @template T
- * @param {import('@apollo/client').ApolloQueryResult<any> | undefined} gqlData
- * @returns {[number, T[]]}
- */
-const getPostsAndPostscountFromGqlData = (gqlData) => {
-  if (!gqlData) {
-    return [0, []]
-  }
-
-  const data = gqlData.data
-  const postsCount = data?.postsCount || 0
-  const posts = data?.posts || []
-  return [postsCount, posts]
-}
-
 export {
   fetchHeaderDataInDefaultPageLayout,
   fetchHeaderDataInPremiumPageLayout,
   fetchPodcastList,
-  getPostsAndPostscountFromGqlData,
 }

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -130,26 +130,6 @@ const fetchHeaderDataInPremiumPageLayout = async () => {
 }
 
 /**
- * @param {Awaited<ReturnType<typeof fetchHeaderDataInDefaultPageLayout>> | undefined} headerData
- * @returns {[HeadersData, Topics]}
- */
-const getSectionAndTopicFromDefaultHeaderData = (headerData) => {
-  /** @type {HeadersData} */
-  let sectionData = []
-  /** @type {Topics} */
-  let topicsData = []
-
-  if (headerData) {
-    if (Array.isArray(headerData['sectionsData']))
-      sectionData = headerData['sectionsData']
-    if (Array.isArray(headerData['topicsData']))
-      topicsData = headerData['topicsData']
-  }
-
-  return [sectionData, topicsData]
-}
-
-/**
  * @param {Awaited<ReturnType<typeof fetchHeaderDataInPremiumPageLayout>> | undefined} headerData
  * @returns {HeadersData}
  */
@@ -185,7 +165,6 @@ export {
   fetchHeaderDataInDefaultPageLayout,
   fetchHeaderDataInPremiumPageLayout,
   fetchPodcastList,
-  getSectionAndTopicFromDefaultHeaderData,
   getSectionFromPremiumHeaderData,
   getPostsAndPostscountFromGqlData,
 }

--- a/packages/mirror-media-next/utils/data-process.js
+++ b/packages/mirror-media-next/utils/data-process.js
@@ -1,5 +1,6 @@
 /**
  * @typedef {import('./api/index').fetchHeaderDataInDefaultPageLayout} fetchHeaderDataInDefaultPageLayout
+ * @typedef {import('./api/index').fetchHeaderDataInPremiumPageLayout} fetchHeaderDataInPremiumPageLayout
  * @typedef {import('./api/index').HeadersData} HeadersData
  * @typedef {import('./api/index').Topics} Topics
  */
@@ -24,4 +25,23 @@ const getSectionAndTopicFromDefaultHeaderData = (headerData) => {
   return [sectionData, topicsData]
 }
 
-export { getSectionAndTopicFromDefaultHeaderData }
+/**
+ * @param {Awaited<ReturnType<fetchHeaderDataInPremiumPageLayout>> | undefined} headerData
+ * @returns {HeadersData}
+ */
+const getSectionFromPremiumHeaderData = (headerData) => {
+  /** @type {HeadersData} */
+  let sectionData = []
+
+  if (headerData) {
+    if (Array.isArray(headerData['sectionsData']))
+      sectionData = headerData['sectionsData']
+  }
+
+  return sectionData
+}
+
+export {
+  getSectionAndTopicFromDefaultHeaderData,
+  getSectionFromPremiumHeaderData,
+}

--- a/packages/mirror-media-next/utils/data-process.js
+++ b/packages/mirror-media-next/utils/data-process.js
@@ -1,0 +1,27 @@
+/**
+ * @typedef {import('./api/index').fetchHeaderDataInDefaultPageLayout} fetchHeaderDataInDefaultPageLayout
+ * @typedef {import('./api/index').HeadersData} HeadersData
+ * @typedef {import('./api/index').Topics} Topics
+ */
+
+/**
+ * @param {Awaited<ReturnType<fetchHeaderDataInDefaultPageLayout>> | undefined} headerData
+ * @returns {[HeadersData, Topics]}
+ */
+const getSectionAndTopicFromDefaultHeaderData = (headerData) => {
+  /** @type {HeadersData} */
+  let sectionData = []
+  /** @type {Topics} */
+  let topicsData = []
+
+  if (headerData) {
+    if (Array.isArray(headerData['sectionsData']))
+      sectionData = headerData['sectionsData']
+    if (Array.isArray(headerData['topicsData']))
+      topicsData = headerData['topicsData']
+  }
+
+  return [sectionData, topicsData]
+}
+
+export { getSectionAndTopicFromDefaultHeaderData }

--- a/packages/mirror-media-next/utils/data-process.js
+++ b/packages/mirror-media-next/utils/data-process.js
@@ -41,7 +41,24 @@ const getSectionFromPremiumHeaderData = (headerData) => {
   return sectionData
 }
 
+/**
+ * @template T
+ * @param {import('@apollo/client').ApolloQueryResult<any> | undefined} gqlData
+ * @returns {[number, T[]]}
+ */
+const getPostsAndPostscountFromGqlData = (gqlData) => {
+  if (!gqlData) {
+    return [0, []]
+  }
+
+  const data = gqlData.data
+  const postsCount = data?.postsCount || 0
+  const posts = data?.posts || []
+  return [postsCount, posts]
+}
+
 export {
   getSectionAndTopicFromDefaultHeaderData,
   getSectionFromPremiumHeaderData,
+  getPostsAndPostscountFromGqlData,
 }

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -3,6 +3,7 @@ import utc from 'dayjs/plugin/utc'
 import errors from '@twreporter/errors'
 import { GCP_PROJECT_ID } from '../config/index.mjs'
 import { ApolloError } from '@apollo/client'
+import { logAxiosError } from './log/shared'
 
 /**
  * @typedef {import('../apollo/fragments/section').Section[]} Sections
@@ -418,38 +419,6 @@ const getLogTraceObject = (req) => {
 }
 
 /**
- * @param {Error | import('axios').AxiosError} axiosErrors
- * @param {string} errorMessage
- * @param {Record<string, any> | undefined} traceObject
- */
-const logAxiosError = (axiosErrors, errorMessage, traceObject) => {
-  const annotatingError = errors.helpers.wrap(
-    axiosErrors,
-    'UnhandledError',
-    errorMessage
-  )
-
-  console.error(
-    JSON.stringify({
-      severity: 'ERROR',
-      message: errors.helpers.printAll(
-        annotatingError,
-        {
-          withStack: true,
-          withPayload: true,
-        },
-        0,
-        0
-      ),
-      debugPayload: {
-        axiosErrors,
-      },
-      ...(traceObject ?? {}),
-    })
-  )
-}
-
-/**
  * @template {import('axios').AxiosResponse['data']} T
  * @template {PromiseSettledResult<T>} U
  * @template V
@@ -578,6 +547,5 @@ export {
   getLogTraceObject,
   handelAxiosResponse,
   handleGqlResponse,
-  logAxiosError,
   logGqlError,
 }

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
+import { GCP_PROJECT_ID } from '../config/index.mjs'
 
 /**
  * @typedef {import('../apollo/fragments/section').Section[]} Sections
@@ -397,6 +398,21 @@ const getSearchParamFromApiKeyUrl = (query, key) => {
   return new URLSearchParams(apiKeyUrl).get(key)
 }
 
+/**
+ * @param {import('http').IncomingMessage} req
+ */
+const getLogTraceObject = (req) => {
+  const traceHeader = req?.headers?.['x-cloud-trace-context']
+  let globalLogFields = {}
+  if (traceHeader && !Array.isArray(traceHeader)) {
+    const [trace] = traceHeader.split('/')
+    globalLogFields[
+      'logging.googleapis.com/trace'
+    ] = `projects/${GCP_PROJECT_ID}/traces/${trace}`
+  }
+  return globalLogFields
+}
+
 export {
   transformTimeDataIntoDotFormat,
   transformTimeDataIntoSlashFormat,
@@ -418,4 +434,5 @@ export {
   isServer,
   getClientSideOnlyError,
   getSearchParamFromApiKeyUrl,
+  getLogTraceObject,
 }

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -463,6 +463,57 @@ const handelAxiosResponse = (
   return dataHandler(undefined)
 }
 
+/**
+ * @template S
+ * @template {import('@apollo/client').ApolloQueryResult<S>} T
+ * @template {PromiseSettledResult<T>} U
+ * @template V
+ *
+ * @param {U} response
+ * @param {(value: T | undefined) => V} dataHandler
+ * @param {string} errorMessage
+ * @param {Record<string, any>} [traceObject]
+ */
+const handleGqlResponse = (
+  response,
+  dataHandler,
+  errorMessage,
+  traceObject
+) => {
+  if (response.status === 'fulfilled') {
+    return dataHandler(response.value)
+  } else if (response.status === 'rejected') {
+    const { graphQLErrors, clientErrors, networkError } = response.reason
+    const annotatingError = errors.helpers.wrap(
+      response.reason,
+      'UnhandledError',
+      errorMessage
+    )
+
+    console.error(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(
+          annotatingError,
+          {
+            withStack: true,
+            withPayload: true,
+          },
+          0,
+          0
+        ),
+        debugPayload: {
+          graphQLErrors,
+          clientErrors,
+          networkError,
+        },
+        ...(traceObject ?? {}),
+      })
+    )
+  }
+  return dataHandler(undefined)
+}
+
 export {
   transformTimeDataIntoDotFormat,
   transformTimeDataIntoSlashFormat,
@@ -486,4 +537,5 @@ export {
   getSearchParamFromApiKeyUrl,
   getLogTraceObject,
   handelAxiosResponse,
+  handleGqlResponse,
 }

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { GCP_PROJECT_ID } from '../config/index.mjs'
-import { logAxiosError, logGqlError } from './log/shared'
+import { logGqlError } from './log/shared'
 
 /**
  * @typedef {import('../apollo/fragments/section').Section[]} Sections
@@ -417,30 +417,6 @@ const getLogTraceObject = (req) => {
 }
 
 /**
- * @template {import('axios').AxiosResponse['data']} T
- * @template {PromiseSettledResult<T>} U
- * @template V
- *
- * @param {U} response
- * @param {(value: T | undefined) => V} dataHandler
- * @param {Parameters<typeof logAxiosError>[1]} errorMessage
- * @param {Parameters<typeof logAxiosError>[2]} [traceObject]
- */
-const handelAxiosResponse = (
-  response,
-  dataHandler,
-  errorMessage,
-  traceObject
-) => {
-  if (response.status === 'fulfilled') {
-    return dataHandler(response.value)
-  } else if (response.status === 'rejected') {
-    logAxiosError(response.reason, errorMessage, traceObject)
-  }
-  return dataHandler(undefined)
-}
-
-/**
  * @template S
  * @template {import('@apollo/client').ApolloQueryResult<S>} T
  * @template {PromiseSettledResult<T>} U
@@ -487,6 +463,5 @@ export {
   getClientSideOnlyError,
   getSearchParamFromApiKeyUrl,
   getLogTraceObject,
-  handelAxiosResponse,
   handleGqlResponse,
 }

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -143,8 +143,10 @@ const transformTimeDataIntoSlashFormat = (time, includeTime = true) => {
 //TODO: add more specific type in param `arrayNeedToSort` and `arraySortReference`
 /**
  * Sorts an array of objects based on the order of ids in another array of objects.
- * @param {Object[]} arrayNeedToSort
- * @param {Object[]} arraySortReference
+ * @template {{ id: any }} T
+ * @template {{ id: any }} S
+ * @param {T[]} arrayNeedToSort
+ * @param {S[]} arraySortReference
  */
 const sortArrayWithOtherArrayId = (arrayNeedToSort, arraySortReference) => {
   const sortedArray = arrayNeedToSort.slice().sort((a, b) => {

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { GCP_PROJECT_ID } from '../config/index.mjs'
-import { logGqlError } from './log/shared'
 
 /**
  * @typedef {import('../apollo/fragments/section').Section[]} Sections
@@ -416,31 +415,6 @@ const getLogTraceObject = (req) => {
   return globalLogFields
 }
 
-/**
- * @template S
- * @template {import('@apollo/client').ApolloQueryResult<S>} T
- * @template {PromiseSettledResult<T>} U
- * @template V
- *
- * @param {U} response
- * @param {(value: T | undefined) => V} dataHandler
- * @param {Parameters<typeof logGqlError>[1]} errorMessage
- * @param {Parameters<typeof logGqlError>[2]} [traceObject]
- */
-const handleGqlResponse = (
-  response,
-  dataHandler,
-  errorMessage,
-  traceObject
-) => {
-  if (response.status === 'fulfilled') {
-    return dataHandler(response.value)
-  } else if (response.status === 'rejected') {
-    logGqlError(response.reason, errorMessage, traceObject)
-  }
-  return dataHandler(undefined)
-}
-
 export {
   transformTimeDataIntoDotFormat,
   transformTimeDataIntoSlashFormat,
@@ -463,5 +437,4 @@ export {
   getClientSideOnlyError,
   getSearchParamFromApiKeyUrl,
   getLogTraceObject,
-  handleGqlResponse,
 }

--- a/packages/mirror-media-next/utils/index.js
+++ b/packages/mirror-media-next/utils/index.js
@@ -1,9 +1,7 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import errors from '@twreporter/errors'
 import { GCP_PROJECT_ID } from '../config/index.mjs'
-import { ApolloError } from '@apollo/client'
-import { logAxiosError } from './log/shared'
+import { logAxiosError, logGqlError } from './log/shared'
 
 /**
  * @typedef {import('../apollo/fragments/section').Section[]} Sections
@@ -443,62 +441,6 @@ const handelAxiosResponse = (
 }
 
 /**
- * @param {Error | import('@apollo/client/errors').ApolloError} gqlErrors
- * @param {string} errorMessage
- * @param {Record<string, any> | undefined} traceObject
- */
-const logGqlError = (gqlErrors, errorMessage, traceObject) => {
-  const annotatingError = errors.helpers.wrap(
-    gqlErrors,
-    'UnhandledError',
-    errorMessage
-  )
-
-  if (gqlErrors instanceof ApolloError) {
-    const { graphQLErrors, clientErrors, networkError } = gqlErrors
-    console.error(
-      JSON.stringify({
-        severity: 'ERROR',
-        message: errors.helpers.printAll(
-          annotatingError,
-          {
-            withStack: true,
-            withPayload: true,
-          },
-          0,
-          0
-        ),
-        debugPayload: {
-          graphQLErrors,
-          clientErrors,
-          networkError,
-        },
-        ...(traceObject ?? {}),
-      })
-    )
-  } else {
-    console.error(
-      JSON.stringify({
-        severity: 'ERROR',
-        message: errors.helpers.printAll(
-          annotatingError,
-          {
-            withStack: true,
-            withPayload: true,
-          },
-          0,
-          0
-        ),
-        debugPayload: {
-          gqlErrors,
-        },
-        ...(traceObject ?? {}),
-      })
-    )
-  }
-}
-
-/**
  * @template S
  * @template {import('@apollo/client').ApolloQueryResult<S>} T
  * @template {PromiseSettledResult<T>} U
@@ -547,5 +489,4 @@ export {
   getLogTraceObject,
   handelAxiosResponse,
   handleGqlResponse,
-  logGqlError,
 }

--- a/packages/mirror-media-next/utils/log/shared.js
+++ b/packages/mirror-media-next/utils/log/shared.js
@@ -1,4 +1,5 @@
 import Bowser from 'bowser'
+import errors from '@twreporter/errors'
 
 function getBrowserInfo(userAgent = '') {
   if (!userAgent) {
@@ -90,10 +91,43 @@ function getFormattedPageType(pathname = '', isMemberArticle = false) {
   }
 }
 
+/**
+ * @param {Error | import('axios').AxiosError} axiosErrors
+ * @param {string} errorMessage
+ * @param {Record<string, any> | undefined} traceObject
+ */
+const logAxiosError = (axiosErrors, errorMessage, traceObject) => {
+  const annotatingError = errors.helpers.wrap(
+    axiosErrors,
+    'UnhandledError',
+    errorMessage
+  )
+
+  console.error(
+    JSON.stringify({
+      severity: 'ERROR',
+      message: errors.helpers.printAll(
+        annotatingError,
+        {
+          withStack: true,
+          withPayload: true,
+        },
+        0,
+        0
+      ),
+      debugPayload: {
+        axiosErrors,
+      },
+      ...(traceObject ?? {}),
+    })
+  )
+}
+
 export {
   getBrowserInfo,
   getDeviceInfo,
   detectIsInApp,
   getWindowSizeInfo,
   getFormattedPageType,
+  logAxiosError,
 }

--- a/packages/mirror-media-next/utils/redirect-to-login-while-unauthed.js
+++ b/packages/mirror-media-next/utils/redirect-to-login-while-unauthed.js
@@ -64,7 +64,7 @@ const redirectToLoginWhileUnauthed =
     /** @type {import('next').GetServerSideProps<P, Q, D>} */ getServerSidePropsFunc
   ) =>
   async (/** @type {SSRPropsContext<Q, D>} */ ctx) => {
-    const { req, query } = ctx
+    const { req, query, resolvedUrl } = ctx
     const authToken = req.headers.authorization?.split(' ')[1]
 
     try {
@@ -113,7 +113,7 @@ const redirectToLoginWhileUnauthed =
       const searchParamsObject = new URLSearchParams(query)
       searchParamsObject.set(
         'destination',
-        new URL(req.url, 'https://www.google.com').pathname
+        new URL(resolvedUrl, 'https://www.google.com').pathname
       )
       const searchParams = searchParamsObject.toString()
       const destination = `/login?${searchParams}`

--- a/packages/mirror-media-next/utils/response-handle.js
+++ b/packages/mirror-media-next/utils/response-handle.js
@@ -1,4 +1,4 @@
-import { logAxiosError } from './log/shared'
+import { logAxiosError, logGqlError } from './log/shared'
 
 /**
  * @template {import('axios').AxiosResponse['data']} T
@@ -24,4 +24,29 @@ const handleAxiosResponse = (
   return dataHandler(undefined)
 }
 
-export { handleAxiosResponse }
+/**
+ * @template S
+ * @template {import('@apollo/client').ApolloQueryResult<S>} T
+ * @template {PromiseSettledResult<T>} U
+ * @template V
+ *
+ * @param {U} response
+ * @param {(value: T | undefined) => V} dataHandler
+ * @param {Parameters<typeof logGqlError>[1]} errorMessage
+ * @param {Parameters<typeof logGqlError>[2]} [traceObject]
+ */
+const handleGqlResponse = (
+  response,
+  dataHandler,
+  errorMessage,
+  traceObject
+) => {
+  if (response.status === 'fulfilled') {
+    return dataHandler(response.value)
+  } else if (response.status === 'rejected') {
+    logGqlError(response.reason, errorMessage, traceObject)
+  }
+  return dataHandler(undefined)
+}
+
+export { handleAxiosResponse, handleGqlResponse }

--- a/packages/mirror-media-next/utils/response-handle.js
+++ b/packages/mirror-media-next/utils/response-handle.js
@@ -1,0 +1,27 @@
+import { logAxiosError } from './log/shared'
+
+/**
+ * @template {import('axios').AxiosResponse['data']} T
+ * @template {PromiseSettledResult<T>} U
+ * @template V
+ *
+ * @param {U} response
+ * @param {(value: T | undefined) => V} dataHandler
+ * @param {Parameters<typeof logAxiosError>[1]} errorMessage
+ * @param {Parameters<typeof logAxiosError>[2]} [traceObject]
+ */
+const handleAxiosResponse = (
+  response,
+  dataHandler,
+  errorMessage,
+  traceObject
+) => {
+  if (response.status === 'fulfilled') {
+    return dataHandler(response.value)
+  } else if (response.status === 'rejected') {
+    logAxiosError(response.reason, errorMessage, traceObject)
+  }
+  return dataHandler(undefined)
+}
+
+export { handleAxiosResponse }


### PR DESCRIPTION
## Notable Changes
內容雖然多，但分幾個部份來說明
### 增加一些 utility function
* `handleGqlResponse` - 處理 Promise.allsettled 的結果是 gql result 的情況
* `handelAxiosResponse` - 處理 Promise.allsettled 的結果是 axios result 的情況
* `logGqlError` - 記錄 gql 錯誤
* `logAxiosError` - 記錄 axios 錯誤
* `getSectionAndTopicFromDefaultHeaderData` - 針對 `fetchHeaderDataInDefaultPageLayout` 的輸出結果，取得 header 顯示所需資訊
* `getSectionFromPremiumHeaderData` - 針對  `fetchHeaderDataInPremiumPageLayout` 的輸出結果，取得 header 顯示所需資訊
* `getPostsAndPostscountFromGqlData` - 從特定 gql 結果取得文章與文章數資料
* `getLogTraceObject` - 取得 gcp log trace 所需資訊

### 改善或修正錯誤訊息的內容

### 以下路徑補上 header 資料
* `/login`
* `/recover-password`
* `/email-handler`
* `/password-change-success`
* `/password-change-fail`

### 以下路徑套用 server 端會員驗證處理
* `/mgaazine`
* `/magazine/[book]/[issue]`

## Reminders
* `/magazine/[book]/[issue]` 在 3.0 實作上沒看到會員驗證處理的邏輯，但在 2.0 有，應該是當初實作上的遺漏
