### PR TITLE
feat:  render AsideArticleList by device

### DIFF
--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -51,6 +51,10 @@ const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
   ssr: false,
 })
 
+const ResponsivePortal = dynamic(() => import('../shared/client-side-portal'), {
+  ssr: false,
+})
+
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
  */
@@ -512,6 +516,7 @@ export default function StoryNormalStyle({
   const { width } = useWindowDimensions()
   const isMobileWidth = width < mediaSize.md
   const [isHDAdEmpty, setISHDAdEmpty] = useState(true)
+
   const {
     title = '',
     subtitle = '',
@@ -735,6 +740,8 @@ export default function StoryNormalStyle({
             relateds={relatedsWithOrdered}
             hiddenAdvertised={hiddenAdvertised}
           />
+          {/* portal target for AsideArticleList on mobile */}
+          <div className="desktop-article-list-portal"></div>
           <SupportMirrorMediaBanner />
           <SocialNetworkServiceSmall />
 
@@ -809,13 +816,18 @@ export default function StoryNormalStyle({
             )}
 
             <Divider />
-            <AsideArticleList
-              listType={'popularNews'}
-              fetchArticle={handleFetchPopularNews}
-              shouldReverseOrder={false}
-              renderAmount={6}
-              hiddenAdvertised={hiddenAdvertised}
-            />
+            <ResponsivePortal
+              isMobile={isMobileWidth}
+              selector=".desktop-article-list-portal"
+            >
+              <AsideArticleList
+                listType="popularNews"
+                fetchArticle={handleFetchPopularNews}
+                shouldReverseOrder={false}
+                renderAmount={6}
+                hiddenAdvertised={hiddenAdvertised}
+              />
+            </ResponsivePortal>
             <AsideFbPagePlugin />
           </FixedContainer>
         </Aside>

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -741,7 +741,7 @@ export default function StoryNormalStyle({
             hiddenAdvertised={hiddenAdvertised}
           />
           {/* portal target for AsideArticleList on mobile */}
-          <div className="desktop-article-list-portal"></div>
+          <div className="mobile-article-list-portal"></div>
           <SupportMirrorMediaBanner />
           <SocialNetworkServiceSmall />
 
@@ -817,8 +817,8 @@ export default function StoryNormalStyle({
 
             <Divider />
             <ResponsivePortal
-              isMobile={isMobileWidth}
-              selector=".desktop-article-list-portal"
+              isTransport={isMobileWidth}
+              selector=".mobile-article-list-portal"
             >
               <AsideArticleList
                 listType="popularNews"

--- a/packages/mirror-media-next/components/story/shared/client-side-portal.js
+++ b/packages/mirror-media-next/components/story/shared/client-side-portal.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+import ReactDOM from 'react-dom'
+
+/**
+ *
+ * @param {Object} props
+ * @param {boolean} props.isMobile - If it is on mobile, render through portal.
+ * @param {string} props.selector - The class name or ID to put the component.
+ * @param {React.ReactNode} props.children - The children to render
+ * @returns {React.ReactNode}
+ */
+export default function ResponsivePortal({ isMobile, selector, children }) {
+  const [portalTarget, setPortalTarget] = useState(null)
+
+  // Make sure the document is mount.
+  useEffect(() => {
+    const target = document.querySelector(selector)
+    setPortalTarget(target)
+  }, [selector])
+
+  if (isMobile && portalTarget) {
+    return ReactDOM.createPortal(children, portalTarget)
+  }
+
+  return children
+}

--- a/packages/mirror-media-next/components/story/shared/client-side-portal.js
+++ b/packages/mirror-media-next/components/story/shared/client-side-portal.js
@@ -3,22 +3,23 @@ import ReactDOM from 'react-dom'
 
 /**
  *
+ * reference: https://react.dev/reference/react-dom/createPortal
+ *
  * @param {Object} props
- * @param {boolean} props.isMobile - If it is on mobile, render through portal.
+ * @param {boolean} props.isTransport - If it is on mobile, render through portal.
  * @param {string} props.selector - The class name or ID to put the component.
  * @param {React.ReactNode} props.children - The children to render
  * @returns {React.ReactNode}
  */
-export default function ResponsivePortal({ isMobile, selector, children }) {
+export default function ResponsivePortal({ isTransport, selector, children }) {
   const [portalTarget, setPortalTarget] = useState(null)
 
-  // Make sure the document is mount.
   useEffect(() => {
     const target = document.querySelector(selector)
     setPortalTarget(target)
   }, [selector])
 
-  if (isMobile && portalTarget) {
+  if (isTransport && portalTarget) {
     return ReactDOM.createPortal(children, portalTarget)
   }
 


### PR DESCRIPTION
手機版：將熱門文章移動到延伸閱讀下方
其他：保持原本邏輯

## Additions

- `<ResponsivePortal/>` component to render component on different DOM by device width.


## Changes

- `<AsideArticleList/>` is wrapped in `ResponsivePortal`

## Screenshots

- 375px
![Screenshot 2025-05-07 at 2 21 24 PM](https://github.com/user-attachments/assets/7e1eb9e8-69e7-4019-8ce9-9383959a2011)

- 1440px
![Screenshot 2025-05-07 at 2 23 23 PM](https://github.com/user-attachments/assets/05e7071b-e2df-4ce1-aa70-41e0ea8fdb7d)




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210169044184412