### PR TITLE
feat: add flash news to story and external header

### DIFF
--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -499,12 +499,13 @@ const StyledGPTAd_PC_E2 = styled(GPTAd)`
 `
 
 /**
+ * @typedef {import('../../header/shared/flash-news').FlashNews[]} FlashNewsData
  *
  * @param {Object} param
  * @param {PostData} param.postData
  * @param {PostContent} param.postContent
  * @param {any} param.headerData
- * @param {any} param.flashNewsData
+ * @param {FlashNewsData} param.flashNewsData
  * @param {string} [param.classNameForGTM]
  * @returns {JSX.Element}
  */

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -504,6 +504,7 @@ const StyledGPTAd_PC_E2 = styled(GPTAd)`
  * @param {PostData} param.postData
  * @param {PostContent} param.postContent
  * @param {any} param.headerData
+ * @param {any} param.flashNewsData
  * @param {string} [param.classNameForGTM]
  * @returns {JSX.Element}
  */
@@ -511,6 +512,7 @@ export default function StoryNormalStyle({
   postData,
   postContent,
   headerData,
+  flashNewsData,
   classNameForGTM = '',
 }) {
   const { width } = useWindowDimensions()
@@ -664,10 +666,11 @@ export default function StoryNormalStyle({
   return (
     <>
       <ShareHeader
-        pageLayoutType="default"
+        pageLayoutType="default-with-flash-news"
         headerData={{
           sectionsData: headerData?.sectionsData,
           topicsData: headerData?.topicsData,
+          flashNewsData,
         }}
       />
 

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -30,8 +30,9 @@ const MisoPageView = dynamic(() => import('../../components/miso-pageview'), {
 /**
  * @typedef {import('../../apollo/fragments/external').External} External
  * @typedef {import('../../components/header/share-header').HeaderData} HeaderData
- * @typedef {Object} DataRes
- * @typedef {import('axios').AxiosResponse<DataRes>} AxiosResponse
+ * @typedef {import('../../components/header/shared/flash-news').FlashNews} FlashNews
+ * @typedef {Record<'posts',FlashNews[]>} FlashNewsData
+ * @typedef {import('axios').AxiosResponse<FlashNewsData>} FlashNewsAxiosResponse
  */
 
 /**
@@ -136,10 +137,10 @@ export async function getServerSideProps({ params, req, res }) {
 
   const flashNewsData = handleAxiosResponse(
     responses[2],
-    (/** @type {AxiosResponse} */ axiosData) => {
-      return axiosData?.data?.posts ?? []
+    (/** @type {FlashNewsAxiosResponse} */ axiosData) => {
+      return axiosData.data.posts ?? []
     },
-    'Error occurs while getting flash news in index page',
+    'Error occurs while getting flash news in external page',
     globalLogFields
   )
   const props = {

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -1,6 +1,11 @@
 //TODO: add component to add html head dynamically, not jus write head in every pag
 import client from '../../apollo/apollo-client'
-import { ENV, SITE_URL } from '../../config/index.mjs'
+import {
+  API_TIMEOUT,
+  ENV,
+  SITE_URL,
+  URL_STATIC_POST_FLASH_NEWS,
+} from '../../config/index.mjs'
 import { setPageCache } from '../../utils/cache-setting'
 import { fetchExternalBySlug } from '../../apollo/query/externals'
 import ExternalNormalStyle from '../../components/external/external-normal-style'
@@ -17,6 +22,7 @@ import {
 } from '../../utils/response-handle'
 import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import dynamic from 'next/dynamic'
+import axios from 'axios'
 const MisoPageView = dynamic(() => import('../../components/miso-pageview'), {
   ssr: false,
 })
@@ -24,6 +30,8 @@ const MisoPageView = dynamic(() => import('../../components/miso-pageview'), {
 /**
  * @typedef {import('../../apollo/fragments/external').External} External
  * @typedef {import('../../components/header/share-header').HeaderData} HeaderData
+ * @typedef {Object} DataRes
+ * @typedef {import('axios').AxiosResponse<DataRes>} AxiosResponse
  */
 
 /**
@@ -60,7 +68,10 @@ export default function External({ external, headerData }) {
           pageType: 'external',
           pageSlug: `${slug}`,
         }}
-        header={{ type: 'default', data: headerData }}
+        header={{
+          type: 'default-with-flash-news',
+          data: headerData,
+        }}
         footer={{ type: 'default' }}
       >
         <MisoPageView productIds={`external_${slug}`} />
@@ -82,7 +93,6 @@ export async function getServerSideProps({ params, req, res }) {
   }
 
   const { slug } = params
-
   const globalLogFields = getLogTraceObject(req)
 
   const responses = await Promise.allSettled([
@@ -90,6 +100,11 @@ export async function getServerSideProps({ params, req, res }) {
     client.query({
       query: fetchExternalBySlug,
       variables: { slug },
+    }),
+    axios({
+      method: 'get',
+      url: URL_STATIC_POST_FLASH_NEWS,
+      timeout: API_TIMEOUT,
     }),
   ])
 
@@ -119,9 +134,17 @@ export async function getServerSideProps({ params, req, res }) {
     return { notFound: true }
   }
 
+  const flashNewsData = handleAxiosResponse(
+    responses[2],
+    (/** @type {AxiosResponse} */ axiosData) => {
+      return axiosData?.data?.posts ?? []
+    },
+    'Error occurs while getting flash news in index page',
+    globalLogFields
+  )
   const props = {
     external,
-    headerData: { sectionsData, topicsData },
+    headerData: { sectionsData, topicsData, flashNewsData },
   }
 
   return { props }

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -189,7 +189,7 @@ export default function Home({
  */
 
 /**
- * @typedef {Object} DataRes
+ *
  * @property {FlashNewsData} [posts]
  * @property {TopicsData} [topics]
  * @property {SectionsData} [sections]
@@ -203,7 +203,7 @@ export default function Home({
  * @property {Array} latest
  */
 
-/** @typedef {import('axios').AxiosResponse<DataRes>} AxiosResponse */
+/** @typedef {import('axios').AxiosResponse<Record<'posts',FlashNewsData>>} AxiosResponse */
 
 //TODO: rename typedef, make it more clear
 /** @typedef {import('axios').AxiosResponse<PostRes>} AxiosPostResponse */

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -234,7 +234,6 @@ export default function Story({
             postData={postData}
             postContent={postContent}
             headerData={headerData}
-            flashNewsData={flashNewsData}
             classNameForGTM={classNameForGTM}
           />
         )
@@ -423,32 +422,7 @@ export async function getServerSideProps({ params, req, res }) {
       }
     } else if (shouldFetchPremiumHeaderData) {
       try {
-        const responses = await Promise.allSettled([
-          axios({
-            method: 'get',
-            url: URL_STATIC_POST_FLASH_NEWS,
-            timeout: API_TIMEOUT,
-          }),
-          fetchHeaderDataInPremiumPageLayout(),
-        ])
-        flashNewsData = handleAxiosResponse(
-          responses[0],
-          (/** @type {AxiosResponse} */ axiosData) => {
-            return axiosData?.data?.posts ?? []
-          },
-          'Error occurs while getting flash news in index page',
-          globalLogFields
-        )
-        headerData = handleAxiosResponse(
-          responses[1],
-          (
-            /** @type {{ sectionsData: HeadersData, } | null | undefined} */ axiosData
-          ) => {
-            return axiosData ?? { sectionsData: [] }
-          },
-          'Error occurs while getting sectionsData and topicsData in index page',
-          globalLogFields
-        )
+        headerData = await fetchHeaderDataInPremiumPageLayout()
       } catch (err) {
         headerData = { sectionsData: [] }
         logAxiosError(

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -5,7 +5,9 @@ import client from '../../apollo/apollo-client'
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 import {
+  API_TIMEOUT,
   ENV,
+  URL_STATIC_POST_FLASH_NEWS,
   // TEST_GPT_AD_FEATURE_TOGGLE,
 } from '../../config/index.mjs'
 import WineWarning from '../../components/shared/wine-warning'
@@ -46,6 +48,8 @@ const StoryPremiumStyle = dynamic(() =>
 )
 import Image from 'next/image'
 import Skeleton from '../../public/images-next/skeleton.png'
+import axios from 'axios'
+import { handleAxiosResponse } from '../../utils/response-handle'
 const MisoPageView = dynamic(() => import('../../components/miso-pageview'), {
   ssr: false,
 })
@@ -56,6 +60,11 @@ const MisoPageView = dynamic(() => import('../../components/miso-pageview'), {
  * @typedef {import('../../components/story/normal').PostContent} PostContent
  * @typedef {'style-normal' | 'style-photography' | 'style-wide' | 'style-premium'} StoryLayoutType
  * @typedef {import('../../components/header/share-header').HeaderData} HeaderData
+ * @typedef {Object} DataRes
+ * @typedef {import('axios').AxiosResponse<DataRes>} AxiosResponse
+ * @typedef {import('../../utils/api').HeadersData} HeadersData
+ * @typedef {import('../../utils/api').Topics} Topics
+ * @typedef {import('axios').AxiosResponse<HeaderData>} AxiosResponseHeaderData
  */
 
 const Loading = styled.div`
