### PR TITLE
feat(topic-page): adjust list and group articles layout, add publishedDate, and CSS class names  

### DIFF
--- a/packages/mirror-media-next/README.md
+++ b/packages/mirror-media-next/README.md
@@ -53,6 +53,12 @@ Ref: [ECMAScript Modules | Node.js](https://nodejs.org/docs/latest-v13.x/api/esm
 
 該className僅用於協助Google Tag Manager蒐集數據，請勿使用該className切版。
 
+### 在調整 element 的 className 時需注意
+在調整 element 的 `className` 時，請特別留意 story、topic 頁面：  
+這些頁面上的部分 `className` 可能是前人刻意保留，用於 CMS 傳遞的自訂 CSS style，用來覆寫原有樣式。
+
+請勿隨意刪除或更動，避免造成某些特定頁面樣式錯誤。
+
 ### 使用 JSDoc 寫出與 TypeScript 中 `as const` 等效的註解
 ```
 /** @type {const} */ ([something]) 

--- a/packages/mirror-media-next/components/topic/group/group-articles-item.js
+++ b/packages/mirror-media-next/components/topic/group/group-articles-item.js
@@ -60,6 +60,7 @@ const ItemDate = styled.div`
   }
 `
 
+// Empty for now, kept for consistency with topic page list-articles structure
 const ItemDetail = styled.div``
 
 const ItemTitle = styled.h3`
