### PR TITLE
fix: revert premium gating logic and update marketing copy

### DIFF
--- a/packages/mirror-media-next/components/story/premium/index.js
+++ b/packages/mirror-media-next/components/story/premium/index.js
@@ -23,7 +23,6 @@ import { SECTION_IDS } from '../../../constants/index'
 import { getCategoryOfWineSlug, getActiveOrderSection } from '../../../utils'
 import GPTMbStAd from '../../../components/ads/gpt/gpt-mb-st-ad'
 import { GPT_Placeholder } from '../../ads/gpt/gpt-placeholder'
-import { ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE } from '../../../config/index.mjs'
 
 const GPTAd = dynamic(() => import('../../../components/ads/gpt/gpt-ad'), {
   ssr: false,
@@ -191,10 +190,7 @@ export default function StoryPremiumStyle({
   classNameForGTM = '',
   allRelatedStories = [],
 }) {
-  const {
-    // isLoggedIn,
-    memberInfo,
-  } = useMembership()
+  const { isLoggedIn, memberInfo } = useMembership()
   const { memberType } = memberInfo
 
   const {
@@ -223,17 +219,8 @@ export default function StoryPremiumStyle({
     hiddenAdvertised = false,
   } = postData
 
-  /**
-   * Determines whether to render the ArticleMask (paywall container).
-   *
-   * Previously, the paywall was rendered only when the user was not logged in || postContent.type === 'trimmedContent'
-   * After the business logic change, this decision is controlled by a global
-   * policy flag (`ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE`) to separate paywall behavior
-   * from authentication state.
-   */
-  const shouldRenderArticleMask =
-    ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE ||
-    postContent.type === 'trimmedContent'
+  const shouldShowArticleMask =
+    !isLoggedIn || postContent.type === 'trimmedContent'
 
   const h2AndH3Block = getContentBlocksH2H3(postContent.data)
 
@@ -346,7 +333,7 @@ export default function StoryPremiumStyle({
               pageKeyForGptAd={pageKeyForGptAd}
             />
             <CopyrightWarning />
-            {shouldRenderArticleMask && <ArticleMask postId={id} />}
+            {shouldShowArticleMask && <ArticleMask postId={id} />}
             {supportBanner}
             {shouldShowAd && (
               <GPTAdContainer>

--- a/packages/mirror-media-next/pages/marketing/index.js
+++ b/packages/mirror-media-next/pages/marketing/index.js
@@ -59,8 +59,7 @@ function Subscribe({ sectionsData = [], topicsData = [] }) {
         <BlankCard>
           <Title>此頁面為個人會員訂閱頁面</Title>
           <Text>
-            由於您為鏡週刊的 VIP 或團體訂購，VIP
-            及團體訂購期間不須付款即享會員專區文章暢讀。
+            由於您為鏡週刊的 VIP ， VIP 期間不須付款即享會員專區文章暢讀。
             若您有意願付費支持，請於期間後再付款。
           </Text>
           <PrimaryBlueBtn title="回會員專區" href="/premiumsection/member" />


### PR DESCRIPTION
Reverted unintended logic changes in `story/premium` and adjusted VIP messaging on the marketing page per PM feedback.

## Additions  
- N/A  

## Removals  
- Removed global open-article flag logic  

## Changes  
- Restored original article mask logic  
- Updated marketing page VIP copy  

## Testing  
- Verified paywall behavior and text changes  

## Screenshots  
- N/A  

## Todos  
- N/A  

## Task Links  
[Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1212234916510825?focus=true)
