### PR TITLE
feat(home): add RecallCampaigns section component

### DIFF
--- a/packages/mirror-media-next/components/recall-campaigns/recall-campaigns.js
+++ b/packages/mirror-media-next/components/recall-campaigns/recall-campaigns.js
@@ -39,7 +39,6 @@ const Header = styled.h3`
   font-family: 'Noto Sans CJK TC';
   font-size: 20px;
   font-weight: 700;
-  line-height: normal;
 `
 
 const ViewMoreLink = styled.a`
@@ -47,7 +46,6 @@ const ViewMoreLink = styled.a`
   font-family: 'Noto Sans CJK TC';
   font-size: 16px;
   font-weight: 700;
-  line-height: normal;
   text-decoration-line: underline;
   text-underline-position: from-font;
 `

--- a/packages/mirror-media-next/components/recall-campaigns/recall-campaigns.js
+++ b/packages/mirror-media-next/components/recall-campaigns/recall-campaigns.js
@@ -15,12 +15,15 @@ import { IS_SPECIAL_EVENT } from '../../config/index.mjs'
  * @returns {import('react/jsx-runtime').JSX.Element | null}
  */
 
-const Wrapper = styled.div`
+const Wrapper = styled.section`
   margin: 20px auto;
   display: flex;
   flex-direction: column;
   align-items: center;
   width: 310px;
+  color: #1d9fb8;
+  font-family: 'Noto Sans CJK TC';
+  font-weight: 700;
   ${({ theme }) => theme.breakpoint.md} {
     width: 100%;
   }
@@ -34,18 +37,11 @@ const Wrapper = styled.div`
   }
 `
 const Header = styled.h3`
-  color: #1d9fb8;
-  text-align: center;
-  font-family: 'Noto Sans CJK TC';
   font-size: 20px;
-  font-weight: 700;
 `
 
 const ViewMoreLink = styled.a`
-  color: #1d9fb8;
-  font-family: 'Noto Sans CJK TC';
   font-size: 16px;
-  font-weight: 700;
   text-decoration-line: underline;
   text-underline-position: from-font;
 `

--- a/packages/mirror-media-next/components/recall-campaigns/recall-campaigns.js
+++ b/packages/mirror-media-next/components/recall-campaigns/recall-campaigns.js
@@ -16,23 +16,20 @@ import { IS_SPECIAL_EVENT } from '../../config/index.mjs'
  */
 
 const Wrapper = styled.div`
-  position: relative;
   margin: 20px auto;
   display: flex;
   flex-direction: column;
   align-items: center;
-  ${({ theme }) => theme.breakpoint.sm} {
-    width: 310px;
-  }
+  width: 310px;
   ${({ theme }) => theme.breakpoint.md} {
-    width: 696px;
+    width: 100%;
   }
   ${({ theme }) => theme.breakpoint.xl} {
     width: 912px;
   }
   iframe {
     background-color: #fff;
-    height: 100%;
+    height: 500px;
     width: 100%;
   }
 `
@@ -41,7 +38,6 @@ const Header = styled.h3`
   text-align: center;
   font-family: 'Noto Sans CJK TC';
   font-size: 20px;
