### PR TITLE
ci(cloudbuild): inject NEXT_PUBLIC_SPECIALEVENT into Docker build via _SPECIAL_EVENT

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,6 +25,7 @@ steps:
     env:
     - 'NEXT_PUBLIC_ENV=${BRANCH_NAME}'
     - 'NEXT_PUBLIC_IS_PREVIEW_MODE=$_IS_PREVIEW_MODE'
+    - 'NEXT_PUBLIC_SPECIALEVENT=$_SPECIAL_EVENT' 
     args:
       - '-c'
       - >
@@ -84,3 +85,4 @@ substitutions:
   _IMAGE_NAME: '' # default value
   _CLOUD_RUN_SERVICE_NAMES: '' # default value
   _IS_PREVIEW_MODE: 'false'  # default value
+  _SPECIAL_EVENT: 'false'  # default value


### PR DESCRIPTION
- Added _SPECIAL_EVENT to Cloud Build substitutions
- Mapped _SPECIAL_EVENT to NEXT_PUBLIC_SPECIALEVENT in Docker build env
- Ensures process.env.NEXT_PUBLIC_SPECIALEVENT is correctly embedded during build
