### PR TITLE
feat(ads/avivid): improve loading stability and reduce CLS for mobile bottom banner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,9 @@ lib
 .gemini/
 GEMINI.md
 
-# gemini
+# claude
 .claude/
 Claude.md
+
+# codex
+AGENTS.md

--- a/packages/mirror-media-next/components/ads/avivid/avivid-script.js
+++ b/packages/mirror-media-next/components/ads/avivid/avivid-script.js
@@ -5,9 +5,11 @@ import { useEffect } from 'react'
 const AVIVID_READY_ATTRIBUTE = 'data-mm-avivid-ready'
 const AVIVID_TARGET_CLASS = 'avivid_onpage_mobile_bottom'
 const AVIVID_CONTENT_CLASS = 'avivid_onpage_content_wrapper'
+const AVIVID_STABLE_DELAY = 180
 
 export default function AvividScript() {
   useEffect(() => {
+    // Find all script tags and check whether src contains the unsafe URL.
     // 找出所有 script 標籤，並檢查 src 是否包含不安全的網址
     // Remove the known unsafe AviviD script if it was injected.
     const scripts = document.querySelectorAll('script')
@@ -18,24 +20,45 @@ export default function AvividScript() {
       }
     })
 
-    // Use a document-level observer to catch late third-party insertion, then attach a per-banner observer until the content wrapper has a measurable size.
-    // This keeps the banner in its hidden CSS state until we can safely reveal it with a transform-based transition instead of a layout jump.
+    // Use a document-level observer to catch late third-party insertion, then attach a per-banner observer until the content wrapper stops changing size briefly.
+    // This keeps the banner hidden until its size is more stable, reducing the chance of showing it midway through a third-party resize sequence.
+    // Track per-node observers and timers so we can stop them as soon as a banner is ready or the page unmounts.
     const nodeObservers = new WeakMap()
+    const nodeReadyTimers = new WeakMap()
     const activeObservers = new Set()
+    const activeTimerIds = new Set()
 
-    const isAvividContentReady = (node) => {
+    // Read the current banner content size and round it so small sub-pixel changes do not keep the banner hidden forever.
+    const getAvividContentSize = (node) => {
       const content = node.querySelector(`.${AVIVID_CONTENT_CLASS}`)
-      if (!content) return false
+      if (!content) return null
 
       const { height, width } = content.getBoundingClientRect()
-      return height > 0 && width > 0
+      if (height <= 0 || width <= 0) return null
+
+      return {
+        height: Math.round(height),
+        width: Math.round(width),
+      }
     }
 
+    // Clear any pending stability timer before scheduling a new one for the same banner.
+    const clearReadyTimer = (node) => {
+      const timerId = nodeReadyTimers.get(node)
+      if (timerId) {
+        clearTimeout(timerId)
+        activeTimerIds.delete(timerId)
+        nodeReadyTimers.delete(node)
+      }
+    }
+
+    // Mark the banner as ready once we decide its size is stable, then stop observing that node.
     const markAvividReady = (node) => {
       if (node.getAttribute(AVIVID_READY_ATTRIBUTE) === 'true') {
         return
       }
 
+      clearReadyTimer(node)
       node.setAttribute(AVIVID_READY_ATTRIBUTE, 'true')
 
       const observer = nodeObservers.get(node)
@@ -46,21 +69,55 @@ export default function AvividScript() {
       }
     }
 
+    // Re-check the banner after a short delay; only reveal it when two consecutive measurements match.
+    const scheduleReadyCheck = (node) => {
+      const snapshot = getAvividContentSize(node)
+      if (!snapshot) return
+
+      clearReadyTimer(node)
+
+      const timerId = window.setTimeout(() => {
+        activeTimerIds.delete(timerId)
+        nodeReadyTimers.delete(node)
+
+        if (!node.isConnected) return
+        const currentSize = getAvividContentSize(node)
+        if (!currentSize) return
+
+        if (
+          currentSize.height === snapshot.height &&
+          currentSize.width === snapshot.width
+        ) {
+          markAvividReady(node)
+          return
+        }
+
+        scheduleReadyCheck(node)
+      }, AVIVID_STABLE_DELAY)
+
+      nodeReadyTimers.set(node, timerId)
+      activeTimerIds.add(timerId)
+    }
+
     const observeAvividNode = (node) => {
       if (!(node instanceof HTMLElement)) return
       if (!node.classList.contains(AVIVID_TARGET_CLASS)) return
       if (nodeObservers.has(node)) return
 
-      // Reveal the banner only after the inner content has measurable dimensions.
-      if (isAvividContentReady(node)) {
-        markAvividReady(node)
+      // Start a stability check if the content already exists, but avoid revealing it until the size stops changing for a short window.
+      if (getAvividContentSize(node)) {
+        scheduleReadyCheck(node)
         return
       }
 
       // Watch third-party mutations because AviviD builds the banner incrementally after GTM executes.
       const innerObserver = new MutationObserver(() => {
-        if (isAvividContentReady(node)) {
-          markAvividReady(node)
+        if (node.getAttribute(AVIVID_READY_ATTRIBUTE) === 'true') {
+          return
+        }
+
+        if (getAvividContentSize(node)) {
+          scheduleReadyCheck(node)
         }
       })
 
@@ -99,6 +156,7 @@ export default function AvividScript() {
     return () => {
       rootObserver.disconnect()
       activeObservers.forEach((observer) => observer.disconnect())
+      activeTimerIds.forEach((timerId) => clearTimeout(timerId))
     }
   }, [])
 

--- a/packages/mirror-media-next/components/ads/avivid/avivid-script.js
+++ b/packages/mirror-media-next/components/ads/avivid/avivid-script.js
@@ -18,6 +18,8 @@ export default function AvividScript() {
       }
     })
 
+    // Use a document-level observer to catch late third-party insertion, then attach a per-banner observer until the content wrapper has a measurable size.
+    // This keeps the banner in its hidden CSS state until we can safely reveal it with a transform-based transition instead of a layout jump.
     const nodeObservers = new WeakMap()
     const activeObservers = new Set()
 

--- a/packages/mirror-media-next/components/ads/avivid/avivid-script.js
+++ b/packages/mirror-media-next/components/ads/avivid/avivid-script.js
@@ -1,9 +1,15 @@
 import Script from 'next/script'
 import { useEffect } from 'react'
 
+// Delay AviviD visibility until its injected content has a stable size to reduce CLS from third-party DOM insertion.
+const AVIVID_READY_ATTRIBUTE = 'data-mm-avivid-ready'
+const AVIVID_TARGET_CLASS = 'avivid_onpage_mobile_bottom'
+const AVIVID_CONTENT_CLASS = 'avivid_onpage_content_wrapper'
+
 export default function AvividScript() {
   useEffect(() => {
     // 找出所有 script 標籤，並檢查 src 是否包含不安全的網址
+    // Remove the known unsafe AviviD script if it was injected.
     const scripts = document.querySelectorAll('script')
     scripts.forEach((script) => {
       if (script.src.includes('aws-sdk-AviviD-min-1')) {
@@ -11,6 +17,87 @@ export default function AvividScript() {
         script.remove()
       }
     })
+
+    const nodeObservers = new WeakMap()
+    const activeObservers = new Set()
+
+    const isAvividContentReady = (node) => {
+      const content = node.querySelector(`.${AVIVID_CONTENT_CLASS}`)
+      if (!content) return false
+
+      const { height, width } = content.getBoundingClientRect()
+      return height > 0 && width > 0
+    }
+
+    const markAvividReady = (node) => {
+      if (node.getAttribute(AVIVID_READY_ATTRIBUTE) === 'true') {
+        return
+      }
+
+      node.setAttribute(AVIVID_READY_ATTRIBUTE, 'true')
+
+      const observer = nodeObservers.get(node)
+      if (observer) {
+        observer.disconnect()
+        activeObservers.delete(observer)
+        nodeObservers.delete(node)
+      }
+    }
+
+    const observeAvividNode = (node) => {
+      if (!(node instanceof HTMLElement)) return
+      if (!node.classList.contains(AVIVID_TARGET_CLASS)) return
+      if (nodeObservers.has(node)) return
+
+      // Reveal the banner only after the inner content has measurable dimensions.
+      if (isAvividContentReady(node)) {
+        markAvividReady(node)
+        return
+      }
+
+      // Watch third-party mutations because AviviD builds the banner incrementally after GTM executes.
+      const innerObserver = new MutationObserver(() => {
+        if (isAvividContentReady(node)) {
+          markAvividReady(node)
+        }
+      })
+
+      innerObserver.observe(node, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+      })
+      nodeObservers.set(node, innerObserver)
+      activeObservers.add(innerObserver)
+    }
+
+    // Catch banners that may already exist before the observer starts.
+    document
+      .querySelectorAll(`.${AVIVID_TARGET_CLASS}`)
+      .forEach((node) => observeAvividNode(node))
+
+    const rootObserver = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((addedNode) => {
+          if (!(addedNode instanceof HTMLElement)) return
+
+          observeAvividNode(addedNode)
+          addedNode
+            .querySelectorAll(`.${AVIVID_TARGET_CLASS}`)
+            .forEach((node) => observeAvividNode(node))
+        })
+      })
+    })
+
+    rootObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+    })
+
+    return () => {
+      rootObserver.disconnect()
+      activeObservers.forEach((observer) => observer.disconnect())
+    }
   }, [])
 
   return (

--- a/packages/mirror-media-next/styles/global-styles.js
+++ b/packages/mirror-media-next/styles/global-styles.js
@@ -591,4 +591,19 @@ video {
   max-width: 100%;
   height: auto;
 }
+
+/* Keep the injected AviviD banner off-screen until our observer marks it ready, so its first visible frame uses transform instead of a layout jump. */
+.avivid_onpage_mobile_bottom {
+  transform: translateY(100%);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 0.3s ease-out, opacity 0.3s ease-out;
+}
+
+/* Re-enable visibility and interaction only after the third-party content has a measurable size. */
+.avivid_onpage_mobile_bottom[data-mm-avivid-ready='true'] {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
 `

--- a/packages/mirror-media-next/styles/global-styles.js
+++ b/packages/mirror-media-next/styles/global-styles.js
@@ -592,17 +592,17 @@ video {
   height: auto;
 }
 
-/* Keep the injected AviviD banner off-screen until our observer marks it ready, so its first visible frame uses transform instead of a layout jump. */
+/* Keep the injected AviviD banner hidden until its content size stabilizes, without overriding any vendor transform used for positioning. */
 .avivid_onpage_mobile_bottom {
-  transform: translateY(100%);
+  visibility: hidden;
   opacity: 0;
   pointer-events: none;
-  transition: transform 0.3s ease-out, opacity 0.3s ease-out;
+  transition: opacity 0.2s ease-out;
 }
 
-/* Re-enable visibility and interaction only after the third-party content has a measurable size. */
+/* Re-enable visibility and interaction only after the third-party content has stayed stable for a short window. */
 .avivid_onpage_mobile_bottom[data-mm-avivid-ready='true'] {
-  transform: translateY(0);
+  visibility: visible;
   opacity: 1;
   pointer-events: auto;
 }


### PR DESCRIPTION
Improve AviviD mobile bottom banner loading behavior by delaying visibility until content size stabilizes, reducing layout shifts caused by third-party DOM mutations.

## Additions
- Introduced `AvividScript` logic to observe AviviD DOM mutations and detect stable content size before revealing the banner.
- Added size snapshot comparison with `MutationObserver` and delayed stability check (`AVIVID_STABLE_DELAY`) to minimize CLS.
- Implemented per-node observer and timer management using `WeakMap` and `Set` to ensure proper cleanup.
- Added global CSS rules to keep `.avivid_onpage_mobile_bottom` hidden until `data-mm-avivid-ready="true"` is set.
- Updated `.gitignore` to include `.claude/`, `Claude.md`, and `AGENTS.md`.

## Removals
- N/A

## Changes
- Modified AviviD loading flow to prevent premature rendering during incremental third-party DOM injection.
- Blocked known unsafe injected script (`aws-sdk-AviviD-min-1`) if detected.
- Ensured cleanup of observers and timers on component unmount to prevent memory leaks.
- Added technical comments explaining CLS mitigation strategy and third-party mutation handling.

## Testing
- Verified that the AviviD mobile bottom banner remains hidden until content dimensions stabilize.
- Confirmed reduced layout shift during banner injection via local CLS observation.
- Ensured no regression in banner visibility after stable render.
- Checked that observer cleanup executes correctly on route change or unmount.

## Screenshots
- N/A

## Todos
- Monitor real-user CLS metrics in production to confirm measurable improvement.
- Evaluate whether a reserved placeholder height could further reduce layout instability.

## Task Links
[[CLS]Survey video頁CLS改善方式 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1212562370693073?focus=true)