-  font-style: normal;
   font-weight: 700;
   line-height: normal;
 `

--- a/packages/mirror-media-next/components/recall-campaigns/recall-campaigns.js
+++ b/packages/mirror-media-next/components/recall-campaigns/recall-campaigns.js
@@ -1,0 +1,75 @@
+import styled from 'styled-components'
+
+import { IS_SPECIAL_EVENT } from '../../config/index.mjs'
+
+/**
+ * @typedef {import('../../type/theme').Theme} Theme
+ */
+/**
+ * @typedef {Object} RecallCampaignsProps
+ * @property {string} [className]
+ */
+
+/**
+ * @param {RecallCampaignsProps} props
+ * @returns {import('react/jsx-runtime').JSX.Element | null}
+ */
+
+const Wrapper = styled.div`
+  position: relative;
+  margin: 20px auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  ${({ theme }) => theme.breakpoint.sm} {
+    width: 310px;
+  }
+  ${({ theme }) => theme.breakpoint.md} {
+    width: 696px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    width: 912px;
+  }
+  iframe {
+    background-color: #fff;
+    height: 100%;
+    width: 100%;
+  }
+`
+const Header = styled.h3`
+  color: #1d9fb8;
+  text-align: center;
+  font-family: 'Noto Sans CJK TC';
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+`
+
+const ViewMoreLink = styled.a`
+  color: #1d9fb8;
+  font-family: 'Noto Sans CJK TC';
+  font-size: 16px;
+  font-weight: 700;
+  line-height: normal;
+  text-decoration-line: underline;
+  text-underline-position: from-font;
+`
+
+export default function RecallCampaigns({ className = '' }) {
+  if (!IS_SPECIAL_EVENT) return null
+
+  return (
+    <Wrapper className={className}>
+      <Header>2025 鏡週刊立委罷免即時開票</Header>
+      <iframe src="https://www.mirrormedia.mg/projects/election2024-homepage/index.html" />
+      <ViewMoreLink
+        target="_blank"
+        rel="noreferrer noopenner"
+        href="https://www.google.com/"
+      >
+        查看完整資料
+      </ViewMoreLink>
+    </Wrapper>
+  )
+}

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -14,6 +14,7 @@ const GOOGLE_SHEETS_PRIVATE_KEY = (
 const GOOGLE_SHEETS_CLIENT_EMAIL = process.env.GOOGLE_SHEETS_CLIENT_EMAIL
 const GOOGLE_SHEETS_CLIENT_ID = process.env.GOOGLE_SHEETS_CLIENT_ID
 const GOOGLE_SHEET_SLOT_ID = process.env.GOOGLE_SHEET_SLOT_ID
+const IS_SPECIAL_EVENT = process.env.NEXT_PUBLIC_SPECIALEVENT === 'true'
 
 // should be applied in preview mode
 const SITE_BASE_PATH = IS_PREVIEW_MODE ? '/preview-server' : ''
@@ -333,4 +334,5 @@ export {
   IS_PRIZE_RIZED,
   COURSE_URL,
   MISO_API_KEY,
+  IS_SPECIAL_EVENT,
 }

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -14,7 +14,7 @@ const GOOGLE_SHEETS_PRIVATE_KEY = (
 const GOOGLE_SHEETS_CLIENT_EMAIL = process.env.GOOGLE_SHEETS_CLIENT_EMAIL
 const GOOGLE_SHEETS_CLIENT_ID = process.env.GOOGLE_SHEETS_CLIENT_ID
 const GOOGLE_SHEET_SLOT_ID = process.env.GOOGLE_SHEET_SLOT_ID
-const IS_SPECIAL_EVENT = process.env.NEXT_PUBLIC_SPECIALEVENT === 'true'
+const IS_SPECIAL_EVENT = process.env.NEXT_PUBLIC_SPECIALEVENT === 'True' // TODO:should remove after 2025 Taiwanese mass electoral recall campaigns is finished
 
 // should be applied in preview mode
 const SITE_BASE_PATH = IS_PREVIEW_MODE ? '/preview-server' : ''

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -170,7 +170,7 @@ export default function Home({
             />
           )}
         </GPT_Placeholder>
-        {/* should remove after 2025 Taiwanese mass electoral recall campaigns is finished */}
+        {/* TODO:should remove after 2025 Taiwanese mass electoral recall campaigns is finished */}
         <RecallCampaigns />
 
         <EditorChoice editorChoice={editorChoice}></EditorChoice>

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -36,6 +36,7 @@ import { VIDEOHUB_CATEGORIES_PLAYLIST_MAPPING } from '../constants/index'
 import { fetchYoutubePlaylistByChannelId } from '../utils/api/section-videohub'
 import { simplifyYoutubePlaylistVideo } from '../utils/youtube'
 import LiveAndCoverstoryYoutube from '../components/index/live-and-coverstory-youtube'
+import RecallCampaigns from '../components/recall-campaigns/recall-campaigns'
 
 const GPTAd = dynamic(() => import('../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -169,7 +170,9 @@ export default function Home({
             />
           )}
         </GPT_Placeholder>
-        {/* should remove after 2024 taiwan election is finished */}
+        {/* should remove after 2025 Taiwanese mass electoral recall campaigns is finished */}
+        <RecallCampaigns />
+
         <EditorChoice editorChoice={editorChoice}></EditorChoice>
         {shouldShowAd && <StyledGPTAd_PC_B1 pageKey="home" adKey="PC_B1" />}
         {shouldShowAd && <StyledGPTAd_MB_L1 pageKey="home" adKey="MB_L1" />}


### PR DESCRIPTION
feat(home): add RecallCampaigns section component

Add a new RecallCampaigns section to the home page, showing a special iframe module for recall election coverage.

## Additions
- `RecallCampaigns` component in `components/recall-campaigns/recall-campaigns.js`
- Conditional rendering based on `IS_SPECIAL_EVENT` flag

## Removals
- N/A

## Changes
- Updated `home` page to include the new RecallCampaigns section between top ads and EditorChoice
- Ensured proper responsive styling for iframe container

## Testing
- Verified that RecallCampaigns only renders when `IS_SPECIAL_EVENT` is true
- Checked responsive layout at sm, md, xl breakpoints
- Confirmed iframe content loads correctly

## Screenshots
- N/A

## Todos
- Remove RecallCampaigns section after the 2025 Taiwanese mass electoral recall campaigns conclude

## Task Links
- N/A