@@ -151,7 +152,7 @@ export default function GroupArticlesItem({ item }) {
       </ImageContainer>
       <ItemDetail className="groupListBlockContent">
         {publishedDate && (
-          <ItemDate className="ItemDate">
+          <ItemDate className="itemDate">
             {transformTimeData(publishedDate, 'slashWithTime')}
           </ItemDate>
         )}

--- a/packages/mirror-media-next/components/topic/group/group-articles-item.js
+++ b/packages/mirror-media-next/components/topic/group/group-articles-item.js
@@ -1,31 +1,38 @@
 import styled from 'styled-components'
 import Image from '@readr-media/react-image'
 
+import { transformTimeData } from '../../../utils'
+import { color } from '../../../styles/theme/color'
+
 /**
  * @typedef {import('../../../type/theme').Theme} Theme
  */
 
 const ItemWrapper = styled.a`
   display: flex;
+  gap: 12px;
   position: relative;
   width: 300px;
   margin: 0 auto;
+  padding: 12px 0;
   font-size: 18px;
-  padding-bottom: 16px;
   border-bottom: 1px solid #4a4a4a;
-  column-gap: 12px;
+
+  :first-child {
+    padding-top: 0;
+  }
+
+  :last-child {
+    padding-bottom: 0;
+    border-bottom: none;
+  }
+
   ${({ theme }) => theme.breakpoint.md} {
     flex-direction: column;
+    gap: 20px;
     width: 320px;
-    padding-bottom: 36px;
-  }
-  ${({ theme }) => theme.breakpoint.xl} {
-    padding-bottom: 40px;
-    margin-bottom: -1px;
-    &:nth-child(3n-1) {
-      width: 384px;
-      padding: 0 32px;
-    }
+    padding: 0;
+    border-bottom: none;
   }
 `
 
@@ -43,27 +50,35 @@ const ImageContainer = styled.div`
   }
 `
 
-const ItemDetail = styled.div`
+const ItemDate = styled.div`
+  color: ${color.brandColor.black};
+  font-size: 14px;
+  font-weight: 500;
+
   ${({ theme }) => theme.breakpoint.md} {
-    margin-top: 20px;
+    font-size: 16px;
   }
 `
+
+const ItemDetail = styled.div``
 
 const ItemTitle = styled.h3`
   color: #b17f5a;
   display: -webkit-box;
-  -webkit-line-clamp: 5;
+  -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;
   overflow: hidden;
   font-weight: 500;
   font-size: 13px;
   line-height: 18px;
+
   ${({ theme }) => theme.breakpoint.md} {
     font-size: 18px;
     line-height: 26px;
     -webkit-line-clamp: 2;
     height: 52px;
   }
+
   ${({ theme }) => theme.breakpoint.xl} {
     font-size: 18px;
   }
@@ -83,10 +98,6 @@ const ItemBrief = styled.p`
     -webkit-line-clamp: 3;
     -webkit-box-orient: vertical;
     overflow: hidden;
-  }
-
-  ${({ theme }) => theme.breakpoint.xl} {
-    margin-top: 20px;
   }
 `
 
@@ -120,25 +131,32 @@ const ItemBrief = styled.p`
  * @returns {React.ReactElement}
  */
 export default function GroupArticlesItem({ item }) {
+  const { slug, heroImage, title, publishedDate, brief } = item
+
   return (
     <ItemWrapper
-      href={`/story/${item.slug}`}
+      href={`/story/${slug}`}
       target="_blank"
       className="groupArticleItem"
     >
       <ImageContainer>
         <Image
-          images={item.heroImage?.resized}
-          imagesWebP={item.heroImage?.resizedWebp}
-          alt={item.title}
+          images={heroImage?.resized}
+          imagesWebP={heroImage?.resizedWebp}
+          alt={title}
           loadingImage="/images-next/loading.gif"
           defaultImage="/images-next/default-og-img.png"
           rwd={{ mobile: '500px', tablet: '500px', laptop: '500px' }}
         />
       </ImageContainer>
       <ItemDetail className="groupListBlockContent">
-        <ItemTitle>{item.title}</ItemTitle>
-        <ItemBrief>{item.brief?.blocks[0]?.text}</ItemBrief>
+        {publishedDate && (
+          <ItemDate className="ItemDate">
+            {transformTimeData(publishedDate, 'slashWithTime')}
+          </ItemDate>
+        )}
+        <ItemTitle>{title}</ItemTitle>
+        <ItemBrief>{brief?.blocks[0]?.text}</ItemBrief>
       </ItemDetail>
     </ItemWrapper>
   )

--- a/packages/mirror-media-next/components/topic/group/topic-group-articles.js
+++ b/packages/mirror-media-next/components/topic/group/topic-group-articles.js
@@ -51,7 +51,7 @@ const GroupArticles = styled.div`
   }
   ${({ theme }) => theme.breakpoint.xl} {
     width: 1024px;
-    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-columns: repeat(3, 1fr);
   }
 `
 

--- a/packages/mirror-media-next/components/topic/group/topic-group-articles.js
+++ b/packages/mirror-media-next/components/topic/group/topic-group-articles.js
@@ -2,6 +2,11 @@ import styled from 'styled-components'
 import GroupArticlesItem from './group-articles-item'
 
 const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
   &:first-of-type h2 {
     padding: 16px 0 19px;
   }
@@ -20,7 +25,7 @@ const Container = styled.div`
 const GroupTitle = styled.h2`
   padding: 20px 0 19px;
   text-align: center;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 24px;
   line-height: 1.5;
   color: #b17f5a;
@@ -37,17 +42,16 @@ const GroupArticles = styled.div`
   display: grid;
   grid-template-columns: 320px;
   justify-content: center;
