### PR TITLE
feat(author, tag): redirect to 404 when no posts; add noindex for author pages with few posts

### DIFF
--- a/packages/mirror-media-next/components/shared/layout.js
+++ b/packages/mirror-media-next/components/shared/layout.js
@@ -33,6 +33,7 @@ export default function Layout({ head, header, footer, children }) {
         skipCanonical={head?.skipCanonical}
         pageType={head?.pageType}
         pageSlug={head?.pageSlug}
+        robotsMetaContent={head?.robotsMetaContent}
       />
       <ShareHeader pageLayoutType={header.type} headerData={header.data} />
       <IdleTimeoutModal />

--- a/packages/mirror-media-next/pages/author/[id].js
+++ b/packages/mirror-media-next/pages/author/[id].js
@@ -105,9 +105,13 @@ export default function Author({ postsCount, posts, author, headerData }) {
   const handleObSlotRenderEnded = useCallback((e) => {
     setISHDAdEmpty(e.isEmpty)
   }, [])
+
   return (
     <Layout
-      head={{ title: `${authorName}相關報導` }}
+      head={{
+        title: `${authorName}相關報導`,
+        robotsMetaContent: posts.length <= 3 && 'noindex, nofollow',
+      }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >
@@ -220,6 +224,18 @@ export async function getServerSideProps({ query, req, res }) {
     `Error occurs while getting post data in author page (authorId: ${authorId})`,
     globalLogFields
   )
+
+  if (posts.length === 0) {
+    // fetchPost return empty array -> 404
+    console.log(
+      JSON.stringify({
+        severity: 'WARNING',
+        message: `fetch post of authorId ${authorId} return empty posts, redirect to 404`,
+        globalLogFields,
+      })
+    )
+    return { notFound: true }
+  }
 
   const props = {
     postsCount,

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -218,6 +218,18 @@ export async function getServerSideProps({ query, req, res }) {
     globalLogFields
   )
 
+  if (posts.length === 0) {
+    // fetchPost return empty array -> 404
+    console.log(
+      JSON.stringify({
+        severity: 'WARNING',
+        message: `fetch post of tagSlug ${tagSlug} return empty posts, redirect to 404`,
+        globalLogFields,
+      })
+    )
+    return { notFound: true }
+  }
+
   const props = {
     postsCount,
     posts,


### PR DESCRIPTION
feat(author, tag): redirect to 404 when no posts; add noindex for author pages with few posts

Redirects author and tag pages to 404 if no posts are found. Adds `meta` tag for noindex on author pages with 3 or fewer posts to improve SEO control.

## Additions
- `robotsMetaContent: 'noindex, nofollow'` on author pages with <= 3 posts

## Removals
- N/A

## Changes
- Updated server-side logic to return 404 when no posts for author or tag
- Added robots meta condition in Layout head for author pages

## Testing
- Verified 404 rendering when no posts
- Confirmed meta tag renders correctly for low-count author pages

## Screenshots
- N/A

## Todos
- N/A

## Task Links
- N/A
