### PR TITLE
fix(promo-video-list): improve preview image resolution when width < 360px by updating width and related styles

### DIFF
--- a/packages/mirror-media-next/components/index/promo-video-list.js
+++ b/packages/mirror-media-next/components/index/promo-video-list.js
@@ -60,9 +60,27 @@ const Ol = styled.ol`
   }
 `
 
+const ytWrapperClass = 'yt-wrapper'
+const ytIframeClass = 'yt-iframe'
+
 const Li = styled.li`
   flex: 0 0 auto;
-  width: 320px;
+  width: 360px;
+
+  .${ytWrapperClass} {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+  }
+
+  .${ytWrapperClass} > iframe.${ytIframeClass} {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
 `
 
 const ArrowButtonBase = styled.button`
@@ -127,8 +145,6 @@ const SCROLL_STEP_COUNT = 2
 
 /** @type {import('react-youtube').YouTubeProps['opts'] & { playerVars: { mute?: 0 | 1 }}} */
 const opts = {
-  width: 320,
-  height: 180,
   playerVars: {
     // https://developers.google.com/youtube/player_parameters
     autoplay: 0,
@@ -266,6 +282,8 @@ export default function PromoVideoList({ promoVideos }) {
                   videoId={youtubeId}
                   id={youtubeId}
                   title="Embedded youtube"
+                  className={ytWrapperClass}
+                  iframeClassName={ytIframeClass}
                   opts={opts}
                 />
               </Li>


### PR DESCRIPTION
fix: improve preview image resolution under 360px width

Improves the quality of YouTube preview images on smaller screen widths by updating the iframe and wrapper styles to ensure better rendering.

## Additions  
- New YouTube wrapper class (`yt-wrapper`) with 100% width and 16:9 aspect ratio
- New YouTube iframe class (`yt-iframe`) to apply absolute positioning and full size
- Explicit iframe and wrapper class names passed to `react-youtube` component

## Removals  
- N/A

## Changes  
- Increased `<li>` width from `320px` to `360px` to improve initial resolution
- Removed hardcoded `width` and `height` in `opts` used by YouTube player
- Updated styles to ensure iframe scales properly inside a responsive wrapper

## Testing  
- Tested on mobile devices and browsers with viewport width below 360px
- Verified that preview thumbnails now load in higher resolution consistently

## Screenshots  
- N/A

## Todos  
- N/A

## Task Links  
[【鏡週刊】首頁新增影音區塊 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1210737680990905?focus=true)
