### PR TITLE
feat(category): change news category page posts data source from GraphQL to JSON

### DIFF
--- a/packages/mirror-media-next/components/category/category-articles.js
+++ b/packages/mirror-media-next/components/category/category-articles.js
@@ -63,7 +63,7 @@ export default function CategoryArticles({
         : await fetchPostsByCategorySlug(category.slug, take, skip)
 
       if (isNewsCategory) {
-        return response.data.posts.items
+        return response.data.posts.items || []
       }
       return response.data.posts
     } catch (error) {

--- a/packages/mirror-media-next/components/category/category-articles.js
+++ b/packages/mirror-media-next/components/category/category-articles.js
@@ -7,6 +7,7 @@ import PremiumArticleList from '../shared/premium-article-list'
 import {
   fetchPostsByCategorySlug,
   fetchPremiumPostsByCategorySlug,
+  fetchNewsCategoryPostsJSON,
 } from '../../utils/api/category'
 import LoadingPage from '../../public/images-next/loading_page.gif'
 
@@ -35,6 +36,7 @@ const Loading = styled.div`
  * @param {Category} props.category
  * @param {Number} props.renderPageSize
  * @param {boolean} props.isPremium
+ * @param {boolean} props.isNewsCategory
  * @returns {React.ReactElement}
  */
 export default function CategoryArticles({
@@ -43,6 +45,7 @@ export default function CategoryArticles({
   category,
   renderPageSize,
   isPremium,
+  isNewsCategory,
 }) {
   const fetchPageSize = renderPageSize * 2
 
@@ -55,7 +58,13 @@ export default function CategoryArticles({
       const skip = (page - 1) * take
       const response = isPremium
         ? await fetchPremiumPostsByCategorySlug(category.slug, take, skip)
+        : isNewsCategory
+        ? await fetchNewsCategoryPostsJSON(page, take)
         : await fetchPostsByCategorySlug(category.slug, take, skip)
+
+      if (isNewsCategory) {
+        return response.data.posts.items
+      }
       return response.data.posts
     } catch (error) {
       // [to-do]: use beacon api to log error on gcs

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -59,6 +59,7 @@ let STORY_GQL_ENDPOINT = ''
 let ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE = true
 let GCS_FUSE_MOUNT_DIR = ''
 let GCS_FUSE_STATIC_BUCKET = ''
+let URL_STATIC_NEWS_CATEGORY_INFO = ''
 let URL_STATIC_NEWS_CATEGORY_POSTS = ''
 /** @type {import("firebase/auth").ActionCodeSettings} */
 let ACTION_CODE_SETTING
@@ -97,6 +98,7 @@ switch (ENV) {
     URL_STATIC_PROMOTE_VIDEOS = `https://${STATIC_FILE_DOMAIN}/files/json/promoting-video.json`
     URL_STATIC_COLUMN_SECTION_POSTS = `https://${STATIC_FILE_DOMAIN}/json/atest/latest_content_section_column_1`
     URL_STATIC_DAILY_COLUMN_HEADLINES = `https://${STATIC_FILE_DOMAIN}/files/json/daily-column.json`
+    URL_STATIC_NEWS_CATEGORY_INFO = `https://${STATIC_FILE_DOMAIN}/json/latest/category_news.json`
     URL_STATIC_NEWS_CATEGORY_POSTS = `https://${STATIC_FILE_DOMAIN}/json/latest/latest_content_category_news_public`
     // Only use STORY_GQL_ENDPOINT if explicitly set via env var
     // Do not fallback to dev endpoint in prod to avoid connecting to dev service
@@ -166,6 +168,7 @@ switch (ENV) {
     URL_STATIC_PROMOTE_VIDEOS = `https://${STATIC_FILE_DOMAIN}/files/json/promoting-video.json`
     URL_STATIC_COLUMN_SECTION_POSTS = `https://${STATIC_FILE_DOMAIN}/json/atest/latest_content_section_column_1`
     URL_STATIC_DAILY_COLUMN_HEADLINES = `https://${STATIC_FILE_DOMAIN}/files/json/daily-column.json`
+    URL_STATIC_NEWS_CATEGORY_INFO = `https://${STATIC_FILE_DOMAIN}/json/latest/category_news.json`
     URL_STATIC_NEWS_CATEGORY_POSTS = `https://${STATIC_FILE_DOMAIN}/json/latest/latest_content_category_news_public`
     STORY_GQL_ENDPOINT =
       process.env.STORY_GQL_ENDPOINT ||
@@ -232,6 +235,7 @@ switch (ENV) {
     URL_STATIC_PROMOTE_VIDEOS = `https://${STATIC_FILE_DOMAIN}/files/json/promoting-video.json`
     URL_STATIC_COLUMN_SECTION_POSTS = `https://storage.googleapis.com/v3-statics-dev.mirrormedia.mg/json/latest/latest_content_section_column_1.json`
     URL_STATIC_DAILY_COLUMN_HEADLINES = `https://${STATIC_FILE_DOMAIN}/files/json/daily-column.json`
+    URL_STATIC_NEWS_CATEGORY_INFO = `https://${STATIC_FILE_DOMAIN}/json/latest/category_news.json`
     URL_STATIC_NEWS_CATEGORY_POSTS = `https://${STATIC_FILE_DOMAIN}/json/latest/latest_content_category_news_public`
     STORY_GQL_ENDPOINT =
       process.env.STORY_GQL_ENDPOINT ||
@@ -304,6 +308,7 @@ switch (ENV) {
     URL_STATIC_PROMOTE_VIDEOS = `https://${STATIC_FILE_DOMAIN}/files/json/promoting-video.json`
     URL_STATIC_COLUMN_SECTION_POSTS = `https://storage.googleapis.com/v3-statics-dev.mirrormedia.mg/json/latest/latest_content_section_column_1.json`
     URL_STATIC_DAILY_COLUMN_HEADLINES = `https://${STATIC_FILE_DOMAIN}/files/json/daily-column.json`
+    URL_STATIC_NEWS_CATEGORY_INFO = `https://${STATIC_FILE_DOMAIN}/json/latest/category_news.json`
     URL_STATIC_NEWS_CATEGORY_POSTS = `https://${STATIC_FILE_DOMAIN}/json/latest/latest_content_category_news_public`
     STORY_GQL_ENDPOINT =
       process.env.STORY_GQL_ENDPOINT ||
@@ -389,5 +394,6 @@ export {
   ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE,
   GCS_FUSE_MOUNT_DIR,
   GCS_FUSE_STATIC_BUCKET,
+  URL_STATIC_NEWS_CATEGORY_INFO,
   URL_STATIC_NEWS_CATEGORY_POSTS,
 }

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -59,7 +59,7 @@ let STORY_GQL_ENDPOINT = ''
 let ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE = true
 let GCS_FUSE_MOUNT_DIR = ''
 let GCS_FUSE_STATIC_BUCKET = ''
-
+let URL_STATIC_NEWS_CATEGORY_POSTS = ''
 /** @type {import("firebase/auth").ActionCodeSettings} */
 let ACTION_CODE_SETTING
 
@@ -97,6 +97,7 @@ switch (ENV) {
     URL_STATIC_PROMOTE_VIDEOS = `https://${STATIC_FILE_DOMAIN}/files/json/promoting-video.json`
     URL_STATIC_COLUMN_SECTION_POSTS = `https://${STATIC_FILE_DOMAIN}/json/atest/latest_content_section_column_1`
     URL_STATIC_DAILY_COLUMN_HEADLINES = `https://${STATIC_FILE_DOMAIN}/files/json/daily-column.json`
+    URL_STATIC_NEWS_CATEGORY_POSTS = `https://${STATIC_FILE_DOMAIN}/json/latest/latest_content_category_news_public`
     // Only use STORY_GQL_ENDPOINT if explicitly set via env var
     // Do not fallback to dev endpoint in prod to avoid connecting to dev service
     STORY_GQL_ENDPOINT =
@@ -165,6 +166,7 @@ switch (ENV) {
     URL_STATIC_PROMOTE_VIDEOS = `https://${STATIC_FILE_DOMAIN}/files/json/promoting-video.json`
     URL_STATIC_COLUMN_SECTION_POSTS = `https://${STATIC_FILE_DOMAIN}/json/atest/latest_content_section_column_1`
     URL_STATIC_DAILY_COLUMN_HEADLINES = `https://${STATIC_FILE_DOMAIN}/files/json/daily-column.json`
+    URL_STATIC_NEWS_CATEGORY_POSTS = `https://${STATIC_FILE_DOMAIN}/json/latest/latest_content_category_news_public`
     STORY_GQL_ENDPOINT =
       process.env.STORY_GQL_ENDPOINT ||
       'https://go-story-staging-983956931553.asia-east1.run.app/api/graphql'
@@ -230,6 +232,7 @@ switch (ENV) {
     URL_STATIC_PROMOTE_VIDEOS = `https://${STATIC_FILE_DOMAIN}/files/json/promoting-video.json`
     URL_STATIC_COLUMN_SECTION_POSTS = `https://storage.googleapis.com/v3-statics-dev.mirrormedia.mg/json/latest/latest_content_section_column_1.json`
     URL_STATIC_DAILY_COLUMN_HEADLINES = `https://${STATIC_FILE_DOMAIN}/files/json/daily-column.json`
+    URL_STATIC_NEWS_CATEGORY_POSTS = `https://${STATIC_FILE_DOMAIN}/json/latest/latest_content_category_news_public`
     STORY_GQL_ENDPOINT =
       process.env.STORY_GQL_ENDPOINT ||
       'https://go-story-dev-983956931553.asia-east1.run.app/api/graphql'
@@ -301,6 +304,7 @@ switch (ENV) {
     URL_STATIC_PROMOTE_VIDEOS = `https://${STATIC_FILE_DOMAIN}/files/json/promoting-video.json`
     URL_STATIC_COLUMN_SECTION_POSTS = `https://storage.googleapis.com/v3-statics-dev.mirrormedia.mg/json/latest/latest_content_section_column_1.json`
     URL_STATIC_DAILY_COLUMN_HEADLINES = `https://${STATIC_FILE_DOMAIN}/files/json/daily-column.json`
+    URL_STATIC_NEWS_CATEGORY_POSTS = `https://${STATIC_FILE_DOMAIN}/json/latest/latest_content_category_news_public`
     STORY_GQL_ENDPOINT =
       process.env.STORY_GQL_ENDPOINT ||
       'https://go-story-dev-983956931553.asia-east1.run.app/api/graphql'
@@ -385,4 +389,5 @@ export {
   ENABLE_NON_PREMIUM_OPEN_ARTICLE_MODE,
   GCS_FUSE_MOUNT_DIR,
   GCS_FUSE_STATIC_BUCKET,
+  URL_STATIC_NEWS_CATEGORY_POSTS,
 }

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -19,6 +19,8 @@ import {
   fetchCategoryByCategorySlug,
   fetchPostsByCategorySlug,
   fetchPremiumPostsByCategorySlug,
+  fetchNewsCategoryInfo,
+  fetchNewsCategoryPostsJSON,
 } from '../../utils/api/category'
 import { useDisplayAd } from '../../hooks/useDisplayAd'
 import { getCategoryOfWineSlug, getLogTraceObject } from '../../utils'
@@ -188,6 +190,7 @@ const RENDER_PAGE_SIZE = 12
  * @param {number} props.postsCount
  * @param {boolean} props.isPremium
  * @param {Object} props.headerData
+ * @param {boolean} props.isNewsCategory
  * @returns {React.ReactElement}
  */
 export default function Category({
@@ -196,6 +199,7 @@ export default function Category({
   category,
   isPremium,
   headerData,
+  isNewsCategory,
 }) {
   const categoryName = category.name || ''
   const { shouldShowAd, isLogInProcessFinished } = useDisplayAd()
@@ -263,6 +267,7 @@ export default function Category({
           category={category}
           renderPageSize={RENDER_PAGE_SIZE}
           isPremium={isPremium}
+          isNewsCategory={isNewsCategory}
         />
 
         {shouldShowAd && isNotWineCategory ? (
@@ -298,15 +303,28 @@ export async function getServerSideProps({ query, req, res }) {
     isMemberOnly: false,
     state: 'inactive',
   }
-  try {
-    const { data } = await fetchCategoryByCategorySlug(categorySlug)
-    category = data.category || category
-  } catch (error) {
-    logGqlError(
-      error,
-      `Error occurs while getting category data in category page (${categorySlug})`,
-      globalLogFields
-    )
+
+  const isNewsCategory =
+    categorySlug.startsWith('news') || categorySlug.startsWith('news?')
+
+  if (isNewsCategory) {
+    try {
+      const { data } = await fetchNewsCategoryInfo()
+      category = data.category || category
+    } catch (error) {
+      console.error('Error fetching news category:', error)
+    }
+  } else {
+    try {
+      const { data } = await fetchCategoryByCategorySlug(categorySlug)
+      category = data.category || category
+    } catch (error) {
+      logGqlError(
+        error,
+        `Error occurs while getting category data in category page (${categorySlug})`,
+        globalLogFields
+      )
+    }
   }
 
   // handle category state, if `inactive` -> redirect to 404
@@ -360,7 +378,9 @@ export async function getServerSideProps({ query, req, res }) {
       `Error occurs while getting premium post data in category page (categorySlug: ${categorySlug})`,
       globalLogFields
     )
-  } else {
+  }
+
+  if (!isNewsCategory && !isPremium) {
     const responses = await Promise.allSettled([
       fetchHeaderDataInDefaultPageLayout(),
       fetchPostsByCategorySlug(categorySlug, RENDER_PAGE_SIZE * 2, 0),
@@ -389,6 +409,25 @@ export async function getServerSideProps({ query, req, res }) {
     )
   }
 
+  if (isNewsCategory && !isPremium) {
+    const responses = await Promise.allSettled([
+      fetchHeaderDataInDefaultPageLayout(),
+    ])
+
+    // handle header data
+    ;[sectionsData, topicsData] = processSettledResult(
+      responses[0],
+      getSectionAndTopicFromDefaultHeaderData,
+      `Error occurs while getting header data in category page (categorySlug: ${categorySlug})`,
+      globalLogFields
+    )
+
+    // handle fetch post data
+    const { data } = await fetchNewsCategoryPostsJSON()
+    posts = data.posts.items || []
+    postsCount = data.posts.counts || 0
+  }
+
   // handle fetch post data
   if (posts.length === 0) {
     // fetchPost return empty array -> wrong authorId -> 404
@@ -408,6 +447,7 @@ export async function getServerSideProps({ query, req, res }) {
     category,
     isPremium,
     headerData: { sectionsData, topicsData },
+    isNewsCategory,
   }
   return { props }
 }

--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -304,8 +304,7 @@ export async function getServerSideProps({ query, req, res }) {
     state: 'inactive',
   }
 
-  const isNewsCategory =
-    categorySlug.startsWith('news') || categorySlug.startsWith('news?')
+  const isNewsCategory = categorySlug === 'news'
 
   if (isNewsCategory) {
     try {

--- a/packages/mirror-media-next/utils/api/category.js
+++ b/packages/mirror-media-next/utils/api/category.js
@@ -69,6 +69,7 @@ export async function fetchNewsCategoryPostsJSON(page = 1, take = 24) {
       'Failed to fetch JSON of URL_STATIC_NEWS_CATEGORY_POSTS: ',
       JSON.stringify(err)
     )
+    return { data: { posts: { items: [], counts: 0 } } }
   }
 }
 

--- a/packages/mirror-media-next/utils/api/category.js
+++ b/packages/mirror-media-next/utils/api/category.js
@@ -1,6 +1,11 @@
 import client from '../../apollo/apollo-client'
 import { fetchCategorySections } from '../../apollo/query/categroies'
 import { fetchPosts } from '../../apollo/query/posts'
+import axios from 'axios'
+import {
+  API_TIMEOUT,
+  URL_STATIC_NEWS_CATEGORY_POSTS,
+} from '../../config/index.mjs'
 
 export function fetchPostsByCategorySlug(categorySlug, take, skip) {
   return client.query({
@@ -15,6 +20,42 @@ export function fetchPostsByCategorySlug(categorySlug, take, skip) {
       },
     },
   })
+}
+
+export async function fetchNewsCategoryPostsJSON(page = 1, take = 24) {
+  const POSTS_PER_JSON = 120
+  const TAKE_PER_JSON = POSTS_PER_JSON / take
+  const jsonFileOrder = Math.ceil(page / TAKE_PER_JSON)
+  const jsonUrl = `${URL_STATIC_NEWS_CATEGORY_POSTS}_${jsonFileOrder}.json`
+
+  try {
+    const response = await axios({
+      method: 'get',
+      url: jsonUrl,
+      timeout: API_TIMEOUT,
+    })
+
+    const jsonIndex = (page - 1) % TAKE_PER_JSON
+    const startIndex = jsonIndex * take
+    const endIndex = startIndex + take
+    const postItems = response.data.posts.items.slice(startIndex, endIndex)
+
+    return {
+      data: {
+        posts: {
+          items: jsonFileOrder <= 4 ? postItems : [],
+          counts:
+            response.data.posts.counts.posts +
+            response.data.posts.counts.externals,
+        },
+      },
+    }
+  } catch (err) {
+    console.error(
+      'Failed to fetch JSON of URL_STATIC_NEWS_CATEGORY_POSTS',
+      JSON.stringify(err)
+    )
+  }
 }
 
 export function fetchPremiumPostsByCategorySlug(categorySlug, take, skip) {

--- a/packages/mirror-media-next/utils/api/category.js
+++ b/packages/mirror-media-next/utils/api/category.js
@@ -4,6 +4,7 @@ import { fetchPosts } from '../../apollo/query/posts'
 import axios from 'axios'
 import {
   API_TIMEOUT,
+  URL_STATIC_NEWS_CATEGORY_INFO,
   URL_STATIC_NEWS_CATEGORY_POSTS,
 } from '../../config/index.mjs'
 
@@ -20,6 +21,19 @@ export function fetchPostsByCategorySlug(categorySlug, take, skip) {
       },
     },
   })
+}
+
+export async function fetchNewsCategoryInfo() {
+  try {
+    const response = await axios({
+      method: 'get',
+      url: URL_STATIC_NEWS_CATEGORY_INFO,
+      timeout: API_TIMEOUT,
+    })
+    return response
+  } catch (err) {
+    console.error('Error fetching news category info: ', JSON.stringify(err))
+  }
 }
 
 export async function fetchNewsCategoryPostsJSON(page = 1, take = 24) {
@@ -52,7 +66,7 @@ export async function fetchNewsCategoryPostsJSON(page = 1, take = 24) {
     }
   } catch (err) {
     console.error(
-      'Failed to fetch JSON of URL_STATIC_NEWS_CATEGORY_POSTS',
+      'Failed to fetch JSON of URL_STATIC_NEWS_CATEGORY_POSTS: ',
       JSON.stringify(err)
     )
   }

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -86,7 +86,7 @@ const createStaticJsonRequest = (requestUrl) => {
   return async () => {
     if (typeof window === 'undefined') {
       try {
-      const mod = await import('../server-side-only/fetch-static-json.js')
+        const mod = await import('../server-side-only/fetch-static-json.js')
         const res = await mod.fetchStaticJson(requestUrl)
         // Note: fetchStaticJson internally logs whether it's from GCS mount or HTTP
         // fetchStaticJson returns { data: ... } format
@@ -128,7 +128,9 @@ const fetchNormalSections = createStaticJsonRequest(URL_STATIC_HEADER_HEADERS)
 /** @type {() => Promise<{ data: { topics: Topics } }>} */
 const fetchTopics = createStaticJsonRequest(URL_STATIC_TOPICS)
 
-const fetchPremiumSections = createStaticJsonRequest(URL_STATIC_PREMIUM_SECTIONS)
+const fetchPremiumSections = createStaticJsonRequest(
+  URL_STATIC_PREMIUM_SECTIONS
+)
 
 const fetchPodcastList = createStaticJsonRequest(URL_STATIC_PODCAST_LIST)
 


### PR DESCRIPTION
# 描述

- 為解決可能是因編輯檯同時間發布多則新聞而產生的頁面新聞重複問題，將 `/category/news`或 `/category/news?` 網址的文章來源從 GraphQL endpoint 改成 JSON URLs

**參考資源**

- news（焦點）category 的基本資訊 JSON
https://storage.googleapis.com/v3-statics-dev.mirrormedia.mg/json/latest/category_news.json

- category 是 news 的新聞（非會員可瀏覽）JSON
  - https://storage.googleapis.com/v3-statics-dev.mirrormedia.mg/json/latest/latest_content_category_news_public_1.json
  - https://storage.googleapis.com/v3-statics-dev.mirrormedia.mg/json/latest/latest_content_category_news_public_2.json
  - https://storage.googleapis.com/v3-statics-dev.mirrormedia.mg/json/latest/latest_content_category_news_public_3.json
  - https://storage.googleapis.com/v3-statics-dev.mirrormedia.mg/json/latest/latest_content_category_news_public_4.json

- Asana 
https://app.asana.com/1/614399484723017/project/1213553957874038/task/1211779788621415?focus=true