### PR TITLE
fix(papermag): correct promote code discount calculation to be per-item

### DIFF
--- a/packages/mirror-media-next/pages/api/papermag.js
+++ b/packages/mirror-media-next/pages/api/papermag.js
@@ -68,9 +68,10 @@ export default async function EncryptInfo(req, res) {
       throw new Error('item is not correct input')
     }
     const itemPrice = item.price
-    const totalPrice =
-      itemPrice * tradeInfo.data.itemCount -
-      (tradeInfo.data.promoteCode ? 80 : 0)
+    const itemCount = tradeInfo.data.itemCount
+    const hasPromoteCode = !!tradeInfo.data.promoteCode
+    const promoteCodeDiscount = hasPromoteCode ? 80 * itemCount : 0
+    const totalPrice = itemPrice * itemCount - promoteCodeDiscount
     if (totalPrice !== infoForNewebpay.Amt) {
       throw new Error(
         `Amt is not correct input, Amt is ${infoForNewebpay.Amt}, but should be ${totalPrice}`


### PR DESCRIPTION
- Extract `itemCount` for better readability.
- Update `promoteCodeDiscount` to multiply the discount rate by the item count.
- Use explicit boolean cast for `hasPromoteCode` check.