### PR TITLE
refactor(mm-search): fetch 100 posts once but should load-more

### DIFF
--- a/packages/mirror-media-search/components/searched-articles.js
+++ b/packages/mirror-media-search/components/searched-articles.js
@@ -22,27 +22,18 @@ const Loading = styled.div`
 `
 
 export default function SearchedArticles({ searchResult }) {
-  const { items: initialArticles, queries } = searchResult
+  const {
+    items: { items },
+    queries,
+  } = searchResult
+  const initialArticles = items.slice(0, PROGRAMABLE_SEARCH_PER_PAGE)
   const searchTerms = queries?.request[0].exactTerms
   async function fetchPostsFromPage(page) {
     gtag.sendGAEvent(`search-${searchTerms}-loadmore-${page}`)
-    try {
-      let startIndex = (page - 1) * PROGRAMABLE_SEARCH_PER_PAGE + 1
-      const { data } = await axios({
-        method: 'get',
-        url: '/api/search',
-        params: {
-          exactTerms: searchTerms,
-          startFrom: startIndex,
-          takeAmount: PROGRAMABLE_SEARCH_PER_PAGE,
-        },
-        timeout: API_TIMEOUT,
-      })
-      return data.items ?? []
-    } catch (error) {
-      console.error(error)
-      return []
-    }
+    return items.slice(
+      PROGRAMABLE_SEARCH_PER_PAGE * (page - 1),
+      PROGRAMABLE_SEARCH_PER_PAGE * page
+    )
   }
 
   const loader = (

--- a/packages/mirror-media-search/pages/search/v3/[searchTerms].js
+++ b/packages/mirror-media-search/pages/search/v3/[searchTerms].js
@@ -12,9 +12,9 @@ import {
   URL_STATIC_HEADER_HEADERS,
   URL_STATIC_TOPICS,
 } from '../../../config'
-import { getSearchResult } from '../../../utils/api/programmable-search'
 import SearchedArticles from '../../../components/searched-articles'
 import { PROGRAMABLE_SEARCH_PER_PAGE } from '../../../utils/programmable-search/const'
+import { getSearchResultAllAndSorted } from '../../../utils/api/programmable-search-all-sorted'
 
 const SearchContainer = styled.main`
   width: 320px;
@@ -133,7 +133,7 @@ export async function getServerSideProps({ params }) {
         url: URL_STATIC_TOPICS,
         timeout: API_TIMEOUT,
       }),
-      getSearchResult({
+      getSearchResultAllAndSorted({
         exactTerms: searchTerms,
         startFrom: 1,
         takeAmount: PROGRAMABLE_SEARCH_PER_PAGE,

--- a/packages/mirror-media-search/utils/api/programmable-search-all-sorted.js
+++ b/packages/mirror-media-search/utils/api/programmable-search-all-sorted.js
@@ -53,12 +53,7 @@ export async function getSearchResultAllAndSorted(query) {
         })
       )
       const cachedResponse = JSON.parse(searchResultCache)
-      return {
-        data: {
-          ...cachedResponse,
-          items: cachedResponse,
-        },
-      }
+      return cachedResponse
     }
 
     let combinedResponse
@@ -114,8 +109,6 @@ export async function getSearchResultAllAndSorted(query) {
       )
       return dateB - dateA
     })
-
-    console.log(combinedResponse.items.length)
 
     writeRedis.set(redisKey, JSON.stringify(combinedResponse), 'EX', REDIS_EX)
 

--- a/packages/mirror-media-search/utils/api/programmable-search-all-sorted.js
+++ b/packages/mirror-media-search/utils/api/programmable-search-all-sorted.js
@@ -1,0 +1,129 @@
+import axios from 'axios'
+import Redis from 'ioredis'
+import { number, object, string } from 'yup'
+import {
+  URL_PROGRAMABLE_SEARCH,
+  PROGRAMABLE_SEARCH_API_KEY,
+  PROGRAMABLE_SEARCH_ENGINE_ID,
+  API_TIMEOUT,
+  REDIS_EX,
+  REDIS_AUTH,
+  READ_REDIS_HOST,
+  WRITE_REDIS_HOST,
+} from '../../config'
+import { PROGRAMABLE_SEARCH_NUM } from '../programmable-search/const'
+
+const MAX_SEARCH_AMOUNT = 100
+
+const readRedis = new Redis({ host: READ_REDIS_HOST, password: REDIS_AUTH })
+const writeRedis = new Redis({ host: WRITE_REDIS_HOST, password: REDIS_AUTH })
+
+const searchQuerySchema = object({
+  exactTerms: string().required(),
+  startFrom: number()
+    .optional()
+    .integer()
+    .positive()
+    .max(MAX_SEARCH_AMOUNT)
+    .min(1),
+  takeAmount: number()
+    .optional()
+    .integer()
+    .default(PROGRAMABLE_SEARCH_NUM)
+    .min(1),
+})
+
+export async function getSearchResultAllAndSorted(query) {
+  try {
+    const params = await searchQuerySchema.validate(query, {
+      stripUnknown: true,
+    })
+
+    let { exactTerms = '' } = params
+
+    const prefix = 'PROGRAMABLE_SEARCH_ALL'
+    const redisKey = `${prefix}_${exactTerms}`
+    const searchResultCache = await readRedis.get(redisKey)
+
+    if (searchResultCache) {
+      console.log(
+        JSON.stringify({
+          severity: 'DEBUG',
+          message: `Get search result from redis cache with key ${redisKey} 100 posts and sorted`,
+        })
+      )
+      const cachedResponse = JSON.parse(searchResultCache)
+      return {
+        data: {
+          ...cachedResponse,
+          items: cachedResponse,
+        },
+      }
+    }
+
+    let combinedResponse
+    let hasMoreData = true
+    let start = 0
+
+    while (start <= MAX_SEARCH_AMOUNT || hasMoreData) {
+      const queryParams = {
+        key: PROGRAMABLE_SEARCH_API_KEY,
+        cx: PROGRAMABLE_SEARCH_ENGINE_ID,
+        exactTerms: exactTerms,
+        start,
+        num: PROGRAMABLE_SEARCH_NUM,
+        sort: ' ,date:s',
+      }
+
+      let resData = {}
+      try {
+        const response = await axios({
+          method: 'get',
+          url: URL_PROGRAMABLE_SEARCH,
+          params: queryParams,
+          timeout: API_TIMEOUT,
+        })
+        resData = response.data
+
+        if (!combinedResponse) {
+          combinedResponse = resData
+        } else if (
+          Array.isArray(combinedResponse.items) &&
+          Array.isArray(resData?.items)
+        ) {
+          combinedResponse.items.push(...resData.items)
+        }
+      } catch (error) {
+        console.log(JSON.stringify({ severity: 'ERROR', message: error.stack }))
+      }
+
+      if (resData?.queries?.nextPage === undefined) {
+        hasMoreData = false
+      }
+
+      // 更新開始索引，搜尋下一批結果
+      start += PROGRAMABLE_SEARCH_NUM
+    }
+
+    combinedResponse.items.sort((a, b) => {
+      const dateA = new Date(
+        a?.pagemap?.metatags?.[0]?.['article:published_time']
+      )
+      const dateB = new Date(
+        b?.pagemap?.metatags?.[0]?.['article:published_time']
+      )
+      return dateB - dateA
+    })
+
+    console.log(combinedResponse.items.length)
+
+    writeRedis.set(redisKey, JSON.stringify(combinedResponse), 'EX', REDIS_EX)
+
+    return {
+      data: combinedResponse,
+    }
+  } catch (error) {
+    console.log(JSON.stringify({ severity: 'ERROR', message: error.stack }))
+    return error.message
+  }
+}


### PR DESCRIPTION
### 描述
- 先在 `programmable-search-all-sorted` 拿好一百筆資料並排序（為了不要和之前的版本互相影響，另外開了檔案）
- 在 render 時還是一樣先 12 篇
- loadmore 的時候用 slice 拿接下來 12 篇