### PR TITLE
fix: remove contenteditable attribute from figcaption in external amp pages

### DIFF
--- a/packages/mirror-media-next/utils/amp-html.js
+++ b/packages/mirror-media-next/utils/amp-html.js
@@ -38,7 +38,7 @@ export function transformHtmlIntoAmpHtml(html, currentPageUrl) {
 
   const redirectUrl = currentPageUrl.replace('/external/amp/', '/external/')
 
-  const invalidElementArrtibPairs = [
+  const invalidElementAttributePairs = [
     {
       element: 'div',
       attribute: `data-progress-bar-1"`,
@@ -46,10 +46,11 @@ export function transformHtmlIntoAmpHtml(html, currentPageUrl) {
     },
     { element: 'a', attribute: 'spellcheck' },
     { element: 'span', attribute: 'sans-serif' },
+    { element: 'figcaption', attribute: 'contenteditable' },
   ]
 
   // handle some html tag with invalid attribute which will grows when new source is added..
-  for (const invalidElementAttribPair of invalidElementArrtibPairs) {
+  for (const invalidElementAttribPair of invalidElementAttributePairs) {
     const selector =
       invalidElementAttribPair.selector ||
       invalidElementAttribPair.element +


### PR DESCRIPTION
This PR addresses an AMP validation error in external AMP pages (`/pages/external/amp/[slug].js`). The `contenteditable` attribute, which is automatically output by Draft.js (`@mirrormedia/lilith-draft-renderer`) within `<figcaption>` elements, is invalid in the AMP HTML specification and negatively impacts SEO. The fix removes this attribute during the AMP HTML transformation process.

## Additions
- Added `{ element: 'figcaption', attribute: 'contenteditable' }` to the array of invalid element attributes to be stripped out during HTML to AMP HTML conversion.

## Removals
- N/A

## Changes
- Fixed a typo in the variable name, changing `invalidElementArrtibPairs` to `invalidElementAttributePairs`.

## Testing
- Verified that the `contenteditable` attribute is successfully removed from `<figcaption>` elements on external AMP pages.

## Screenshots
- N/A

## Todos
- N/A

## Task Links
[[amp]external網頁移除contenteditable="false" tag - Asana](https://app.asana.com/1/614399484723017/project/1213553957874038/task/1213534132992252?focus=true)