### PR TITLE
feat: prevent Google indexing for login page

### DIFF
--- a/packages/mirror-media-next/components/shared/custom-head.js
+++ b/packages/mirror-media-next/components/shared/custom-head.js
@@ -44,6 +44,7 @@ const createCanonicalLink = (routerAsPath) => {
  * @property {boolean} [skipCanonical] - flag to indicates whether the canonical should be added here
  * @property {'story' | 'external'} [pageType] - pageType for search result navigation in App
  * @property {string} [pageSlug] - set pageSlug with pageType. This is also for search result navigation in App
+ * @property {string} [robotsMetaContent] - content for the robots meta tag, e.g. 'noindex, nofollow', controlling search engine indexing and crawling
  */
 
 /**
@@ -57,6 +58,7 @@ export default function CustomHead({
   imageUrl,
   pageType,
   pageSlug,
+  robotsMetaContent,
 }) {
   const router = useRouter()
   const canonicalLink = skipCanonical ? (
@@ -92,6 +94,9 @@ export default function CustomHead({
         content={siteInformation.description}
         key="description"
       />
+      {robotsMetaContent && (
+        <meta name="robots" content={robotsMetaContent} key="robots" />
+      )}
       <meta name="article-description" content={siteInformation.description} />
       {/* <OpenGraph properties={siteInformation} /> */}
       <meta name="application-name" content={siteInformation.title} />

--- a/packages/mirror-media-next/components/shared/layout-full.js
+++ b/packages/mirror-media-next/components/shared/layout-full.js
@@ -44,6 +44,7 @@ export default function LayoutFull({ head, header, footer, children }) {
         description={head?.description}
         imageUrl={head?.imageUrl}
         skipCanonical={head?.skipCanonical}
+        robotsMetaContent={head?.robotsMetaContent}
       />
       <Container>
         <ShareHeader pageLayoutType={header.type} headerData={header.data} />

--- a/packages/mirror-media-next/pages/api/robots.js
+++ b/packages/mirror-media-next/pages/api/robots.js
@@ -6,6 +6,7 @@ export default function handler(req, res) {
   if (ENV === 'prod') {
     res.write(`User-agent: Googlebot
 	 Disallow: /external/
+   Disallow: /login
 
 	User-agent: *
      Allow: /`)

--- a/packages/mirror-media-next/pages/login/index.js
+++ b/packages/mirror-media-next/pages/login/index.js
@@ -152,6 +152,7 @@ export default function Login({ headerData, isWebview }) {
 
   return (
     <LayoutFull
+      head={{ robotsMetaContent: 'noindex, nofollow' }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >


### PR DESCRIPTION
This change adds proper meta tags and robots.txt rules to exclude the login page from Google indexing in production.

## Additions
- `<meta name="robots" content="noindex, nofollow">` in the login page via `CustomHead` with `LayoutFull` support.
- `Disallow: /login` rule in `robots.txt` (production only).

## Removals
- N/A

## Changes
- Updated login page component to support passing `CustomHead` props for meta tag injection.
- Modified `robots.txt` generation logic to include `Disallow: /login` only in production environment.

## Testing
- Verified rendered HTML for the login page includes the correct `<meta>` tag.
- Confirmed `robots.txt` returns `Disallow: /login` with `ENV=prod` and omits it in other environments.

## Screenshots
- N/A

## Todos
- Review deployment configuration to ensure `robots.txt` updates are picked up in production.

## Task Links
- [Asana Task](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1210667421036730?focus=true)