-  row-gap: 20px;
   margin: 0 auto;
   ${({ theme }) => theme.breakpoint.md} {
     grid-template-columns: repeat(2, 320px);
-    gap: 36px 32px;
+    gap: 24px 32px;
+    padding-bottom: 24px;
+    border-bottom: 2px solid #4a4a4a;
   }
   ${({ theme }) => theme.breakpoint.xl} {
     width: 1024px;
-    grid-template-columns: 320px 384px 320px;
-    column-gap: unset;
-    border-bottom: 1px solid #4a4a4a;
+    grid-template-columns: 1fr 1fr 1fr;
   }
 `
 

--- a/packages/mirror-media-next/components/topic/list/list-articles-item.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles-item.js
@@ -136,8 +136,12 @@ export default function ListArticlesItem({ item }) {
   const itemSection = sections.find((section) => section.slug !== 'member')
 
   return (
-    <ItemWrapper href={`/story/${slug}`} target="_blank">
-      <ImageContainer>
+    <ItemWrapper
+      className="itemWrapper"
+      href={`/story/${slug}`}
+      target="_blank"
+    >
+      <ImageContainer className="imageContainer">
         <Image
           images={heroImage?.resized}
           imagesWebP={heroImage?.resizedWebp}
@@ -147,19 +151,19 @@ export default function ListArticlesItem({ item }) {
           rwd={{ mobile: '500px', tablet: '500px', desktop: '500px' }}
         />
         {itemSection && (
-          <ItemSection sectionName={itemSection?.slug}>
+          <ItemSection className="itemSection" sectionName={itemSection?.slug}>
             {itemSection?.name}
           </ItemSection>
         )}
       </ImageContainer>
       {publishedDate && (
-        <ItemDate className="ItemDate">
+        <ItemDate className="itemDate">
           {transformTimeData(publishedDate, 'slashWithTime')}
         </ItemDate>
       )}
-      <ItemDetail>
-        <ItemTitle>{title}</ItemTitle>
-        <ItemBrief>{brief?.blocks[0]?.text}</ItemBrief>
+      <ItemDetail className="itemDetail">
+        <ItemTitle className="itemTitle">{title}</ItemTitle>
+        <ItemBrief className="itemBrief">{brief?.blocks[0]?.text}</ItemBrief>
       </ItemDetail>
     </ItemWrapper>
   )

--- a/packages/mirror-media-next/components/topic/list/list-articles-item.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles-item.js
@@ -59,6 +59,7 @@ const ItemSection = styled.div`
 const ItemDate = styled.div`
   color: ${color.brandColor.darkBlue};
   font-size: 16px;
+  font-weight: 500;
 `
 
 const ItemDetail = styled.div`

--- a/packages/mirror-media-next/components/topic/list/list-articles-item.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles-item.js
@@ -1,11 +1,16 @@
 import styled from 'styled-components'
 import Image from '@readr-media/react-image'
 
+import { transformTimeData } from '../../../utils'
+import { color } from '../../../styles/theme/color'
+
 /** @typedef {import('../../../type/theme').Theme} Theme */
 
 const ItemWrapper = styled.a`
-  display: block;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
   width: 100%;
   margin: 0 auto;
   font-size: 18px;
@@ -34,7 +39,7 @@ const ItemSection = styled.div`
   color: white;
   font-size: 18px;
   font-weight: 600;
-  border-radius: 16px;
+  border-radius: 0 16px 16px 16px;
   background-color: ${
     /**
      * @param {Object} props
@@ -51,15 +56,19 @@ const ItemSection = styled.div`
   }
 `
 
+const ItemDate = styled.div`
+  color: ${color.brandColor.darkBlue};
+  font-size: 16px;
+`
+
 const ItemDetail = styled.div`
-  margin: 20px 20px 36px 20px;
-  ${({ theme }) => theme.breakpoint.md} {
-    margin: 8px 8px 40px 8px;
-  }
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 `
 
 const ItemTitle = styled.div`
-  color: #054f77;
+  color: ${color.brandColor.darkBlue};
   line-height: 25px;
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -77,18 +86,12 @@ const ItemTitle = styled.div`
 const ItemBrief = styled.div`
   font-size: 16px;
   color: #979797;
-  margin-top: 20px;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
 
