### PR TITLE
feat: fetch posts by both manual and algorithm tags

### DIFF
--- a/packages/mirror-media-next/utils/api/tag.js
+++ b/packages/mirror-media-next/utils/api/tag.js
@@ -3,6 +3,7 @@ import { fetchPosts } from '../../apollo/query/posts'
 import { fetchTag } from '../../apollo/query/tags'
 
 /**
+ * Fetch posts by tag slug, including both manual tags and algorithm tags
  * @param {string} tagSlug
  * @param {number} take
  * @param {number} skip
@@ -16,7 +17,10 @@ export function fetchPostsByTagSlug(tagSlug, take, skip) {
       orderBy: { publishedDate: 'desc' },
       filter: {
         state: { equals: 'published' },
-        tags: { some: { slug: { equals: tagSlug } } },
+        OR: [
+          { tags: { some: { slug: { equals: tagSlug } } } },
+          { tags_algo: { some: { slug: { equals: tagSlug } } } },
+        ],
       },
     },
   })


### PR DESCRIPTION
This PR updates the `fetchPostsByTagSlug` utility function to search for the provided tag slug in both the manual `tags` field and the algorithmic `tags_algo` field. This ensures that the tag page displays all relevant posts, whether manually tagged or algorithmically generated.

## Additions
- Added `OR` condition to the GraphQL query filter to include `tags_algo` in the search scope.
- Added JSDoc comments to `fetchPostsByTagSlug` explaining the inclusion of algorithm tags.

## Removals
- N/A

## Changes
- Modified the filter logic in `utils/api/tag.js` to accept posts where the tag slug matches either `tags` or `tags_algo`.

## Testing
- Verified that posts with matching `tags_algo` (but no matching manual `tags`) now appear on the tag page.
- Confirmed that posts matching both fields are not duplicated (handled by backend ORM).

## Screenshots
- N/A

## Todos
- N/A

## Task Links
[[Tag]同步抓演算法標籤 - Asana](https://app.asana.com/1/614399484723017/project/1199408264065173/task/1212991687107734?focus=true)