### PR TITLE
fix: restore full-screen ad condition and prevent CLS via visibility control

### DIFF
--- a/packages/mirror-media-next/components/ads/full-screen-ads/ad-item.js
+++ b/packages/mirror-media-next/components/ads/full-screen-ads/ad-item.js
@@ -104,9 +104,15 @@ const Wrapper = styled.div`
         case 'modified':
           return modifiedWrapperStyle
         case 'unset':
-          return null
+          return css`
+            visibility: hidden;
+            pointer-events: none;
+          `
         default:
-          return null
+          return css`
+            visibility: hidden;
+            pointer-events: none;
+          `
       }
     }
   }

--- a/packages/mirror-media-next/pages/video/[id].js
+++ b/packages/mirror-media-next/pages/video/[id].js
@@ -173,7 +173,7 @@ export default function Video({ video, latestVideos, headerData }) {
           </GPT_Placeholder>
 
           <StickyGPTAd pageKey="videohub" />
-          {hasScrolled && <FullScreenAds />}
+          {hasScrolled && shouldShowAd && <FullScreenAds />}
         </Wrapper>
       </Layout>
     </>


### PR DESCRIPTION
Restore conditional rendering for full-screen ads and optimize layout stability by hiding ad wrapper instead of removing styles.

## Additions  
- Add `shouldShowAd` condition to `<FullScreenAds />` rendering in `pages/video/[id].js`.  
- Add `visibility: hidden;` and `pointer-events: none;` styles for `unset` and `default` cases in `ad-item.js`.  

## Removals  
- Remove direct `null` return for `unset` and `default` wrapper styles.  

## Changes  
- Replace `null` style return with CSS that hides the element while preserving layout space to reduce CLS.  
- Update rendering logic from `{hasScrolled && <FullScreenAds />}` to `{hasScrolled && shouldShowAd && <FullScreenAds />}` to restore correct ad display condition.  

## Testing  
- Verified full-screen ads only render when both `hasScrolled` and `shouldShowAd` are true.  
- Confirmed layout space is preserved when ads are hidden, reducing unexpected layout shifts.  
- Performed local CLS testing (Lighthouse) to compare before/after behavior.  
- Manual verification on video page scrolling and ad transition behavior.  

## Screenshots  
- N/A  

## Todos  
- Monitor real-user CLS metrics in production to validate long-term impact.  
- Validate ad behavior across breakpoints and device types.  

## Task Links  
[[CLS]Survey video頁CLS改善方式 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1212562370693073?focus=true)