### PR TITLE
fix: prevent SSR crash in image component when source is invalid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,7 @@ lib
 # gemini
 .gemini/
 GEMINI.md
+
+# gemini
+.claude/
+Claude.md

--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -19,7 +19,7 @@
     "@mirrormedia/newebpay-node": "^1.0.8",
     "@miso.ai/client-sdk": "^1.11.5",
     "@next/font": "^13.1.2",
-    "@readr-media/react-image": "^2.2.9",
+    "@readr-media/react-image": "^2.2.10",
     "@readr-media/react-infinite-scroll-list": "^1.2.0",
     "@readr-media/share-button": "^1.0.3",
     "@reduxjs/toolkit": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2918,10 +2918,10 @@
   resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.1.3.tgz#97834255b39f42d15b93449637131d28a3aca168"
   integrity sha512-XAuKKSqRNSvH/CJAfbBhVE7Ezkaetc0pM3AEKUPydYJP51N6fp8mWfPR0HUSw/7QLElHSGXVKCvyuOpVIXa5eQ==
 
-"@readr-media/react-image@^2.2.9":
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.2.9.tgz#b7b5c62b15618fa36af4c080f75fdec66d1f2bfe"
-  integrity sha512-KCq8qygw0J0cJOUcPr+VAaRfhGC4X0BnRxzO3FsjyCurbP61cJWqqPRBY9T6caDg0Su+gB5IIMM7kkYqR+EVTg==
+"@readr-media/react-image@^2.2.10":
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.2.10.tgz#4e3cf7b09099765c714c1b1ebefd1caa8306e6f0"
+  integrity sha512-Iu5xHMNWLLv8f++UXMwtjl3DzgwN2vDqDozoGnRFMFuX86ADbCJopcx6WHKxFUcq9OSb32SYx1MtQmm6hLu5AQ==
 
 "@readr-media/react-infinite-scroll-list@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
Updates the `@readr-media/react-image` dependency to address SSR stability issues and enhances `.gitignore` for development tools.

## Additions
- N/A

## Removals
- N/A

## Changes

- Bumped `@readr-media/react-image` from `^2.2.9` to `^2.2.10` to include the following fixes:
  - Wrapped image list generation in a `try-catch` block to handle missing or invalid image properties during SSR.
  - Fallback to an empty array upon error to trigger the default image display logic.
  - Logged detailed error information when debug mode is enabled.

## Testing

- Verify that pages with potentially broken or invalid image data no longer cause server-side crashes.
- Confirm the fallback image displays correctly when the image source is invalid.

## Screenshots

- N/A

## Todos

- N/A

## Task Links
[Category/news增加異常處理 - Asana](https://app.asana.com/1/614399484723017/project/1212714038945191/task/1212585861866483?focus=true)