### PR TITLE
feat: display tags and related posts on external articles

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/external.js
+++ b/packages/mirror-media-next/apollo/fragments/external.js
@@ -1,5 +1,8 @@
 import { gql } from '@apollo/client'
 import { partner } from './partner'
+import { tag } from './tag'
+import { aiTag } from './ai-tag'
+import { relatedPost } from './post'
 
 /**
  * @typedef {import('./partner').Partner} Partner
@@ -23,10 +26,9 @@ import { partner } from './partner'
  * @property {string} updatedAt
  * @property {string} createdBy
  * @property {string} updatedBy
- */
-
-/**
- * @typedef {Pick<GenericExternal, 'id' | 'slug' | 'partner' |  'title' | 'thumb' | 'thumbCaption' | 'brief' | 'content' | 'publishedDate' | 'extend_byline' | 'updatedAt' >} External
+ * @property {import('./post').Related[] } relateds related articles selected by cms users
+ * @property {import('./tag').Tag[] } tags - tags of the post
+ * @property {import('./ai-tag').Tag[]} tags_algo
  */
 
 /**
@@ -48,8 +50,15 @@ export const listingExternal = gql`
   }
 `
 
+/**
+ * @typedef {Pick<GenericExternal, 'id' | 'slug' | 'partner' |  'title' | 'thumb' | 'thumbCaption' | 'brief' | 'content' | 'publishedDate' | 'extend_byline' | 'updatedAt' | 'relateds' |'tags' | 'tags_algo'>} External
+ */
+
 export const external = gql`
   ${partner}
+  ${relatedPost}
+  ${tag}
+  ${aiTag}
   fragment external on External {
     id
     slug
@@ -66,5 +75,14 @@ export const external = gql`
       showBrief
     }
     updatedAt
+    relateds {
+      ...relatedPost
+    }
+    tags {
+      ...tag
+    }
+    tags_algo {
+      ...aiTag
+    }
   }
 `

--- a/packages/mirror-media-next/components/external/external-article-info.js
+++ b/packages/mirror-media-next/components/external/external-article-info.js
@@ -5,6 +5,7 @@ import ButtonCopyLink from '../../components/story/shared/button-copy-link'
 import DonateLink from '../../components/story/shared/donate-link'
 import ButtonSocialNetworkShare from '../../components/story/shared/button-social-network-share'
 import { getCreditsHtml } from '../../utils/external'
+import Tags from '../story/shared/tags'
 
 /**
  * @typedef {import('../../type/theme').Theme} Theme
@@ -103,6 +104,13 @@ const ExternalCreditTitle = styled.div`
   margin-bottom: auto;
 `
 
+const StyledTags = styled(Tags)`
+  margin-top: 20px;
+  ${({ theme }) => theme.breakpoint.md} {
+    margin-top: 24px;
+  }
+`
+
 /**
  * @typedef {import('../../apollo/fragments/partner').Partner} Partner
  */
@@ -113,6 +121,7 @@ const ExternalCreditTitle = styled.div`
  * @param {string} props.publishedDate
  * @param {string} props.credits
  * @param {Partner | null} props.partner
