### PR TITLE
refactor(search): update getSearchResult and `/search/v3`

### DIFF
--- a/packages/mirror-media-search/components/searched-articles.js
+++ b/packages/mirror-media-search/components/searched-articles.js
@@ -22,15 +22,27 @@ const Loading = styled.div`
 `
 
 export default function SearchedArticles({ searchResult }) {
-  const {
-    items: initialArticles,
-    queries,
-    searchInformation = {},
-  } = searchResult
-  const { totalResults = 0 } = searchInformation
+  const { items: initialArticles, queries } = searchResult
   const searchTerms = queries?.request[0].exactTerms
   async function fetchPostsFromPage(page) {
     gtag.sendGAEvent(`search-${searchTerms}-loadmore-${page}`)
+    try {
+      let startIndex = (page - 1) * PROGRAMABLE_SEARCH_PER_PAGE + 1
+      const { data } = await axios({
+        method: 'get',
+        url: '/api/search',
+        params: {
+          exactTerms: searchTerms,
+          startFrom: startIndex,
+          takeAmount: PROGRAMABLE_SEARCH_PER_PAGE,
+        },
+        timeout: API_TIMEOUT,
+      })
+      return data.items ?? []
+    } catch (error) {
+      console.error(error)
+      return []
+    }
   }
 
   const loader = (
@@ -43,7 +55,6 @@ export default function SearchedArticles({ searchResult }) {
     <InfiniteScrollList
       initialList={initialArticles}
       pageSize={PROGRAMABLE_SEARCH_PER_PAGE}
-      amountOfElements={Math.min(totalResults, 100)}
       fetchListInPage={fetchPostsFromPage}
       isAutoFetch={true}
       loader={loader}

--- a/packages/mirror-media-search/pages/search/v3/[searchTerms].js
+++ b/packages/mirror-media-search/pages/search/v3/[searchTerms].js
@@ -136,30 +136,16 @@ export async function getServerSideProps({ params }) {
       getSearchResult({
         exactTerms: searchTerms,
         startFrom: 1,
-        takeAmount: 100,
+        takeAmount: PROGRAMABLE_SEARCH_PER_PAGE,
       }),
     ])
 
     const sectionsData = responses[0].value?.data?.headers || []
     const topicsData = responses[1].value?.data?.topics || []
-    const searchResult = responses[2].value?.data
-    const sortedResult = {
-      ...searchResult,
-      items:
-        searchResult?.items?.sort((a, b) => {
-          const dateA = new Date(
-            a?.pagemap?.metatags?.[0]?.['article:published_time']
-          )
-          const dateB = new Date(
-            b?.pagemap?.metatags?.[0]?.['article:published_time']
-          )
-          return dateB - dateA
-        }) || [],
-    }
 
     const props = {
       headerData: { sectionsData, topicsData },
-      searchResult: sortedResult,
+      searchResult: responses[2].value?.data || {},
       redirectUrl: URL_MIRROR_MEDIA_V3,
     }
 


### PR DESCRIPTION
## Notable Changes
* 調整 getSearchResult，一次抓取到 100 筆，並將抓取到的結果進行排序
* 調整 `/search/v3`，一次抓取數量調整為 12 筆，並且不做排序處理

## Notes
* 應在後端一次抓取到 100 比並做排序，而非在前端抓取 100，導致初次載入網路頻寬的增加 cc @v61265 