-  ${({ theme }) => theme.breakpoint.md} {
-    margin-top: 16px;
-  }
-
   ${({ theme }) => theme.breakpoint.xl} {
-    margin-top: 20px;
     -webkit-line-clamp: 4;
   }
 `
@@ -128,15 +131,16 @@ const ItemBrief = styled.div`
  * @returns {React.ReactElement}
  */
 export default function ListArticlesItem({ item }) {
-  const itemSection = item.sections.find((section) => section.slug !== 'member')
+  const { slug, sections, heroImage, title, publishedDate, brief } = item
+  const itemSection = sections.find((section) => section.slug !== 'member')
 
   return (
-    <ItemWrapper href={`/story/${item.slug}`} target="_blank">
+    <ItemWrapper href={`/story/${slug}`} target="_blank">
       <ImageContainer>
         <Image
-          images={item.heroImage?.resized}
-          imagesWebP={item.heroImage?.resizedWebp}
-          alt={item.title}
+          images={heroImage?.resized}
+          imagesWebP={heroImage?.resizedWebp}
+          alt={title}
           loadingImage="/images-next/loading.gif"
           defaultImage="/images-next/default-og-img.png"
           rwd={{ mobile: '500px', tablet: '500px', desktop: '500px' }}
@@ -147,9 +151,14 @@ export default function ListArticlesItem({ item }) {
           </ItemSection>
         )}
       </ImageContainer>
+      {publishedDate && (
+        <ItemDate className="ItemDate">
+          {transformTimeData(publishedDate, 'slashWithTime')}
+        </ItemDate>
+      )}
       <ItemDetail>
-        <ItemTitle>{item.title}</ItemTitle>
-        <ItemBrief>{item.brief?.blocks[0]?.text}</ItemBrief>
+        <ItemTitle>{title}</ItemTitle>
+        <ItemBrief>{brief?.blocks[0]?.text}</ItemBrief>
       </ItemDetail>
     </ItemWrapper>
   )

--- a/packages/mirror-media-next/components/topic/list/list-articles.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles.js
@@ -6,15 +6,17 @@ const ItemContainer = styled.div`
   grid-template-columns: 320px;
   justify-content: center;
   row-gap: 28px;
-  margin-top: 40px;
+  margin: 28px 0;
 
   ${({ theme }) => theme.breakpoint.md} {
     grid-template-columns: repeat(3, 220px);
     gap: 36px 20px;
+    margin: 32px 0;
   }
   ${({ theme }) => theme.breakpoint.xl} {
     grid-template-columns: repeat(4, 220px);
     gap: 36px 48px;
+    margin: 40px 0;
   }
 `
 
@@ -29,7 +31,7 @@ const ItemContainer = styled.div`
  */
 export default function ListArticles({ renderList }) {
   return (
-    <ItemContainer>
+    <ItemContainer className="itemContainer">
       {renderList.map((item) => (
         <ListArticlesItem key={item.id} item={item} />
       ))}

--- a/packages/mirror-media-next/components/topic/list/list-articles.js
+++ b/packages/mirror-media-next/components/topic/list/list-articles.js
@@ -5,16 +5,16 @@ const ItemContainer = styled.div`
   display: grid;
   grid-template-columns: 320px;
   justify-content: center;
-  row-gap: 20px;
+  row-gap: 28px;
   margin-top: 40px;
 
   ${({ theme }) => theme.breakpoint.md} {
     grid-template-columns: repeat(3, 220px);
-    gap: 32px 10px;
+    gap: 36px 20px;
   }
   ${({ theme }) => theme.breakpoint.xl} {
     grid-template-columns: repeat(4, 220px);
-    gap: 48px;
+    gap: 36px 48px;
   }
 `
 


### PR DESCRIPTION
Align topic page article components (`list-articles` and `group-articles`) with Figma design. Added published date display, introduced semantic class names for CSS styling, and refined responsive layouts.  

## Additions  
- Published date rendering in both `ListArticlesItem` and `GroupArticlesItem`.  
- Semantic class names (`itemWrapper`, `imageContainer`, `itemSection`, `itemDetail`, etc.) for CSS targeting.  

## Removals  
- N/A  

## Changes  
- Updated `ItemWrapper`, `ItemTitle`, `ItemBrief`, and related styled-components to match Figma specs.  
- Adjusted responsive grid and spacing for `ListArticles` and `GroupArticles`.  
- Tweaked typography (font sizes, weights, and line clamps) for better readability.  
- Unified prop destructuring for cleaner component code.  

## Testing  
- Verified topic page renders correctly across breakpoints (mobile, tablet, desktop).  
- Checked published date display and ensured fallback when missing.  
- Confirmed class names apply correctly for custom CSS overrides.  

## Screenshots  
- N/A  

## Todos  
- After deploying to `dev`, check styles on this page: https://dev.mirrormedia.mg/topic/topic-inner-voice-page  

## Task Links  
[【鏡週刊】心內話頁面需要新增topic樣式 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1211351933190017?focus=true)