### PR TITLE
release: remove main image lazyloading for LCP optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,10 @@ lib
 
 # vscode
 .vscode
+
+# cursor
+.cursor
+
+# gemini
+.gemini/
+GEMINI.md

--- a/packages/mirror-media-next/components/external/external-hero-image.js
+++ b/packages/mirror-media-next/components/external/external-hero-image.js
@@ -76,11 +76,10 @@ export default function ExternalHeroImage({
       <HeroImage>
         <CustomImage
           images={images}
-          loadingImage={'/images-next/loading@4x.gif'}
           defaultImage={'/images-next/default-og-img.png'}
           alt={title}
           objectFit={'cover'}
-          priority={true}
+          priority
           fetchPriority="high"
         />
       </HeroImage>

--- a/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
+++ b/packages/mirror-media-next/components/story/normal/hero-image-and-video.js
@@ -126,11 +126,10 @@ export default function HeroImageAndVideo({
           <CustomImage
             images={heroImage.resized}
             imagesWebP={heroImage.resizedWebp}
-            loadingImage={'/images-next/loading@4x.gif'}
             defaultImage={'/images-next/default-og-img.png'}
             alt={heroCaption ? heroCaption : title}
             objectFit={'contain'}
-            priority={true}
+            priority
             fetchPriority="high"
           />
         </HeroImage>

--- a/packages/mirror-media-next/components/story/shared/hero-image-and-video.js
+++ b/packages/mirror-media-next/components/story/shared/hero-image-and-video.js
@@ -193,14 +193,13 @@ export default function HeroImageAndVideo({
         <CustomImage
           images={heroImage.resized}
           imagesWebP={heroImage.resizedWebp}
-          loadingImage={'/images-next/loading@4x.gif'}
           defaultImage={'/images-next/default-og-img.png'}
           alt={heroCaption ? heroCaption : title}
           objectFit={'cover'}
           width={'100%'}
           height={style === 'wide' ? '100vh' : '66.67vw'}
           rwd={{ mobile: '100vw', default: '100vw' }}
-          priority={true}
+          priority
           fetchPriority="high"
         />
       )

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -19,7 +19,7 @@
     "@mirrormedia/newebpay-node": "^1.0.8",
     "@miso.ai/client-sdk": "^1.11.5",
     "@next/font": "^13.1.2",
-    "@readr-media/react-image": "^2.2.5",
+    "@readr-media/react-image": "^2.2.6",
     "@readr-media/react-infinite-scroll-list": "^1.2.0",
     "@readr-media/share-button": "^1.0.3",
     "@reduxjs/toolkit": "^2.1.0",

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -19,7 +19,7 @@
     "@mirrormedia/newebpay-node": "^1.0.8",
     "@miso.ai/client-sdk": "^1.11.5",
     "@next/font": "^13.1.2",
-    "@readr-media/react-image": "2.2.4",
+    "@readr-media/react-image": "^2.2.5",
     "@readr-media/react-infinite-scroll-list": "^1.2.0",
     "@readr-media/share-button": "^1.0.3",
     "@reduxjs/toolkit": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2918,10 +2918,10 @@
   resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.1.3.tgz#97834255b39f42d15b93449637131d28a3aca168"
   integrity sha512-XAuKKSqRNSvH/CJAfbBhVE7Ezkaetc0pM3AEKUPydYJP51N6fp8mWfPR0HUSw/7QLElHSGXVKCvyuOpVIXa5eQ==
 
-"@readr-media/react-image@2.2.4":
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.2.4.tgz#0a53f42246fc38a862ac407b31811e4e5715d79e"
-  integrity sha512-cWx5p7Ezt2wSR2FMykmXVhS/C0PsBgEMr2o3bDW8n+OiTGLB+98Fwn6yCUHGyELuNO676zlpWTCyFtELq19lBQ==
+"@readr-media/react-image@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.2.5.tgz#4b799c7ccda7bb9447bb7a730943bac7ea9958cc"
+  integrity sha512-BrH2lUYLtU3myjmcIKT/nHeyZ3r/8s06u/xCgyiGysRZSafOP1TSTdmuOUCDzPMhnCkyIIJI77d+TNs9UsscgQ==
 
 "@readr-media/react-infinite-scroll-list@^1.2.0":
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2918,10 +2918,10 @@
   resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.1.3.tgz#97834255b39f42d15b93449637131d28a3aca168"
   integrity sha512-XAuKKSqRNSvH/CJAfbBhVE7Ezkaetc0pM3AEKUPydYJP51N6fp8mWfPR0HUSw/7QLElHSGXVKCvyuOpVIXa5eQ==
 
-"@readr-media/react-image@^2.2.5":
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.2.5.tgz#4b799c7ccda7bb9447bb7a730943bac7ea9958cc"
-  integrity sha512-BrH2lUYLtU3myjmcIKT/nHeyZ3r/8s06u/xCgyiGysRZSafOP1TSTdmuOUCDzPMhnCkyIIJI77d+TNs9UsscgQ==
+"@readr-media/react-image@^2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.2.6.tgz#930a1f51bf9eb3f26a0f1888d9c20322abf245c6"
+  integrity sha512-ZXqKIBDTZSyzrO29c0bhrpYrHGsz0s2eTzdQQYm5wlf0/E/AmaS90q/G/IPUEEAiBnv3nZsJ7prPnAPpehK6HA==
 
 "@readr-media/react-infinite-scroll-list@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
 - Deploy specific performance improvements to production by bypassing blocked staging.
 - Remove loading placeholders and GIFs from hero images to improve Largest Contentful Paint (LCP).
 - Upgrade @readr-media/react-image to 2.2.6 for better stability.
 - Add tool-specific patterns to .gitignore.