### PR TITLE
feat(mm-next): add metatags for search result

### DIFF
--- a/packages/mirror-media-next/components/shared/custom-head.js
+++ b/packages/mirror-media-next/components/shared/custom-head.js
@@ -27,7 +27,7 @@ import { useRouter } from 'next/router'
  * Since '/story' page and '/story/amp' page has special logic on creating canonical link,
  * we decide not handle canonical link on these page.
  * @param {string} routerAsPath
- * @return {null | JSX.Element}
+ * @return {null | React.ReactNode}
  */
 const createCanonicalLink = (routerAsPath) => {
   const url = new URL(routerAsPath, 'https://' + SITE_URL)
@@ -42,6 +42,8 @@ const createCanonicalLink = (routerAsPath) => {
  * @property {string} [description] - head description used to setup description related meta
  * @property {string} [imageUrl] - image url used to setup image related meta
  * @property {boolean} [skipCanonical] - flag to indicates whether the canonical should be added here
+ * @property {'story' | 'external'} [pageType] - pageType for search result navigation in App
+ * @property {string} [pageSlug] - set pageSlug with pageType. This is also for search result navigation in App
  */
 
 /**
@@ -53,6 +55,8 @@ export default function CustomHead({
   title,
   description,
   imageUrl,
+  pageType,
+  pageSlug,
 }) {
   const router = useRouter()
   const canonicalLink = skipCanonical ? (
@@ -167,6 +171,14 @@ export default function CustomHead({
         content={siteInformation.description || ''}
         key="twitter:description"
       />
+      {pageType && (
+        <>
+          {/* These metatags are for search result usage */}
+          <meta name="page-type" content={pageType} />
+          <meta name="page-slug" content={pageSlug} />
+          <meta name="page-image" content={siteInformation?.image?.url} />
+        </>
+      )}
     </Head>
   )
 }

--- a/packages/mirror-media-next/components/shared/layout.js
+++ b/packages/mirror-media-next/components/shared/layout.js
@@ -31,6 +31,8 @@ export default function Layout({ head, header, footer, children }) {
         description={head?.description}
         imageUrl={head?.imageUrl}
         skipCanonical={head?.skipCanonical}
+        pageType={head?.pageType}
+        pageSlug={head?.pageSlug}
       />
       <ShareHeader pageLayoutType={header.type} headerData={header.data} />
       <IdleTimeoutModal />

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -19,14 +19,15 @@ import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-proces
 
 /**
  * @typedef {import('../../apollo/fragments/external').External} External
+ * @typedef {import('../../components/header/share-header').HeaderData} HeaderData
  */
 
 /**
  *
  * @param {Object} props
  * @param {External} props.external
- * @param {Object} props.headerData
- * @returns {JSX.Element}
+ * @param {HeaderData} props.headerData
+ * @returns {React.ReactNode}
  */
 export default function External({ external, headerData }) {
   const router = useRouter()
@@ -52,6 +53,8 @@ export default function External({ external, headerData }) {
         head={{
           title: `${external?.title}`,
           imageUrl: external?.thumb,
+          pageType: 'external',
+          pageSlug: `${slug}`,
         }}
         header={{ type: 'default', data: headerData }}
         footer={{ type: 'default' }}

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -50,13 +50,9 @@ import Skeleton from '../../public/images-next/skeleton.png'
 
 /**
  * @typedef {import('../../components/story/normal').PostData} PostData
- */
-/**
  * @typedef {import('../../components/story/normal').PostContent} PostContent
- */
-
-/**
  * @typedef {'style-normal' | 'style-photography' | 'style-wide' | 'style-premium'} StoryLayoutType
+ * @typedef {import('../../components/header/share-header').HeaderData} HeaderData
  */
 
 const Loading = styled.div`
@@ -91,9 +87,9 @@ const getStoryLayoutType = (articleStyle, isMemberOnlyArticle) => {
  *
  * @param {Object} props
  * @param {PostData} props.postData
- * @param {any} props.headerData
+ * @param {HeaderData} props.headerData
  * @param {StoryLayoutType} props.storyLayoutType
- * @returns {JSX.Element}
+ * @returns {React.ReactNode}
  */
 export default function Story({ postData, headerData, storyLayoutType }) {
   const {
@@ -267,6 +263,8 @@ export default function Story({ postData, headerData, storyLayoutType }) {
             getResizedUrl(postData.og_image?.resized) ||
             getResizedUrl(postData.heroImage?.resized),
           skipCanonical: true,
+          pageType: 'story',
+          pageSlug: slug,
         }}
         header={{ type: 'empty' }}
         footer={{ type: 'empty' }}


### PR DESCRIPTION
## Notable Changes
* 增加 `page-type`、`page-slug` 和 `page-image` 作為搜尋引擎輸出內容使用

## Notes
* `page-type` 和 `page-slug` 主要是給 App 的搜尋結果導向使用