### PR TITLE
feat(recall-campaigns): use API result instead of env variable for display

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,7 +25,6 @@ steps:
     env:
       - 'NEXT_PUBLIC_ENV=${BRANCH_NAME}'
       - 'NEXT_PUBLIC_IS_PREVIEW_MODE=$_IS_PREVIEW_MODE'
-      - 'NEXT_PUBLIC_SPECIALEVENT=$_SPECIALEVENT'
     args:
       - '-c'
       - >
@@ -84,4 +83,3 @@ substitutions:
   _IMAGE_NAME: '' # default value
   _CLOUD_RUN_SERVICE_NAMES: '' # default value
   _IS_PREVIEW_MODE: 'false' # default value
-  _SPECIALEVENT: 'false' # default value

--- a/packages/mirror-media-next/components/recall-campaigns/recall-campaigns.js
+++ b/packages/mirror-media-next/components/recall-campaigns/recall-campaigns.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import { ENV, IS_SPECIAL_EVENT } from '../../config/index.mjs'
+import { ENV } from '../../config/index.mjs'
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -58,8 +58,6 @@ const iframeSrc = `https://${prefix}.mirrormedia.mg/projects/election2025-homepa
 const moreLink = `https://${prefix}.mirrormedia.mg/projects/taiwan-elections/index.html`
 
 export default function RecallCampaigns({ className = '' }) {
-  if (!IS_SPECIAL_EVENT) return null
-
   return (
     <Wrapper className={className}>
       <Header>2025 鏡週刊立委罷免即時開票</Header>
@@ -67,7 +65,7 @@ export default function RecallCampaigns({ className = '' }) {
         src={iframeSrc}
         scrolling="no" // Use scrolling="no" to suppress unwanted scrollbars in Chrome and avoid 1–2px layout shift
       />
-      <ViewMoreLink target="_blank" rel="noreferrer noopenner" href={moreLink}>
+      <ViewMoreLink target="_blank" rel="noreferrer noopener" href={moreLink}>
         查看完整資料
       </ViewMoreLink>
     </Wrapper>

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -14,7 +14,6 @@ const GOOGLE_SHEETS_PRIVATE_KEY = (
 const GOOGLE_SHEETS_CLIENT_EMAIL = process.env.GOOGLE_SHEETS_CLIENT_EMAIL
 const GOOGLE_SHEETS_CLIENT_ID = process.env.GOOGLE_SHEETS_CLIENT_ID
 const GOOGLE_SHEET_SLOT_ID = process.env.GOOGLE_SHEET_SLOT_ID
-const IS_SPECIAL_EVENT = process.env.NEXT_PUBLIC_SPECIALEVENT === 'True' // TODO:should remove after 2025 Taiwanese mass electoral recall campaigns is finished
 
 // should be applied in preview mode
 const SITE_BASE_PATH = IS_PREVIEW_MODE ? '/preview-server' : ''
@@ -334,5 +333,4 @@ export {
   IS_PRIZE_RIZED,
   COURSE_URL,
   MISO_API_KEY,
-  IS_SPECIAL_EVENT,
 }

--- a/packages/mirror-media-next/constants/url.js
+++ b/packages/mirror-media-next/constants/url.js
@@ -1,2 +1,4 @@
 export const SERVICE_RULE_URL = 'https://www.mirrormedia.mg/story/service-rule'
 export const PRIVACY_POLICY_URL = 'https://www.mirrormedia.mg/story/privacy'
+export const RECALL_CAMPAIGNS_DISPLAY_JSON_URL =
+  'https://storage.googleapis.com/whoareyou-gcs.readr.tw/json/202507_recall_homepage_display.json'

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -33,6 +33,7 @@ import GPT_Placeholder from '../components/ads/gpt/gpt-placeholder'
 
 import { isDateInsideDatesRange } from '../utils/date'
 import { VIDEOHUB_CATEGORIES_PLAYLIST_MAPPING } from '../constants/index'
+import { RECALL_CAMPAIGNS_DISPLAY_JSON_URL } from '../constants/url'
 import { fetchYoutubePlaylistByChannelId } from '../utils/api/section-videohub'
 import { simplifyYoutubePlaylistVideo } from '../utils/youtube'
 import LiveAndCoverstoryYoutube from '../components/index/live-and-coverstory-youtube'
@@ -114,6 +115,7 @@ const StyledGPTAd_MB_L1 = styled(GPTAd)`
  * @param {Object[] } props.sectionsData
  * @param {LiveYoutubeInfo} props.liveYoutubeInfo
  * @param {import('../type/youtube').YoutubeVideo[]} props.youtubeCoverstoryVideos
+ * @param {boolean} [props.isCampaignsVisible]
  * @returns {React.ReactElement}
  */
 export default function Home({
@@ -124,6 +126,7 @@ export default function Home({
   sectionsData = [],
   liveYoutubeInfo,
   youtubeCoverstoryVideos,
+  isCampaignsVisible,
 }) {
   const editorChoice = editorChoicesData.map((item) => {
     const sectionSlug = getSectionSlugGql(item.sections, undefined)
@@ -171,7 +174,7 @@ export default function Home({
           )}
         </GPT_Placeholder>
         {/* TODO:should remove after 2025 Taiwanese mass electoral recall campaigns is finished */}
-        <RecallCampaigns />
+        {isCampaignsVisible && <RecallCampaigns />}
 
         <EditorChoice editorChoice={editorChoice}></EditorChoice>
         {shouldShowAd && <StyledGPTAd_PC_B1 pageKey="home" adKey="PC_B1" />}
@@ -324,6 +327,13 @@ export async function getServerSideProps({ res, req }) {
       globalLogFields
     )
 
+    const campaignsDisplayConfig = await fetch(
+      RECALL_CAMPAIGNS_DISPLAY_JSON_URL
+    ).then((res) => res.json())
+    const envKey =
+      ENV === 'local' ? 'display_iframe_dev' : `display_iframe_${ENV}`
+    const isCampaignsVisible = campaignsDisplayConfig[envKey] === 'TRUE'
+
     return {
       props: {
         topicsData,
@@ -333,6 +343,7 @@ export async function getServerSideProps({ res, req }) {
         sectionsData,
         liveYoutubeInfo,
         youtubeCoverstoryVideos,
+        isCampaignsVisible,
       },
     }
   } catch (err) {


### PR DESCRIPTION
Refactored the display logic for the RecallCampaigns component to fetch visibility status from a JSON API instead of relying on an environment variable. This ensures more flexible control and decouples the display toggle from deployment configuration.

## Additions
- Added `RECALL_CAMPAIGNS_DISPLAY_JSON_URL` constant in `constants/url.js` to point to the visibility configuration JSON.
- Implemented API fetch in `getServerSideProps` of `pages/index.js` to determine `isCampaignsVisible` dynamically.
- Passed `isCampaignsVisible` prop to `RecallCampaigns` component for conditional rendering.

## Removals
- Removed `IS_SPECIAL_EVENT` constant from `config/index.mjs`.
- Removed environment variable `NEXT_PUBLIC_SPECIALEVENT` from `cloudbuild.yaml`.

## Changes
- Updated `RecallCampaigns` component to remove direct dependency on `IS_SPECIAL_EVENT`.
- Modified `pages/index.js` to render `RecallCampaigns` only when `isCampaignsVisible` is true.

## Testing
- Verified API response controls visibility correctly across different environments.
- Checked that when `display_iframe_{ENV}` equals `TRUE`, the section renders as expected.
- Confirmed no regressions in homepage layout or other sections.

## Screenshots
- N/A

## Todos
- Monitor post-deployment to ensure JSON API availability and correct environment key usage.
- Remove related TODO comments after campaign period ends.

## Task Links
- N/A