+ * @param {import('../../apollo/fragments/ai-tag.js').Tag[]} props.displayTags
  * @returns {import('react').JSX.Element}
  */
 export default function ArticleInfo({
@@ -120,6 +129,7 @@ export default function ArticleInfo({
   publishedDate,
   credits,
   partner,
+  displayTags,
 }) {
   const creditJsx = credits.length > 0 && (
     <ExternalCredit>
@@ -157,6 +167,7 @@ export default function ArticleInfo({
         </SocialMedia>
         <DonateLink />
       </SocialMediaAndDonateLink>
+      <StyledTags tags={displayTags} />
     </ArticleInfoContainer>
   )
 }

--- a/packages/mirror-media-next/components/external/external-normal-style.js
+++ b/packages/mirror-media-next/components/external/external-normal-style.js
@@ -441,6 +441,8 @@ export default function ExternalNormalStyle({ external, allRelatedStories }) {
     updatedAt = '',
     extend_byline = '',
     thumbCaption = '',
+    tags = [],
+    tags_algo = [],
   } = external
 
   // 正則表達式匹配 <img> 標籤中包含 style 並帶有 width 和 height
@@ -478,6 +480,8 @@ export default function ExternalNormalStyle({ external, allRelatedStories }) {
 
   const externalSectionTitle = getExternalSectionTitle(partner)
   const partnerColor = getExternalPartnerColor(partner)
+
+  const displayTags = [...(tags ?? []), ...(tags_algo ?? [])]
 
   /**
    * @returns {Promise<AsideArticleDataContainSectionsWithOrdered[] |[]>}
@@ -594,6 +598,7 @@ export default function ExternalNormalStyle({ external, allRelatedStories }) {
               publishedDate={publishedTaipeiTime}
               credits={extend_byline}
               partner={partner}
+              displayTags={displayTags}
             />
           </InfoAndHero>
 

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -2,7 +2,6 @@
 import client, { getStoryClient } from '../../apollo/apollo-client'
 import {
   API_TIMEOUT,
-  API_TIMEOUT_GRAPHQL,
   ENV,
   SITE_URL,
   URL_STATIC_POST_FLASH_NEWS,
@@ -22,7 +21,6 @@ import { getLogTraceObject } from '../../utils'
 import { processSettledResult } from '../../utils/response-processor'
 import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import dynamic from 'next/dynamic'
-import axios from 'axios'
 import { getRelatedStories } from '../../pages/api/recomemd'
 import { useState, useEffect } from 'react'
 import { toTaipeiISOString } from '../../utils/index'
@@ -57,49 +55,49 @@ export default function External({ external, headerData, jsonLdData }) {
   useEffect(() => {
     // Wait for page to be fully rendered before setting up miso API calls
     const setupScrollHandler = () => {
-    const handleScroll = async () => {
-      try {
-        const result = await getRelatedStories(
-          external.slug,
-          [],
-          10,
-          'external'
-        )
+      const handleScroll = async () => {
+        try {
+          const result = await getRelatedStories(
+            external.slug,
+            [],
+            10,
+            'external'
+          )
 
-        if (result && result.data && result.data.products) {
-          const formattedStories = result.data.products.map((product) => {
-            const productId = product.product_id
-            const slug = productId.split('_').slice(2).join('_')
+          if (result && result.data && result.data.products) {
+            const formattedStories = result.data.products.map((product) => {
+              const productId = product.product_id
+              const slug = productId.split('_').slice(2).join('_')
 
-            return {
-              id: productId,
-              slug: slug,
-              title: product.title || '',
-              url: product.url || '',
-              heroImage: product.cover_image
-                ? {
-                    resized: { original: product.cover_image },
-                  }
-                : null,
-              publishedDate: new Date().toISOString(),
-              brief: { blocks: [{ text: '' }] },
-              categories: [],
-              sections: [],
-            }
-          })
+              return {
+                id: productId,
+                slug: slug,
+                title: product.title || '',
+                url: product.url || '',
+                heroImage: product.cover_image
+                  ? {
+                      resized: { original: product.cover_image },
+                    }
+                  : null,
+                publishedDate: new Date().toISOString(),
+                brief: { blocks: [{ text: '' }] },
+                categories: [],
+                sections: [],
+              }
+            })
 
-          setAllRelatedStories((prev) => [...prev, ...formattedStories])
+            setAllRelatedStories((prev) => [...prev, ...formattedStories])
+          }
+        } catch (error) {
+          console.error(
+            'Failed to fetch MISO related external stories:',
+            JSON.stringify(error)
+          )
         }
-      } catch (error) {
-        console.error(
-          'Failed to fetch MISO related external stories:',
-          JSON.stringify(error)
-        )
       }
-    }
 
-    window.addEventListener('scroll', handleScroll, { once: true })
-    return () => window.removeEventListener('scroll', handleScroll)
+      window.addEventListener('scroll', handleScroll, { once: true })
+      return () => window.removeEventListener('scroll', handleScroll)
     }
 
     // Execute after page is fully loaded to avoid blocking TTFB
@@ -215,7 +213,9 @@ export async function getServerSideProps({ params, req, res }) {
 
   const fetchStaticJsonSafe = async (url, timeout, label) => {
     try {
-      const mod = await import('../../utils/server-side-only/fetch-static-json.js')
+      const mod = await import(
+        '../../utils/server-side-only/fetch-static-json.js'
+      )
       const res = await mod.fetchStaticJson(url, timeout)
       return res
     } catch (err) {

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -49,7 +49,9 @@ export default function External({ external, headerData, jsonLdData }) {
   const router = useRouter()
   const { slug } = router.query
   const ampUrl = `https://${SITE_URL}/external/amp/${slug}`
-  const [allRelatedStories, setAllRelatedStories] = useState([])
+  const [allRelatedStories, setAllRelatedStories] = useState([
+    ...(external.relateds ?? []),
+  ])
   const robots = 'index, max-image-preview:large'
 
   useEffect(() => {

--- a/packages/mirror-media-next/utils/log/shared.js
+++ b/packages/mirror-media-next/utils/log/shared.js
@@ -1,6 +1,7 @@
 import Bowser from 'bowser'
 import errors from '@twreporter/errors'
 import { ApolloError } from '@apollo/client'
+import { ENV } from '../../config/index.mjs'
 
 function getBrowserInfo(userAgent = '') {
   if (!userAgent) {
@@ -104,6 +105,21 @@ function logAxiosError(axiosErrors, errorMessage, traceObject) {
     errorMessage
   )
 
+  if (ENV === 'local') {
+    console.error(
+      errors.helpers.printAll(
+        annotatingError,
+        {
+          withStack: true,
+          withPayload: true,
+        },
+        0,
+        0
+      )
+    )
+    return
+  }
+
   console.error(
     JSON.stringify({
       severity: 'ERROR',
@@ -143,6 +159,21 @@ function logGqlError(gqlErrors, errorMessage, traceObject) {
     errorMessage
   )
 
+  if (ENV === 'local') {
+    console.error(
+      errors.helpers.printAll(
+        annotatingError,
+        {
+          withStack: true,
+          withPayload: true,
+        },
+        0,
+        0
+      )
+    )
+    return
+  }
+
   const { graphQLErrors, clientErrors, networkError } = gqlErrors
   console.error(
     JSON.stringify({
@@ -177,6 +208,19 @@ function logGenericError(genericError, errorMessage, traceObject) {
     'UnhandledError',
     errorMessage
   )
+
+  if (ENV === 'local') {
+    console.error(
+      errors.helpers.printAll(
+        annotatingError,
+        { withStack: true, withPayload: true },
+        0,
+        0
+      )
+    )
+    return
+  }
+
   console.error(
     JSON.stringify({
       severity: 'ERROR',


### PR DESCRIPTION
This PR introduces the display of tags and AI-generated tags on external articles, includes manually selected related posts in the related stories list, and improves error logging for the local development environment.

## Additions

- Integrated `Tags` component into `ExternalArticleInfo` to display article tags.
- Added `tags`, `tags_algo`, and `relateds` fields to the `external` GraphQL fragment.
- Added logic to combine `tags` and `tags_algo` into `displayTags` in `ExternalNormalStyle`.
- Added conditional logic in logging utilities (`logAxiosError`, `logGqlError`, `logGenericError`) to print human-readable errors when `ENV` is 'local'.

## Removals

- Removed unused `API_TIMEOUT_GRAPHQL` and `axios` imports from `pages/external/[slug].js`.

## Changes

- Fixed indentation and cleanup in `pages/external/[slug].js`.

## Testing

- **External Article Tags:** Navigate to an external article page and verify that tags (both manual and AI) are displayed correctly in the article info section.
- **Related Posts:** Check that manually selected related posts from the CMS are displayed in the related stories section of an external article.

## Screenshots

N/A

## Todos

N/A

## Task Links
[[external]前台顯示演算法標籤與相關新聞 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1212543367355167?focus=true)