### PR TITLE
feat: improve HeroImage responsiveness and logo sizing  

### DIFF
--- a/packages/mirror-media-next/components/ads/gpt/gpt-placeholder.js
+++ b/packages/mirror-media-next/components/ads/gpt/gpt-placeholder.js
@@ -43,7 +43,7 @@ const DEFAULT_SIZES = {
 
 /**
  * Build display CSS by displayAt.
- * @param {PlaceholderStyleProps & { theme: any }} styleProps
+ * @param {PlaceholderStyleProps & { theme: import('../../../styles/theme/media').Theme }} styleProps
  */
 const displayByBreakpoint = (styleProps) => {
   const { $displayAt, $visible, theme } = styleProps
@@ -98,7 +98,7 @@ const displayByBreakpoint = (styleProps) => {
 /** @type {import('styled-components').StyledComponent<'div', any, PlaceholderStyleProps>} */
 const Container = styled.div(
   /**
-   * @param {PlaceholderStyleProps & { theme: any }} styleProps
+   * @param {PlaceholderStyleProps & { theme: import('../../../styles/theme/media').Theme }} styleProps
    */
   (styleProps) => css`
     position: relative;
@@ -125,7 +125,7 @@ const Container = styled.div(
 /** @type {import('styled-components').StyledComponent<'div', any, { $visible: boolean }>} */
 const ContainerAside = styled.div(
   /**
-   * @param {{ $visible: boolean, theme: any }} styleProps
+   * @param {{ $visible: boolean, theme: import('../../../styles/theme/media').Theme }} styleProps
    */
   (styleProps) => css`
     display: none;

--- a/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
+++ b/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import Image from 'next/image'
 import defaultImage from '../../../public/images-next/default-og-img.png'
 /**
- * @typedef {Pick<import('../../../apollo/fragments/post').HeroImage ,'id' | 'resized' | 'resizedWebp'>} HeroImage
+ * @typedef {Pick<import('../../../apollo/fragments/post').HeroImage ,'id' | 'resized' | 'resizedWebp' | "imageFile">} HeroImage
  */
 
 /**
@@ -17,17 +17,41 @@ const Wrapper = styled.figure`
   }
 `
 
-const HeroImage = styled.figure`
-  position: relative;
-  width: 100%;
-  .readr-media-react-image {
-    object-position: center center;
-  }
+/**
+ * @typedef {Object} HeroImageProps
+ * @property {number} [$imgWidth] - Original image width
+ * @property {number} [$imgHeight] - Original image height
+ */
 
-  ${({ theme }) => theme.breakpoint.md} {
-    width: 640px;
-  }
-`
+/** @type {import('styled-components').StyledComponent<'figure', any, HeroImageProps , never>} */
+const HeroImage = styled('figure')(
+  /**
+   * @param {HeroImageProps & { theme: import('../../../styles/theme/media').Theme }} props
+   */
+  ({ $imgWidth, $imgHeight, theme }) => `
+    position: relative;
+    width: 100%;
+    aspect-ratio: ${
+      $imgWidth && $imgHeight ? `${$imgWidth} / ${$imgHeight}` : '16 / 9'
+    };
+    overflow: hidden;
+
+    .readr-media-react-image {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      object-position: center center;
+    }
+
+    @media ${theme.breakpoint.md} {
+      width: 640px;
+    }
+  `
+)
+
 const HeroCaption = styled.figcaption`
   width: 100%;
   min-height: 22px;
@@ -93,7 +117,10 @@ export default function HeroImageAndVideo({
       )
     } else if (shouldShowHeroImage) {
       return (
-        <HeroImage>
+        <HeroImage
+          $imgWidth={heroImage?.imageFile?.width}
+          $imgHeight={heroImage?.imageFile?.height}
+        >
           <CustomImage
             images={heroImage.resized}
             imagesWebP={heroImage.resizedWebp}

--- a/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
+++ b/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
@@ -32,7 +32,9 @@ const HeroImage = styled('figure')(
     position: relative;
     width: 100%;
     aspect-ratio: ${
-      $imgWidth && $imgHeight ? `${$imgWidth} / ${$imgHeight}` : '16 / 9'
+      Number($imgWidth) > 0 && Number($imgHeight) > 0
+        ? `${Number($imgWidth)} / ${Number($imgHeight)}`
+        : '16 / 9'
     };
     overflow: hidden;
 

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -259,12 +259,17 @@ const SectionAndLogo = styled.div`
     margin-top: 20px;
     justify-content: left;
   }
+`
 
-  img {
-    margin-right: 8px;
-    ${({ theme }) => theme.breakpoint.md} {
-      margin-right: 12px;
-    }
+const LogoBox = styled.div`
+  width: 20px;
+  height: 20px;
+  margin-right: 8px;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    width: 32px;
+    height: 32px;
+    margin-right: 12px;
   }
 `
 
@@ -689,12 +694,14 @@ export default function StoryNormalStyle({
           <SectionAndLogo>
             {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
             <a className="link-to-index" href="/" aria-label="go-to-index-page">
-              <Image
-                width={isMobileWidth ? 20 : 32}
-                height={isMobileWidth ? 20 : 32}
-                alt="mm-logo"
-                src="/images-next/logo-circle@2x.png"
-              ></Image>
+              <LogoBox>
+                <Image
+                  width={32}
+                  height={32}
+                  alt="mm-logo"
+                  src="/images-next/logo-circle@2x.png"
+                />
+              </LogoBox>
             </a>
             {postData.isAdvertised ? (
               <div />

--- a/packages/mirror-media-next/styles/theme/media.js
+++ b/packages/mirror-media-next/styles/theme/media.js
@@ -7,6 +7,11 @@ const mediaSize = {
   xxl: 1440,
 }
 
+/**
+ * @typedef {Object} Theme
+ * @property {typeof breakpoint} breakpoint - Media query breakpoints
+ */
+
 export const breakpoint = {
   xs: `@media (min-width: ${mediaSize.xs}px)`,
   sm: `@media (min-width: ${mediaSize.sm}px)`,


### PR DESCRIPTION
Refactored HeroImage to use aspect-ratio container for CLS prevention and extracted LogoBox for consistent responsive logo sizing.  

## Additions  
- Added `HeroImageProps` type with `$imgWidth` and `$imgHeight` for aspect-ratio calculation  
- Introduced `LogoBox` styled component to handle logo sizing consistently  
- Added `Theme` typedef in `media.js` for typed theme breakpoint support  

## Removals  
- N/A  

## Changes  
- Updated `HeroImage` to use aspect-ratio container based on original image dimensions  
- Adjusted `CustomImage` to fit within aspect-ratio wrapper  
- Replaced inline logo sizing logic with `LogoBox` styled component  
- Updated JSDoc types in `gpt-placeholder.js` to use `Theme` import instead of `any`  

## Testing  
- Verified HeroImage maintains correct aspect ratio across devices  
- Checked logo renders at `20x20` on mobile and `32x32` on desktop  
- Confirmed no CLS issues remain on Story pages  

## Screenshots  
- N/A  

## Todos  
- N/A  

## Task Links  
[【鏡週刊】行動裝置（文章頁面）出現CLS問題 - Asana](https://app.asana.com/1/614399484723017/project/1211193124403759/task/1211168348683367?focus=true)
