### PR TITLE
feat(membership): align article UI and entry points with updated business strategy  

### DIFF
--- a/packages/mirror-media-next/components/magazine/ui-join-premium-member.js
+++ b/packages/mirror-media-next/components/magazine/ui-join-premium-member.js
@@ -101,11 +101,11 @@ export default function JoinPremiumMember() {
     <Wrapper>
       <InfoWrapper>
         <Title>動態雜誌</Title>
-        <Subtitle>加入 premium 會員，免費閱覽最新電子版週刊</Subtitle>
+        <Subtitle>加入premium會員，換取一整個世界的即時更新，立即訂閱</Subtitle>
         <Box>
           <p className="textL">準備好升級為鏡週刊 Premium 會員了嗎？</p>
           <p className="textS">
-            每月 ${PRIZE_LIST.monthly} 元，暢享專區零廣告閱讀、優質報導看到飽
+            {`每期 $${PRIZE_LIST.monthly} 元，即時享受所有文章的無限閱讀，零限制探索知識的邊界。`}
           </p>
           <SubscribeLink className="subscribe-btn" />
         </Box>

--- a/packages/mirror-media-next/components/story/normal/subscribe-invite-banner.js
+++ b/packages/mirror-media-next/components/story/normal/subscribe-invite-banner.js
@@ -18,6 +18,7 @@ const Wrapper = styled.div`
     margin-top: 32px;
   }
   a {
+    margin: 0 4px;
     color: rgba(234, 193, 81, 1);
     font-weight: 600;
     border-bottom: 1px solid rgba(234, 193, 81, 1);
@@ -39,8 +40,8 @@ export default function SubscribeInviteBanner() {
   return (
     <Wrapper>
       <p>
-        鏡週刊訂閱制上線，讓有價的閱聽成就更多優質文章，並獻上無廣告的閱讀環境，讓您盡情享受15類會員專屬內容，誠摯邀請您
-        <Link href={href}>立即加入</Link>。
+        鏡週刊掌握趨勢，領先一步：從國際大事到生活小確幸，我們確保您不錯過任何一個重要瞬間，誠摯邀請您
+        <Link href={href}>立即加入閱讀</Link>。
       </p>
     </Wrapper>
   )

--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -23,6 +23,7 @@ import { SECTION_IDS } from '../../../constants/index'
 import { getCategoryOfWineSlug, getActiveOrderSection } from '../../../utils'
 import GPTMbStAd from '../../../components/ads/gpt/gpt-mb-st-ad'
 import { GPT_Placeholder } from '../../ads/gpt/gpt-placeholder'
+import { ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE } from '../../../config/index.mjs'
 
 const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -190,7 +191,10 @@ export default function StoryPremiumStyle({
   classNameForGTM = '',
   allRelatedStories = [],
 }) {
-  const { isLoggedIn, memberInfo } = useMembership()
+  const {
+    // isLoggedIn,
+    memberInfo,
+  } = useMembership()
   const { memberType } = memberInfo
 
   const {
@@ -219,8 +223,18 @@ export default function StoryPremiumStyle({
     hiddenAdvertised = false,
   } = postData
 
-  const shouldShowArticleMask =
-    !isLoggedIn || postContent.type === 'trimmedContent'
+  /**
+   * Determines whether to render the ArticleMask (paywall container).
+   *
+   * Previously, the paywall was rendered only when the user was not logged in || postContent.type === 'trimmedContent'
+   * After the business logic change, this decision is controlled by a global
+   * policy flag (`ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE`) to separate paywall behavior
+   * from authentication state.
+   */
+  const shouldRenderArticleMask =
+    ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE ||
+    postContent.type === 'trimmedContent'
+
   const h2AndH3Block = getContentBlocksH2H3(postContent.data)
 
   const sectionsWithOrdered = getActiveOrderSection(
@@ -332,7 +346,7 @@ export default function StoryPremiumStyle({
               pageKeyForGptAd={pageKeyForGptAd}
             />
             <CopyrightWarning />
-            {shouldShowArticleMask && <ArticleMask postId={id} />}
+            {shouldRenderArticleMask && <ArticleMask postId={id} />}
             {supportBanner}
             {shouldShowAd && (
               <GPTAdContainer>

--- a/packages/mirror-media-next/components/story/shared/article-mask.js
+++ b/packages/mirror-media-next/components/story/shared/article-mask.js
@@ -7,9 +7,10 @@ import { useMembership } from '../../../context/membership'
 import { PRIZE_LIST } from '../../../constants/subscribe-constants'
 import { getLoginHref } from '../../../utils'
 import {
-  ALLOW_NON_PREMIUM_ACCESS,
+  ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE,
   IS_ANNIVERSARY_PROMO_ACTIVE,
 } from '../../../config/index.mjs'
+
 const inviteMemberOptionColor = {
   premium: {
     description: '#61B8C6', //light blue of theme color
@@ -68,6 +69,7 @@ const OptionWrapper = styled.div`
 `
 const InviteMemberOption = styled.div`
   height: fit-content;
+  width: 100%;
   margin-bottom: 32px;
   .description {
     text-align: center;
@@ -107,7 +109,8 @@ const InviteMemberCard = ({ postId = '' }) => {
       <OptionWrapper>
         <InviteMemberOption optionType="premium">
           <p className="description">
-            限時優惠每月${PRIZE_LIST.monthly}元 <br></br>全站看到飽
+            每期 ${PRIZE_LIST.monthly} 元可享獨家新聞 <br />
+            無限暢讀
           </p>
 
           <Link
@@ -118,23 +121,26 @@ const InviteMemberCard = ({ postId = '' }) => {
             加入premium會員
           </Link>
         </InviteMemberOption>
-        <InviteMemberOption optionType="oneTime">
-          <p className="description">
-            ＄{PRIZE_LIST.oneTime}元可享單篇好文14天 <br></br>無限瀏覽
-          </p>
+        {!ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE && (
+          <InviteMemberOption optionType="oneTime">
+            <p className="description">
+              ＄{PRIZE_LIST.oneTime}元可享單篇好文14天 <br />
+              無限瀏覽
+            </p>
 
-          <Link
-            href={
-              postId
-                ? `/subscribe/info?plan=${Frequency.OneTimeHyphen}&one-time-post-id=${postId}`
-                : '/subscribe'
-            }
-            className="link GTM-subscribe-one-time"
-            target="blank"
-          >
-            解鎖單篇報導
-          </Link>
-        </InviteMemberOption>
+            <Link
+              href={
+                postId
+                  ? `/subscribe/info?plan=${Frequency.OneTimeHyphen}&one-time-post-id=${postId}`
+                  : '/subscribe'
+              }
+              className="link GTM-subscribe-one-time"
+              target="blank"
+            >
+              解鎖單篇報導
+            </Link>
+          </InviteMemberOption>
+        )}
       </OptionWrapper>
       <p className="already-member">
         {isLoggedIn ? null : (
@@ -149,22 +155,40 @@ const InviteMemberCard = ({ postId = '' }) => {
     </InviteMemberCardWrapper>
   )
 }
+
 const Wrapper = styled.div`
   width: 100%;
-
   margin: 0 auto;
   position: relative;
-  &::before {
-    content: '';
-    position: absolute;
-    bottom: 100%;
-    width: 100%;
-    height: 300px;
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, white 80%);
+
+  ${
+    /**
+     * Controls the visual gradient mask only.
+     * @param {{ $showMask?: boolean }} props
+     * Disabled when non-premium users are allowed full access.
+     */
+    ({ $showMask = false }) =>
+      $showMask &&
+      `
+    &::before {
+      content: '';
+      position: absolute;
+      bottom: 100%;
+      width: 100%;
+      height: 300px;
+      background: linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0) 0%,
+        white 80%
+      );
+    }
+  `
   }
 `
+
 /**
- * The Article Mask for story page, displayed when user is not subscribe certain member only article.
+ * ArticleMask acts as a paywall container for story pages.
+ * It may render subscription prompts and optionally apply a visual mask.
  * @param {Object} props
  * @param {string} props.postId
  * @returns
@@ -178,10 +202,13 @@ export default function ArticleMask({ postId = '' }) {
    */
 
   // TODO: 周年慶完結後要移除 IS_ANNIVERSARY_PROMO_ACTIVE
-  if (IS_ANNIVERSARY_PROMO_ACTIVE || ALLOW_NON_PREMIUM_ACCESS) return null
+  if (IS_ANNIVERSARY_PROMO_ACTIVE) return null
 
   return (
-    <Wrapper className="paywall">
+    <Wrapper
+      className="paywall"
+      $showMask={!ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE}
+    >
       <InviteMemberCard postId={postId}></InviteMemberCard>
     </Wrapper>
   )

--- a/packages/mirror-media-next/components/story/shared/magazine-invite-banner.js
+++ b/packages/mirror-media-next/components/story/shared/magazine-invite-banner.js
@@ -42,7 +42,7 @@ const Wrapper = styled.div`
 // TODO: 周年慶完結後要恢復 '月費、年費會員免費線上閱讀動態雜誌'
 const inviteText = IS_ANNIVERSARY_PROMO_ACTIVE
   ? '活動期間，動態雜誌免費線上閱讀'
-  : '月費、年費會員免費線上閱讀動態雜誌'
+  : '獨家深度分析報導'
 
 /**
  *

--- a/packages/mirror-media-next/components/story/shared/support-mirrormedia-banner.js
+++ b/packages/mirror-media-next/components/story/shared/support-mirrormedia-banner.js
@@ -111,9 +111,9 @@ export default function SupportMirrorMediaBanner({ className }) {
         {!IS_ANNIVERSARY_PROMO_ACTIVE && (
           <InnerBox>
             <p className="desc">
-              每月 ${PRIZE_LIST.monthly} 元全站看到飽
+              每期 ${PRIZE_LIST.monthly} 元動態話題報導
               <br />
-              暢享無廣告閱讀體驗
+              無限閱讀解鎖新鮮事
             </p>
             <SubscribeLink className="banner-button GTM-subscribe-link-bottom" />
           </InnerBox>

--- a/packages/mirror-media-next/components/story/wide/index.js
+++ b/packages/mirror-media-next/components/story/wide/index.js
@@ -22,6 +22,7 @@ import ButtonSocialNetworkShare from '../shared/button-social-network-share'
 import Aside from '../shared/aside'
 import { getActiveOrderSection } from '../../../utils'
 import ArticleBrief from '../shared/brief'
+import { ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE } from '../../../config/index.mjs'
 
 /**
  * @typedef {import('../../../apollo/fragments/post').Post} PostData
@@ -179,7 +180,13 @@ export default function StoryWideStyle({
 
   const h2AndH3Block = getContentBlocksH2H3(postContent.data)
 
-  const shouldShowArticleMask = postContent.type === 'trimmedContent'
+  /**
+   * Determines whether to render the ArticleMask (paywall container).
+   * Rendering this component does not necessarily enable visual masking.
+   */
+  const shouldRenderArticleMask =
+    ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE ||
+    postContent.type === 'trimmedContent'
 
   const { memberInfo } = useMembership()
   const { memberType } = memberInfo
@@ -188,7 +195,7 @@ export default function StoryWideStyle({
 
   let supportBanner
 
-  if (!shouldShowArticleMask) {
+  if (!shouldRenderArticleMask) {
     if (isPremiumMember) {
       supportBanner = <SupportSingleArticleBanner />
     } else {
@@ -250,7 +257,7 @@ export default function StoryWideStyle({
             </section>
             <MoreInfoAndTag tags={tags} />
 
-            {shouldShowArticleMask && <ArticleMask postId={id} />}
+            {shouldRenderArticleMask && <ArticleMask postId={id} />}
             {supportBanner}
           </ContentWrapper>
           <Aside

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -57,7 +57,7 @@ let URL_STATIC_COLUMN_SECTION_POSTS = ''
 let URL_STATIC_DAILY_COLUMN_HEADLINES = ''
 let IS_ANNIVERSARY_PROMO_ACTIVE = false
 let IS_ANNIVERSARY_MODAL_ACTIVE = false
-let ALLOW_NON_PREMIUM_ACCESS = false
+let ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE = false
 
 /** @type {import("firebase/auth").ActionCodeSettings} */
 let ACTION_CODE_SETTING
@@ -71,15 +71,6 @@ let FIREBASE_AUTH_DOMAIN
 
 let GCP_STACKDRIVER_LOG_NAME = ''
 let GCP_STACKDRIVER_ERROR_LOG_NAME = ''
-
-let IS_PRIZE_RIZED
-
-const now = new Date()
-const currentYear = now.getFullYear()
-// Target time: June 1st, 00:00 AM Taiwan time (UTC+8)
-// JavaScript's month is 0-indexed (0 for January, 4 for May, 5 for June).
-// 00:00 AM on June 1st in Taiwan (UTC+8) is 16:00 (4 PM) on May 31st in UTC.
-const activationDate = new Date(Date.UTC(currentYear, 4, 31, 16, 0, 0)) // Month 4 for May, Day 31, Hour 16 (corresponds to May 31st, 16:00 UTC)
 
 switch (ENV) {
   case 'prod':
@@ -116,7 +107,7 @@ switch (ENV) {
     GTM_ID = 'GTM-NCH86SP'
     IS_ANNIVERSARY_PROMO_ACTIVE = true
     IS_ANNIVERSARY_MODAL_ACTIVE = true
-    ALLOW_NON_PREMIUM_ACCESS = true
+    ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE = false
 
     GPT_MODE = 'prod'
 
@@ -135,7 +126,6 @@ switch (ENV) {
 
     GCP_STACKDRIVER_LOG_NAME = 'mirror-media-next-user-behavior'
     GCP_STACKDRIVER_ERROR_LOG_NAME = 'mirror-media-next-error-log'
-    IS_PRIZE_RIZED = now.getTime() >= activationDate.getTime()
     COURSE_URL = 'https://course.mirrormedia.mg'
 
     break
@@ -178,7 +168,7 @@ switch (ENV) {
     GTM_ID = 'GTM-KVDZ27K'
     IS_ANNIVERSARY_PROMO_ACTIVE = true
     IS_ANNIVERSARY_MODAL_ACTIVE = true
-    ALLOW_NON_PREMIUM_ACCESS = true
+    ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE = false
     GPT_MODE = 'prod'
 
     FIREBASE_AUTH_DOMAIN = 'mirrormedia-staging.firebaseapp.com'
@@ -196,8 +186,6 @@ switch (ENV) {
 
     GCP_STACKDRIVER_LOG_NAME = 'mirror-media-next-user-behavior_staging'
     GCP_STACKDRIVER_ERROR_LOG_NAME = 'mirror-media-next-error-log_staging'
-
-    IS_PRIZE_RIZED = true
 
     COURSE_URL = 'https://course.mirrormedia.mg'
 
@@ -235,7 +223,7 @@ switch (ENV) {
     GTM_ID = 'GTM-PBNLSMX'
     IS_ANNIVERSARY_PROMO_ACTIVE = false
     IS_ANNIVERSARY_MODAL_ACTIVE = false
-    ALLOW_NON_PREMIUM_ACCESS = false
+    ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE = true
     ACCESS_SUBSCRIBE_FEATURE_TOGGLE = 'on'
     DRAFT_RENDERER_FEATURE_TOGGLE = 'on'
     LOGIN_PAGE_FEATURE_TOGGLE = 'on'
@@ -257,7 +245,6 @@ switch (ENV) {
 
     GCP_STACKDRIVER_LOG_NAME = 'mirror-media-next-user-behavior_dev'
     GCP_STACKDRIVER_ERROR_LOG_NAME = 'mirror-media-next-error-log_dev'
-    IS_PRIZE_RIZED = true
 
     COURSE_URL = 'https://dev-course.mirrormedia.mg'
 
@@ -281,7 +268,7 @@ switch (ENV) {
     TEST_GPT_AD_FEATURE_TOGGLE = 'on'
     IS_ANNIVERSARY_PROMO_ACTIVE = false
     IS_ANNIVERSARY_MODAL_ACTIVE = false
-    ALLOW_NON_PREMIUM_ACCESS = false
+    ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE = true
     URL_STATIC_PREMIUM_SECTIONS = `http://localhost:8080/json/header_member.json`
     URL_STATIC_NORMAL_SECTIONS = `http://localhost:8080/json/header_sections.json`
     URL_STATIC_TOPICS = `http://localhost:8080/json/header_topics.json`
@@ -315,7 +302,6 @@ switch (ENV) {
 
     GCP_STACKDRIVER_LOG_NAME = 'mirror-media-next-user-behavior_local'
     GCP_STACKDRIVER_ERROR_LOG_NAME = 'mirror-media-next-error-log_local'
-    IS_PRIZE_RIZED = true
 }
 
 import { FIREBASE_CONFIG } from './firebase.mjs'
@@ -363,7 +349,6 @@ export {
   URL_STATIC_DAILY_COLUMN_HEADLINES,
   WEEKLY_API_SERVER_ORIGIN,
   WEEKLY_API_SERVER_YOUTUBE_ENDPOINT,
-  IS_PRIZE_RIZED,
   COURSE_URL,
   MISO_API_KEY,
   URL_STATIC_COLUMN_SECTION_POSTS,
@@ -371,5 +356,5 @@ export {
   MISO_ENDPOINTS,
   IS_ANNIVERSARY_PROMO_ACTIVE,
   IS_ANNIVERSARY_MODAL_ACTIVE, // TODO: 周年慶完結後跟 IS_ANNIVERSARY_PROMO_ACTIVE 一起刪除
-  ALLOW_NON_PREMIUM_ACCESS,
+  ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE,
 }

--- a/packages/mirror-media-next/constants/subscribe-constants.js
+++ b/packages/mirror-media-next/constants/subscribe-constants.js
@@ -1,9 +1,7 @@
-import { IS_PRIZE_RIZED } from '../config/index.mjs'
-
 const PRIZE_LIST = {
-  yearly: IS_PRIZE_RIZED ? 799 : 499,
-  monthly: IS_PRIZE_RIZED ? 99 : 79,
-  oneTime: 10,
+  yearly: 1800,
+  monthly: 35,
+  oneTime: 10, // This price field is currently not in use 2025.12.15
 }
 
 const PREMIUM_FEATURES = [


### PR DESCRIPTION
Update article rendering and membership-related UI to comply with the latest business model.  

## Additions  
- Enhanced UI logic to toggle visual masks dynamically according to business policy  

## Removals  
- Deleted outdated `IS_PRIZE_RIZED`–based pricing logic  

## Changes  
- Replaced `ALLOW_NON_PREMIUM_ACCESS` with new `ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE` flag, refactored related paywall and open-article logic accordingly  
- Adjusted membership and subscription banners to use new marketing copy  
- Updated `PRIZE_LIST` constants: set `monthly = 35`, `yearly = 1800`, removed dynamic pricing logic  
- Updated `JoinPremiumMember`, `SubscribeInviteBanner`, and `SupportMirrorMediaBanner` with revised wording  
- Revised `StoryPremiumStyle` and `StoryWideStyle` to use `ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE` instead of login state  
- Simplified paywall gradient logic to be optional depending on open-article mode  
- Revised configuration defaults:  
  - `prod`, `staging`: `ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE = false`  
  - `dev`, `local`: `ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE = true`  

## Testing  
- Verified correct rendering of article pages in all environments (dev/staging/prod)  
- Confirmed paywall mask toggles correctly according to the `ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE` flag  
- Manually checked subscription banners and links for accurate copy and functionality  

## Screenshots  
- N/A  

## Todos  
- Remove all `IS_ANNIVERSARY_PROMO_ACTIVE` references after promotional period ends   

## Task Links  
[Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1212234916510825?focus=true)