### PR TITLE
feat(RelatedArticleList): enhance link generation for MISO and GQL related articles

### DIFF
--- a/packages/mirror-media-next/components/story/normal/related-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/related-article-list.js
@@ -31,7 +31,7 @@ const StyledPopInAdRelated = dynamic(
 
 /**
  * @typedef {(import('../../../apollo/fragments/post').Related & {
- *  id: string, slug: string, title: string, heroImage: HeroImage})[]
+ *  id: string, slug: string, title: string, heroImage: HeroImage, url: string, __typename: string})[]
  * } Relateds
  */
 
@@ -207,7 +207,12 @@ export default function RelatedArticleList({
         <li key={related.id}>
           <Article>
             <Link
-              href={`/story/${related.slug}`}
+              href={
+                related.url ??
+                `${related.__typename === 'Post' ? '/story' : '/external'}/${
+                  related.slug
+                }`
+              }
               target="_blank"
               className={`article-image GTM-story-related-list ${
                 related.isMesoRecommend
@@ -231,7 +236,12 @@ export default function RelatedArticleList({
 
             <StyledFigcaption className="article-title">
               <Link
-                href={`/story/${related.slug}`}
+                href={
+                  related.url ??
+                  `${related.__typename === 'Post' ? '/story' : '/external'}/${
+                    related.slug
+                  }`
+                }
                 className={`GTM-story-related-list ${
                   related.isMesoRecommend
                     ? 'GTM-story-related-miso'


### PR DESCRIPTION
### 描述
- story 頁和 external 頁共用同份檔案（`/components/story/normal/related-article-list.js`）來渲染「延伸閱讀」區塊。其中，每則文章的標題和圖片超連結原本是寫死成 `/story/${related.slug}`，現改為先判斷每個相關文章物件是否有 `url`屬性（有的話代表是 Miso 推薦，沒有的話代表來自 CMS 後台上稿），有的話就直接使用 ; 沒有的話，則判斷 `__typename` 屬性的值是否為 `'Post'`，是的話，路徑就寫`/story/${related.slug}`，不是的話，路徑就寫`/external/${related.slug}`。
- 承上，把文章物件陣列輸出到主控台的話，會像下面這樣：第一到第五個物件來源為 GQL，第六到第十個物件來源為 Miso API。主要差別在 GQL 有  `__typename` 屬性、沒有 `url`屬性，Miso 則剛好相反。

-  <img width="700"  alt="截圖 2025-11-06 下午12 57 44" src="https://github.com/user-attachments/assets/31f9979c-5e3e-4ee8-8fe5-9cdbb5f0118b" />

**任務卡**
https://app.asana.com/1/614399484723017/project/1211801299164510/task/1211779046536288?focus=true