@@ -91,10 +100,16 @@ const getStoryLayoutType = (articleStyle, isMemberOnlyArticle) => {
  * @param {Object} props
  * @param {PostData} props.postData
  * @param {HeaderData} props.headerData
+ * @param {DataRes} props.flashNewsData
  * @param {StoryLayoutType} props.storyLayoutType
  * @returns {React.ReactNode}
  */
-export default function Story({ postData, headerData, storyLayoutType }) {
+export default function Story({
+  postData,
+  headerData,
+  flashNewsData,
+  storyLayoutType,
+}) {
   const {
     title = '',
     slug = '',
@@ -209,6 +224,7 @@ export default function Story({ postData, headerData, storyLayoutType }) {
             postData={postData}
             postContent={postContent}
             headerData={headerData}
+            flashNewsData={flashNewsData}
             classNameForGTM={classNameForGTM}
           />
         )
@@ -218,6 +234,7 @@ export default function Story({ postData, headerData, storyLayoutType }) {
             postData={postData}
             postContent={postContent}
             headerData={headerData}
+            flashNewsData={flashNewsData}
             classNameForGTM={classNameForGTM}
           />
         )
@@ -243,6 +260,7 @@ export default function Story({ postData, headerData, storyLayoutType }) {
             postData={postData}
             postContent={postContent}
             headerData={headerData}
+            flashNewsData={flashNewsData}
             classNameForGTM={classNameForGTM}
           />
         )
@@ -364,11 +382,37 @@ export async function getServerSideProps({ params, req, res }) {
       postData?.isMember
     )
     let headerData = null
+    let flashNewsData = null
     const shouldFetchDefaultHeaderData = storyLayoutType === 'style-normal'
     const shouldFetchPremiumHeaderData = storyLayoutType === 'style-premium'
     if (shouldFetchDefaultHeaderData) {
       try {
-        headerData = await fetchHeaderDataInDefaultPageLayout()
+        const responses = await Promise.allSettled([
+          axios({
+            method: 'get',
+            url: URL_STATIC_POST_FLASH_NEWS,
+            timeout: API_TIMEOUT,
+          }),
+          fetchHeaderDataInDefaultPageLayout(),
+        ])
+        flashNewsData = handleAxiosResponse(
+          responses[0],
+          (/** @type {AxiosResponse} */ axiosData) => {
+            return axiosData?.data?.posts ?? []
+          },
+          'Error occurs while getting flash news in index page',
+          globalLogFields
+        )
+        headerData = handleAxiosResponse(
+          responses[1],
+          (
+            /** @type {{ sectionsData: HeadersData, topicsData: Topics } | null | undefined} */ axiosData
+          ) => {
+            return axiosData ?? { sectionsData: [], topicsData: [] }
+          },
+          'Error occurs while getting sectionsData and topicsData in index page',
+          globalLogFields
+        )
       } catch (err) {
         headerData = { sectionsData: [], topicsData: [] }
         logAxiosError(
@@ -379,7 +423,32 @@ export async function getServerSideProps({ params, req, res }) {
       }
     } else if (shouldFetchPremiumHeaderData) {
       try {
-        headerData = await fetchHeaderDataInPremiumPageLayout()
+        const responses = await Promise.allSettled([
+          axios({
+            method: 'get',
+            url: URL_STATIC_POST_FLASH_NEWS,
+            timeout: API_TIMEOUT,
+          }),
+          fetchHeaderDataInPremiumPageLayout(),
+        ])
+        flashNewsData = handleAxiosResponse(
+          responses[0],
+          (/** @type {AxiosResponse} */ axiosData) => {
+            return axiosData?.data?.posts ?? []
+          },
+          'Error occurs while getting flash news in index page',
+          globalLogFields
+        )
+        headerData = handleAxiosResponse(
+          responses[1],
+          (
+            /** @type {{ sectionsData: HeadersData, } | null | undefined} */ axiosData
+          ) => {
+            return axiosData ?? { sectionsData: [] }
+          },
+          'Error occurs while getting sectionsData and topicsData in index page',
+          globalLogFields
+        )
       } catch (err) {
         headerData = { sectionsData: [] }
         logAxiosError(
@@ -393,6 +462,7 @@ export async function getServerSideProps({ params, req, res }) {
     return {
       props: {
         postData,
+        flashNewsData,
         headerData,
         storyLayoutType,
       },

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -60,8 +60,8 @@ const MisoPageView = dynamic(() => import('../../components/miso-pageview'), {
  * @typedef {import('../../components/story/normal').PostContent} PostContent
  * @typedef {'style-normal' | 'style-photography' | 'style-wide' | 'style-premium'} StoryLayoutType
  * @typedef {import('../../components/header/share-header').HeaderData} HeaderData
- * @typedef {Object} DataRes
- * @typedef {import('axios').AxiosResponse<DataRes>} AxiosResponse
+ * @typedef {HeaderData['flashNewsData']} flashNewsData
+ * @typedef {import('axios').AxiosResponse<Record<'posts',flashNewsData>>} AxiosResponse
  * @typedef {import('../../utils/api').HeadersData} HeadersData
  * @typedef {import('../../utils/api').Topics} Topics
  * @typedef {import('axios').AxiosResponse<HeaderData>} AxiosResponseHeaderData
@@ -100,7 +100,7 @@ const getStoryLayoutType = (articleStyle, isMemberOnlyArticle) => {
  * @param {Object} props
  * @param {PostData} props.postData
  * @param {HeaderData} props.headerData
- * @param {DataRes} props.flashNewsData
+ * @param {flashNewsData} props.flashNewsData
  * @param {StoryLayoutType} props.storyLayoutType
  * @returns {React.ReactNode}
  */
@@ -399,7 +399,7 @@ export async function getServerSideProps({ params, req, res }) {
           (/** @type {AxiosResponse} */ axiosData) => {
             return axiosData?.data?.posts ?? []
           },
-          'Error occurs while getting flash news in index page',
+          'Error occurs while getting flash news in story page',
           globalLogFields
         )
         headerData = handleAxiosResponse(
@@ -409,7 +409,7 @@ export async function getServerSideProps({ params, req, res }) {
           ) => {
             return axiosData ?? { sectionsData: [], topicsData: [] }
           },
-          'Error occurs while getting sectionsData and topicsData in index page',
+          'Error occurs while getting sectionsData and topicsData in story page',
           globalLogFields
         )
       } catch (err) {


### PR DESCRIPTION
Add flash news to story headers

## Additions

- normal story header
- external story header

## Changes

- set external and normal story header to 'default-with-flash-news'

## Screenshots

- external mobile
<img width="372" alt="Screenshot 2025-05-29 at 4 12 26 PM" src="https://github.com/user-attachments/assets/231e1cb1-8d6a-4e2b-97a3-ff507bec3452" />

- external desktop
<img width="825" alt="Screenshot 2025-05-29 at 4 12 58 PM" src="https://github.com/user-attachments/assets/e99ad186-1953-498b-a1c6-3184e7304c00" />

- normal mobile
<img width="375" alt="Screenshot 2025-05-29 at 4 14 14 PM" src="https://github.com/user-attachments/assets/29d4983f-558e-480e-9fef-f34167e32498" />


- normal desktop
<img width="808" alt="Screenshot 2025-05-29 at 4 13 33 PM" src="https://github.com/user-attachments/assets/58884089-3f03-4362-8d7c-c1d5c1dae4fe" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210384428191910