### PR TITLE
feat: implement site-wide promote topic widget and refactor static JSON fetching

### DIFF
--- a/packages/mirror-media-next/components/promote-topic/index.js
+++ b/packages/mirror-media-next/components/promote-topic/index.js
@@ -6,28 +6,78 @@ import PromoteTopicSwiper from './promote-topic-swiper'
 
 /**
  * @typedef {import('./promote-topic-item').PromoteTopicData} PromoteTopicData
+ *
+ * @typedef {Object} RawPromoteTopicHeroImage
+ * @property {Record<string, string>} [resized]
+ * @property {Record<string, string>} [resizedWebp]
+ *
+ * @typedef {Object} RawPromoteTopic
+ * @property {string} [id]
+ * @property {string} [slug]
+ * @property {string} [name]
+ * @property {RawPromoteTopicHeroImage | null} [heroImage]
+ *
+ * @typedef {Object} RawPromoteTopicItem
+ * @property {string | number} [id]
+ * @property {string | number | null} [order]
+ * @property {RawPromoteTopic | null} [topics]
  */
+
+/**
+ * @param {Record<string, string> | null | undefined} images
+ * @returns {boolean}
+ */
+function hasAvailableImages(images) {
+  return Object.values(images ?? {}).some(Boolean)
+}
+
+/**
+ * @param {RawPromoteTopicItem | null | undefined} item
+ * @returns {PromoteTopicData | null}
+ */
+function normalizePromoteTopic(item) {
+  const topic = item?.topics
+  const heroImage = topic?.heroImage
+  const resized = heroImage?.resized
+  const resizedWebp = heroImage?.resizedWebp
+  const hasImage = hasAvailableImages(resized)
+
+  if (!topic?.slug || !topic?.name || !hasImage) {
+    return null
+  }
+
+  return {
+    id: String(item?.id ?? topic.id ?? topic.slug),
+    order: item?.order ?? null,
+    slug: topic.slug,
+    name: topic.name,
+    heroImage: {
+      resized: resized ?? {},
+      resizedWebp: hasAvailableImages(resizedWebp) ? resizedWebp : undefined,
+    },
+  }
+}
 
 /**
  * @param {unknown} promoteTopics
  * @returns {PromoteTopicData[]}
  */
-const normalizePromoteTopics = (promoteTopics) => {
+function normalizePromoteTopics(promoteTopics) {
   if (!Array.isArray(promoteTopics)) return []
 
-  return promoteTopics
-    .map((item) => item?.topics)
-    .filter((topic) => {
-      const hasImage = Object.values(topic?.heroImage?.resized ?? {}).some(
-        Boolean
-      )
+  return promoteTopics.reduce((topics, item) => {
+    const topic = normalizePromoteTopic(item)
 
-      return Boolean(topic?.slug && topic?.name && hasImage)
-    })
+    if (topic) {
+      topics.push(topic)
+    }
+
+    return topics
+  }, /** @type {PromoteTopicData[]} */ ([]))
 }
 
 export default function PromoteTopic() {
-  const [topics, setTopics] = useState([])
+  const [topics, setTopics] = useState(/** @type {PromoteTopicData[]} */ ([]))
 
   useEffect(() => {
     let isMounted = true

--- a/packages/mirror-media-next/components/promote-topic/index.js
+++ b/packages/mirror-media-next/components/promote-topic/index.js
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+
+import { URL_STATIC_PROMOTE_TOPICS } from '../../config/index.mjs'
+import { fetchStaticJsonByUrl } from '../../utils/api'
+import PromoteTopicSwiper from './promote-topic-swiper'
+
+/**
+ * @typedef {import('./promote-topic-item').PromoteTopicData} PromoteTopicData
+ */
+
+/**
+ * @param {unknown} promoteTopics
+ * @returns {PromoteTopicData[]}
+ */
+const normalizePromoteTopics = (promoteTopics) => {
+  if (!Array.isArray(promoteTopics)) return []
+
+  return promoteTopics
+    .map((item) => item?.topics)
+    .filter((topic) => {
+      const hasImage = Object.values(topic?.heroImage?.resized ?? {}).some(
+        Boolean
+      )
+
+      return Boolean(topic?.slug && topic?.name && hasImage)
+    })
+}
+
+export default function PromoteTopic() {
+  const [topics, setTopics] = useState([])
+
+  useEffect(() => {
+    let isMounted = true
+
+    const fetchData = async () => {
+      try {
+        const res = await fetchStaticJsonByUrl(URL_STATIC_PROMOTE_TOPICS)
+        if (!isMounted) return
+        setTopics(normalizePromoteTopics(res.data?.promoteTopics))
+      } catch {
+        if (isMounted) setTopics([])
+      }
+    }
+
+    fetchData()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  if (!topics.length) return null
+
+  return <PromoteTopicSwiper list={topics} />
+}

--- a/packages/mirror-media-next/components/promote-topic/index.js
+++ b/packages/mirror-media-next/components/promote-topic/index.js
@@ -21,6 +21,9 @@ import PromoteTopicSwiper from './promote-topic-swiper'
  * @property {string | number} [id]
  * @property {string | number | null} [order]
  * @property {RawPromoteTopic | null} [topics]
+ *
+ * @typedef {Object} PromoteTopicsStaticJsonResponse
+ * @property {RawPromoteTopicItem[]} [promoteTopics]
  */
 
 /**
@@ -87,12 +90,13 @@ export default function PromoteTopic() {
 
     const fetchData = async () => {
       try {
-        const res = await fetchStaticJsonByUrl(URL_STATIC_PROMOTE_TOPICS, {
-          signal: abortController.signal,
-        })
-        // fetchStaticJsonByUrl normalizes both server/client paths to { data: ... }.
-        const promoteTopics = res.data?.promoteTopics
-        setTopics(normalizePromoteTopics(promoteTopics))
+        const response =
+          /** @type {{ data: PromoteTopicsStaticJsonResponse }} */ (
+            await fetchStaticJsonByUrl(URL_STATIC_PROMOTE_TOPICS, {
+              signal: abortController.signal,
+            })
+          )
+        setTopics(normalizePromoteTopics(response.data.promoteTopics))
       } catch (err) {
         if (
           abortController.signal.aborted ||

--- a/packages/mirror-media-next/components/promote-topic/index.js
+++ b/packages/mirror-media-next/components/promote-topic/index.js
@@ -76,26 +76,40 @@ function normalizePromoteTopics(promoteTopics) {
   }, /** @type {PromoteTopicData[]} */ ([]))
 }
 
+/**
+ * @returns {React.ReactElement | null}
+ */
 export default function PromoteTopic() {
   const [topics, setTopics] = useState(/** @type {PromoteTopicData[]} */ ([]))
 
   useEffect(() => {
-    let isMounted = true
+    const abortController = new AbortController()
 
     const fetchData = async () => {
       try {
-        const res = await fetchStaticJsonByUrl(URL_STATIC_PROMOTE_TOPICS)
-        if (!isMounted) return
-        setTopics(normalizePromoteTopics(res.data?.promoteTopics))
-      } catch {
-        if (isMounted) setTopics([])
+        const res = await fetchStaticJsonByUrl(URL_STATIC_PROMOTE_TOPICS, {
+          signal: abortController.signal,
+        })
+        // fetchStaticJsonByUrl normalizes both server/client paths to { data: ... }.
+        const promoteTopics = res.data?.promoteTopics
+        setTopics(normalizePromoteTopics(promoteTopics))
+      } catch (err) {
+        if (
+          abortController.signal.aborted ||
+          err?.code === 'ERR_CANCELED' ||
+          err?.name === 'CanceledError'
+        ) {
+          return
+        }
+
+        setTopics([])
       }
     }
 
     fetchData()
 
     return () => {
-      isMounted = false
+      abortController.abort()
     }
   }, [])
 

--- a/packages/mirror-media-next/components/promote-topic/promote-topic-item.js
+++ b/packages/mirror-media-next/components/promote-topic/promote-topic-item.js
@@ -1,0 +1,90 @@
+import styled from 'styled-components'
+import CustomImage from '@readr-media/react-image'
+
+const Card = styled.a`
+  display: block;
+  width: 100%;
+  background-color: #054f77;
+`
+
+const ImageFrame = styled.div`
+  position: relative;
+  width: 100%;
+  height: 120px;
+  background-color: #d8d8d8;
+
+  picture,
+  img {
+    width: 100%;
+    height: 100%;
+  }
+
+  img {
+    object-fit: cover;
+  }
+`
+
+const TitleFrame = styled.div`
+  height: 76px;
+  padding: 10px 10px 20px;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+`
+
+const Title = styled.p`
+  margin: 0;
+  width: 100%;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 23px;
+  text-align: center;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`
+
+/**
+ * @typedef {Object} PromoteTopicHeroImage
+ * @property {Record<string, string>} [resized]
+ * @property {Record<string, string>} [resizedWebp]
+ *
+ * @typedef {Object} PromoteTopicData
+ * @property {string} [id]
+ * @property {string} slug
+ * @property {string} name
+ * @property {PromoteTopicHeroImage} heroImage
+ */
+
+/**
+ * @param {Object} props
+ * @param {PromoteTopicData} props.topic
+ * @returns {React.ReactElement}
+ */
+export default function PromoteTopicItem({ topic }) {
+  return (
+    <Card href={`/topic/${topic.slug}`} target="_blank" rel="noreferrer">
+      <ImageFrame>
+        <CustomImage
+          images={topic.heroImage?.resized}
+          imagesWebP={topic.heroImage?.resizedWebp}
+          loadingImage="/images-next/loading.gif"
+          defaultImage="/images-next/default-og-img.png"
+          rwd={{
+            mobile: '124px',
+            tablet: '124px',
+            desktop: '124px',
+            default: '124px',
+          }}
+          alt={`推廣專題-${topic.name}`}
+        />
+      </ImageFrame>
+      <TitleFrame>
+        <Title>{topic.name}</Title>
+      </TitleFrame>
+    </Card>
+  )
+}

--- a/packages/mirror-media-next/components/promote-topic/promote-topic-item.js
+++ b/packages/mirror-media-next/components/promote-topic/promote-topic-item.js
@@ -54,6 +54,7 @@ const Title = styled.p`
  *
  * @typedef {Object} PromoteTopicData
  * @property {string} [id]
+ * @property {number | string | null} [order]
  * @property {string} slug
  * @property {string} name
  * @property {PromoteTopicHeroImage} heroImage

--- a/packages/mirror-media-next/components/promote-topic/promote-topic-swiper.js
+++ b/packages/mirror-media-next/components/promote-topic/promote-topic-swiper.js
@@ -67,6 +67,8 @@ const CloseButton = styled.button`
   justify-content: center;
   width: 32px;
   height: 32px;
+  padding: 0;
+  border: none;
   border-radius: 50%;
   cursor: pointer;
   color: #fff;

--- a/packages/mirror-media-next/components/promote-topic/promote-topic-swiper.js
+++ b/packages/mirror-media-next/components/promote-topic/promote-topic-swiper.js
@@ -19,19 +19,40 @@ const Wrapper = styled.div`
   transform: translateY(-50%);
   width: ${CARD_WIDTH}px;
 
-  &::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: 10px;
-    box-shadow: 0 2.47px 2.47px rgba(0, 0, 0, 0.25);
-    pointer-events: none;
-    z-index: 0;
-  }
-
-  .promote-topic-swiper {
+  .swiper {
     position: relative;
     z-index: 1;
+    overflow: hidden;
+    border-radius: 10px;
+    background-color: #054f77;
+    box-shadow: 0 3px 3px rgba(0, 0, 0, 0.25);
+  }
+
+  .swiper-pagination {
+    position: absolute;
+    z-index: 2;
+    bottom: 10px !important;
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 0;
+  }
+
+  .swiper-pagination-bullet {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: #d9d9d9;
+    cursor: pointer;
+    opacity: 1;
+  }
+
+  .swiper-pagination-bullet-active {
+    background-color: #0000004d;
+    cursor: default;
   }
 `
 
@@ -46,7 +67,6 @@ const CloseButton = styled.button`
   justify-content: center;
   width: 32px;
   height: 32px;
-  gap: 16px;
   border-radius: 50%;
   cursor: pointer;
   color: #fff;
@@ -85,14 +105,11 @@ export default function PromoteTopicSwiper({ list }) {
         <CloseIcon />
       </CloseButton>
       <Swiper
-        className="promote-topic-swiper"
         modules={[Autoplay, Pagination]}
         pagination={
           shouldLoop
             ? {
                 clickable: true,
-                bulletClass: 'promote-topic-swiper-bullet',
-                bulletActiveClass: 'promote-topic-swiper-bullet-active',
               }
             : false
         }
@@ -101,7 +118,7 @@ export default function PromoteTopicSwiper({ list }) {
         autoplay={
           shouldLoop
             ? {
-                delay: 30000,
+                delay: 10000,
                 disableOnInteraction: false,
               }
             : false

--- a/packages/mirror-media-next/components/promote-topic/promote-topic-swiper.js
+++ b/packages/mirror-media-next/components/promote-topic/promote-topic-swiper.js
@@ -1,0 +1,119 @@
+import { useState } from 'react'
+import styled from 'styled-components'
+import { Swiper, SwiperSlide } from 'swiper/react'
+import { Autoplay, Pagination } from 'swiper'
+import 'swiper/css'
+import 'swiper/css/pagination'
+
+import { Z_INDEX } from '../../constants/index'
+import CloseIcon from '../../public/images-next/close.svg'
+import PromoteTopicItem from './promote-topic-item'
+
+const CARD_WIDTH = 124
+
+const Wrapper = styled.div`
+  position: fixed;
+  right: 20px;
+  top: 50%;
+  z-index: ${Z_INDEX.promoteTopic};
+  transform: translateY(-50%);
+  width: ${CARD_WIDTH}px;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 10px;
+    box-shadow: 0 2.47px 2.47px rgba(0, 0, 0, 0.25);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .promote-topic-swiper {
+    position: relative;
+    z-index: 1;
+  }
+`
+
+const CloseButton = styled.button`
+  position: absolute;
+  right: 0;
+  top: 0;
+  transform: translate(50%, -50%);
+  z-index: ${Z_INDEX.promoteTopic + 1};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  gap: 16px;
+  border-radius: 50%;
+  cursor: pointer;
+  color: #fff;
+  background-color: #61b8c6;
+  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
+
+  svg {
+    width: 24px;
+    height: 24px;
+  }
+`
+
+/**
+ * @typedef {import('./promote-topic-item').PromoteTopicData} PromoteTopicData
+ */
+
+/**
+ * @param {Object} props
+ * @param {PromoteTopicData[]} props.list
+ * @returns {React.ReactElement | null}
+ */
+export default function PromoteTopicSwiper({ list }) {
+  const [shouldShow, setShouldShow] = useState(true)
+
+  if (!shouldShow || !list.length) return null
+
+  const shouldLoop = list.length > 1
+
+  return (
+    <Wrapper>
+      <CloseButton
+        type="button"
+        aria-label="關閉推薦專題"
+        onClick={() => setShouldShow(false)}
+      >
+        <CloseIcon />
+      </CloseButton>
+      <Swiper
+        className="promote-topic-swiper"
+        modules={[Autoplay, Pagination]}
+        pagination={
+          shouldLoop
+            ? {
+                clickable: true,
+                bulletClass: 'promote-topic-swiper-bullet',
+                bulletActiveClass: 'promote-topic-swiper-bullet-active',
+              }
+            : false
+        }
+        slidesPerView={1}
+        resistanceRatio={0}
+        autoplay={
+          shouldLoop
+            ? {
+                delay: 30000,
+                disableOnInteraction: false,
+              }
+            : false
+        }
+        rewind={shouldLoop}
+      >
+        {list.map((topic) => (
+          <SwiperSlide key={topic.id || topic.slug}>
+            <PromoteTopicItem topic={topic} />
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </Wrapper>
+  )
+}

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -53,6 +53,7 @@ let URL_STATIC_LATEST_NEWS_IN_CERTAIN_SECTION = ''
 let GPT_MODE = ''
 let COURSE_URL = ''
 let URL_STATIC_PROMOTE_VIDEOS = ''
+let URL_STATIC_PROMOTE_TOPICS = ''
 let URL_STATIC_COLUMN_SECTION_POSTS = ''
 let URL_STATIC_DAILY_COLUMN_HEADLINES = ''
 let STORY_GQL_ENDPOINT = ''
@@ -96,6 +97,7 @@ switch (ENV) {
     URL_STATIC_LATEST_NEWS_IN_CERTAIN_SECTION = `https://${STATIC_FILE_DOMAIN}/files/json/sections`
     URL_STATIC_PODCAST_LIST = `https://${STATIC_FILE_DOMAIN}/json/podcast_list.json`
     URL_STATIC_PROMOTE_VIDEOS = `https://${STATIC_FILE_DOMAIN}/files/json/promoting-video.json`
+    URL_STATIC_PROMOTE_TOPICS = `https://${STATIC_FILE_DOMAIN}/json/promote-topics.json`
     URL_STATIC_COLUMN_SECTION_POSTS = `https://${STATIC_FILE_DOMAIN}/json/atest/latest_content_section_column_1`
     URL_STATIC_DAILY_COLUMN_HEADLINES = `https://${STATIC_FILE_DOMAIN}/files/json/daily-column.json`
     URL_STATIC_NEWS_CATEGORY_INFO = `https://${STATIC_FILE_DOMAIN}/json/latest/category_news.json`
@@ -166,6 +168,7 @@ switch (ENV) {
     URL_STATIC_LATEST_NEWS_IN_CERTAIN_SECTION = `https://${STATIC_FILE_DOMAIN}/files/json/sections`
     URL_STATIC_PODCAST_LIST = `https://${STATIC_FILE_DOMAIN}/json/podcast_list.json`
     URL_STATIC_PROMOTE_VIDEOS = `https://${STATIC_FILE_DOMAIN}/files/json/promoting-video.json`
+    URL_STATIC_PROMOTE_TOPICS = `https://${STATIC_FILE_DOMAIN}/json/promote-topics.json`
     URL_STATIC_COLUMN_SECTION_POSTS = `https://${STATIC_FILE_DOMAIN}/json/atest/latest_content_section_column_1`
     URL_STATIC_DAILY_COLUMN_HEADLINES = `https://${STATIC_FILE_DOMAIN}/files/json/daily-column.json`
     URL_STATIC_NEWS_CATEGORY_INFO = `https://${STATIC_FILE_DOMAIN}/json/latest/category_news.json`
@@ -233,6 +236,7 @@ switch (ENV) {
     URL_STATIC_LATEST_NEWS_IN_CERTAIN_SECTION = `https://${STATIC_FILE_DOMAIN}/files/json/sections`
     URL_STATIC_PODCAST_LIST = `https://${STATIC_FILE_DOMAIN}/json/podcast_list.json`
     URL_STATIC_PROMOTE_VIDEOS = `https://${STATIC_FILE_DOMAIN}/files/json/promoting-video.json`
+    URL_STATIC_PROMOTE_TOPICS = `https://${STATIC_FILE_DOMAIN}/json/promote-topics.json`
     URL_STATIC_COLUMN_SECTION_POSTS = `https://storage.googleapis.com/v3-statics-dev.mirrormedia.mg/json/latest/latest_content_section_column_1.json`
     URL_STATIC_DAILY_COLUMN_HEADLINES = `https://${STATIC_FILE_DOMAIN}/files/json/daily-column.json`
     URL_STATIC_NEWS_CATEGORY_INFO = `https://${STATIC_FILE_DOMAIN}/json/latest/category_news.json`
@@ -306,6 +310,7 @@ switch (ENV) {
     URL_STATIC_LATEST_NEWS_IN_CERTAIN_SECTION = `http://localhost:8080/json/sections`
     URL_STATIC_PODCAST_LIST = `https://${STATIC_FILE_DOMAIN}/json/podcast_list.json`
     URL_STATIC_PROMOTE_VIDEOS = `https://${STATIC_FILE_DOMAIN}/files/json/promoting-video.json`
+    URL_STATIC_PROMOTE_TOPICS = `https://${STATIC_FILE_DOMAIN}/json/promote-topics.json`
     URL_STATIC_COLUMN_SECTION_POSTS = `https://storage.googleapis.com/v3-statics-dev.mirrormedia.mg/json/latest/latest_content_section_column_1.json`
     URL_STATIC_DAILY_COLUMN_HEADLINES = `https://${STATIC_FILE_DOMAIN}/files/json/daily-column.json`
     URL_STATIC_NEWS_CATEGORY_INFO = `https://${STATIC_FILE_DOMAIN}/json/latest/category_news.json`
@@ -382,6 +387,7 @@ export {
   URL_STATIC_PREMIUM_SECTIONS,
   URL_STATIC_TOPICS,
   URL_STATIC_PROMOTE_VIDEOS,
+  URL_STATIC_PROMOTE_TOPICS,
   URL_STATIC_DAILY_COLUMN_HEADLINES,
   STORY_GQL_ENDPOINT,
   WEEKLY_API_SERVER_ORIGIN,

--- a/packages/mirror-media-next/constants/index.js
+++ b/packages/mirror-media-next/constants/index.js
@@ -222,6 +222,7 @@ const Z_INDEX = /** @type {const}*/ ({
   top: 10000,
   coverHeader: 2000,
   header: 1000,
+  promoteTopic: 500,
   coverContent: 100,
 })
 

--- a/packages/mirror-media-next/pages/_app.js
+++ b/packages/mirror-media-next/pages/_app.js
@@ -13,6 +13,7 @@ import { useRouter } from 'next/router'
 import { MembershipProvider } from '../context/membership'
 import { Provider } from 'react-redux'
 import store from '../store'
+import PromoteTopic from '../components/promote-topic'
 /**
  *
  * @param {Object} props
@@ -48,6 +49,7 @@ function MyApp({ Component, pageProps }) {
             In order to avoiding send log repeatedly, make sure not add UserBehaviorLogger components here when at story page. */}
               {!isStoryPage && <UserBehaviorLogger />}
               <Component {...pageProps} />
+              <PromoteTopic />
             </ThemeProvider>
           </Provider>
         </ApolloProvider>

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -240,7 +240,7 @@ export async function getServerSideProps({ params, req, res }) {
       const mod = await import(
         '../../utils/server-side-only/fetch-static-json.js'
       )
-      const res = await mod.fetchStaticJson(url, timeout)
+      const res = await mod.fetchStaticJsonOnServer(url, timeout)
       return res
     } catch (err) {
       return null

--- a/packages/mirror-media-next/pages/index.js
+++ b/packages/mirror-media-next/pages/index.js
@@ -207,10 +207,10 @@ export async function getServerSideProps({ res, req }) {
   const fetchStaticJsonSafe = async (url, timeout, label) => {
     try {
       const mod = await import('../utils/server-side-only/fetch-static-json.js')
-      const res = await mod.fetchStaticJson(url, timeout)
+      const res = await mod.fetchStaticJsonOnServer(url, timeout)
       return res
     } catch (err) {
-      // fetchStaticJson already has axios fallback, but if import fails, fallback to axios
+      // fetchStaticJsonOnServer already has axios fallback, but if import fails, fallback to axios
       return axios({
         method: 'get',
         url,

--- a/packages/mirror-media-next/pages/podcasts/index.js
+++ b/packages/mirror-media-next/pages/podcasts/index.js
@@ -81,6 +81,9 @@ const Title = styled.p`
  * @typedef {Object} Props
  * @property {Object} headerData
  * @property {PodcastData[]} podcastListData
+ *
+ * @typedef {Object} PodcastListResponse
+ * @property {PodcastData[]} data
  */
 
 /**
@@ -185,7 +188,9 @@ export async function getServerSideProps({ req, res }) {
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
-    fetchStaticJsonByUrl(URL_STATIC_PODCAST_LIST),
+    /** @type {Promise<PodcastListResponse>} */ (
+      fetchStaticJsonByUrl(URL_STATIC_PODCAST_LIST)
+    ),
   ])
 
   // handle header data
@@ -200,8 +205,8 @@ export async function getServerSideProps({ req, res }) {
   /** @type {PodcastData[]} */
   const podcastListData = processSettledResult(
     responses[1],
-    (/** @type {{ data?: PodcastData[] } | undefined} */ axiosData) => {
-      return axiosData?.data ?? []
+    (/** @type {PodcastListResponse | undefined} */ response) => {
+      return response?.data ?? []
     },
     'Error occurs while getting podcast list in podcasts page',
     globalLogFields

--- a/packages/mirror-media-next/pages/podcasts/index.js
+++ b/packages/mirror-media-next/pages/podcasts/index.js
@@ -4,10 +4,10 @@ import AudioPlayer from '../../components/podcast/audio-player'
 import Dropdown from '../../components/podcast/author-select-dropdown'
 import PodcastList from '../../components/podcast/podcast-list'
 import Layout from '../../components/shared/layout'
-import { ENV } from '../../config/index.mjs'
+import { ENV, URL_STATIC_PODCAST_LIST } from '../../config/index.mjs'
 import {
+  fetchStaticJsonByUrl,
   fetchHeaderDataInDefaultPageLayout,
-  fetchPodcastList,
 } from '../../utils/api'
 import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-process'
 import { setPageCache } from '../../utils/cache-setting'
@@ -185,7 +185,7 @@ export async function getServerSideProps({ req, res }) {
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
-    fetchPodcastList(),
+    fetchStaticJsonByUrl(URL_STATIC_PODCAST_LIST),
   ])
 
   // handle header data
@@ -200,9 +200,7 @@ export async function getServerSideProps({ req, res }) {
   /** @type {PodcastData[]} */
   const podcastListData = processSettledResult(
     responses[1],
-    (
-      /** @type {Awaited<ReturnType<typeof fetchPodcastList>> | undefined} */ axiosData
-    ) => {
+    (/** @type {{ data?: PodcastData[] } | undefined} */ axiosData) => {
       return axiosData?.data ?? []
     },
     'Error occurs while getting podcast list in podcasts page',

--- a/packages/mirror-media-next/pages/section/column.js
+++ b/packages/mirror-media-next/pages/section/column.js
@@ -104,6 +104,8 @@ const RENDER_PAGE_SIZE = 12
 /**
  * @typedef {import('../../components/shared/section-articles').Article} Article
  * @typedef {import('../../components/shared/section-articles').Section} Section
+ * @typedef {Object} ColumnSectionStaticJsonResponse
+ * @property {import('../../utils/api').ColumnSectionResponse} data
  */
 
 /**
@@ -189,7 +191,9 @@ export async function getServerSideProps({ req, res }) {
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
-    fetchStaticJsonByUrl(URL_STATIC_COLUMN_SECTION_POSTS),
+    /** @type {Promise<ColumnSectionStaticJsonResponse>} */ (
+      fetchStaticJsonByUrl(URL_STATIC_COLUMN_SECTION_POSTS)
+    ),
     fetchSectionBySectionSlug(sectionSlug),
   ])
 
@@ -211,10 +215,10 @@ export async function getServerSideProps({ req, res }) {
   /** @type {[ number, Article[]]} */
   const postResult = processSettledResult(
     responses[1],
-    /** @param {import('axios').AxiosResponse<ColumnSectionResponse> | undefined} data */
-    (data) => {
-      const items = data?.data?.section?.items || []
-      const counts = data?.data?.section?.counts || {
+    /** @param {ColumnSectionStaticJsonResponse | undefined} response */
+    (response) => {
+      const items = response?.data.section?.items || []
+      const counts = response?.data.section?.counts || {
         posts: 0,
         externals: 0,
       }

--- a/packages/mirror-media-next/pages/section/column.js
+++ b/packages/mirror-media-next/pages/section/column.js
@@ -1,9 +1,9 @@
 import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
-import { ENV } from '../../config/index.mjs'
+import { ENV, URL_STATIC_COLUMN_SECTION_POSTS } from '../../config/index.mjs'
 import {
-  fetchColumnSectionPosts,
+  fetchStaticJsonByUrl,
   fetchHeaderDataInDefaultPageLayout,
 } from '../../utils/api'
 import {
@@ -189,7 +189,7 @@ export async function getServerSideProps({ req, res }) {
 
   const responses = await Promise.allSettled([
     fetchHeaderDataInDefaultPageLayout(),
-    fetchColumnSectionPosts(),
+    fetchStaticJsonByUrl(URL_STATIC_COLUMN_SECTION_POSTS),
     fetchSectionBySectionSlug(sectionSlug),
   ])
 

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -489,7 +489,7 @@ export async function getServerSideProps({ params, req, res }) {
         const fetchStaticJsonSafe = async (url, timeout) => {
           try {
             const mod = await import('../../utils/server-side-only/fetch-static-json.js')
-            const res = await mod.fetchStaticJson(url, timeout)
+            const res = await mod.fetchStaticJsonOnServer(url, timeout)
             return res
           } catch (err) {
             return axios({

--- a/packages/mirror-media-next/public/images-next/close.svg
+++ b/packages/mirror-media-next/public/images-next/close.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 4L4 12" stroke="currentColor" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 4L12 12" stroke="currentColor" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/mirror-media-next/styles/global-styles.js
+++ b/packages/mirror-media-next/styles/global-styles.js
@@ -606,4 +606,38 @@ video {
   opacity: 1;
   pointer-events: auto;
 }
+
+.promote-topic-swiper {
+  position: relative;
+  overflow: hidden;
+  border-radius: 10px;
+  background-color: #054f77;
+}
+
+.promote-topic-swiper .swiper-pagination {
+  position: absolute;
+  z-index: 2;
+  bottom: 10px !important;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 0;
+}
+
+.promote-topic-swiper-bullet {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: #d9d9d9;
+  cursor: pointer;
+  opacity: 1;
+}
+
+.promote-topic-swiper-bullet-active {
+  background-color: #0000004D;
+  cursor: default;
+}
 `

--- a/packages/mirror-media-next/styles/global-styles.js
+++ b/packages/mirror-media-next/styles/global-styles.js
@@ -606,38 +606,4 @@ video {
   opacity: 1;
   pointer-events: auto;
 }
-
-.promote-topic-swiper {
-  position: relative;
-  overflow: hidden;
-  border-radius: 10px;
-  background-color: #054f77;
-}
-
-.promote-topic-swiper .swiper-pagination {
-  position: absolute;
-  z-index: 2;
-  bottom: 10px !important;
-  display: flex;
-  width: 100%;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  margin-top: 0;
-}
-
-.promote-topic-swiper-bullet {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background-color: #d9d9d9;
-  cursor: pointer;
-  opacity: 1;
-}
-
-.promote-topic-swiper-bullet-active {
-  background-color: #0000004D;
-  cursor: default;
-}
 `

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -102,9 +102,9 @@ import { fetchAnnoucements } from '../../apollo/query/announcements'
 const fetchStaticJsonByUrl = async (requestUrl, requestConfig) => {
   if (typeof window === 'undefined') {
     const mod = await import('../server-side-only/fetch-static-json.js')
-    const res = await mod.fetchStaticJson(requestUrl, requestConfig)
-    // Note: fetchStaticJson internally logs whether it's from GCS mount or HTTP
-    // fetchStaticJson returns { data: ... } format
+    const res = await mod.fetchStaticJsonOnServer(requestUrl, requestConfig)
+    // Note: fetchStaticJsonOnServer internally logs whether it's from GCS mount or HTTP
+    // fetchStaticJsonOnServer returns { data: ... } format
     return /** @type {{ data: T }} */ (res)
   }
 

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -101,17 +101,13 @@ import { fetchAnnoucements } from '../../apollo/query/announcements'
  */
 const fetchStaticJsonByUrl = async (requestUrl, requestConfig) => {
   if (typeof window === 'undefined') {
-    try {
-      const mod = await import('../server-side-only/fetch-static-json.js')
-      const res = await mod.fetchStaticJson(requestUrl)
-      // Note: fetchStaticJson internally logs whether it's from GCS mount or HTTP
-      // fetchStaticJson returns { data: ... } format
-      return /** @type {{ data: T }} */ (res)
-    } catch (err) {
-      console.warn('[static-json] fallback to axios', err)
-      // Continue to fall through to unified axios fallback below
-    }
+    const mod = await import('../server-side-only/fetch-static-json.js')
+    const res = await mod.fetchStaticJson(requestUrl, requestConfig)
+    // Note: fetchStaticJson internally logs whether it's from GCS mount or HTTP
+    // fetchStaticJson returns { data: ... } format
+    return /** @type {{ data: T }} */ (res)
   }
+
   const axiosRes = await axiosInstance(requestUrl, requestConfig)
   return /** @type {{ data: T }} */ ({ data: axiosRes?.data })
 }

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -2,9 +2,7 @@ import errors from '@twreporter/errors'
 import client from '../../apollo/apollo-client.js'
 import axiosInstance from '../../axios/index.js'
 import {
-  URL_STATIC_COLUMN_SECTION_POSTS,
   URL_STATIC_HEADER_HEADERS,
-  URL_STATIC_PODCAST_LIST,
   URL_STATIC_PREMIUM_SECTIONS,
   URL_STATIC_TOPICS,
 } from '../../config/index.mjs'
@@ -79,26 +77,24 @@ import { fetchAnnoucements } from '../../apollo/query/announcements'
  * @typedef { (HeadersDataSection | HeadersDataCategory)[]} HeadersData
  */
 /**
- * Creates a request function that tries local GCS FUSE first, then falls back to HTTP.
+ * Fetches static JSON by URL. It tries local GCS FUSE first, then falls back to HTTP.
  * @param {string} requestUrl - The URL to send the request to.
  */
-const createStaticJsonRequest = (requestUrl) => {
-  return async () => {
-    if (typeof window === 'undefined') {
-      try {
-        const mod = await import('../server-side-only/fetch-static-json.js')
-        const res = await mod.fetchStaticJson(requestUrl)
-        // Note: fetchStaticJson internally logs whether it's from GCS mount or HTTP
-        // fetchStaticJson returns { data: ... } format
-        return res
-      } catch (err) {
-        console.warn('[static-json] fallback to axios', err)
-        // Continue to fall through to unified axios fallback below
-      }
+const fetchStaticJsonByUrl = async (requestUrl) => {
+  if (typeof window === 'undefined') {
+    try {
+      const mod = await import('../server-side-only/fetch-static-json.js')
+      const res = await mod.fetchStaticJson(requestUrl)
+      // Note: fetchStaticJson internally logs whether it's from GCS mount or HTTP
+      // fetchStaticJson returns { data: ... } format
+      return res
+    } catch (err) {
+      console.warn('[static-json] fallback to axios', err)
+      // Continue to fall through to unified axios fallback below
     }
-    const axiosRes = await axiosInstance(requestUrl)
-    return { data: axiosRes?.data }
   }
+  const axiosRes = await axiosInstance(requestUrl)
+  return { data: axiosRes?.data }
 }
 
 const errorLogger = (errorMessage) => {
@@ -122,18 +118,6 @@ const errorLogger = (errorMessage) => {
   throw annotatingAxiosError
 }
 
-/** @type {() => Promise<{ data: { headers: HeadersData } }>} */
-const fetchNormalSections = createStaticJsonRequest(URL_STATIC_HEADER_HEADERS)
-
-/** @type {() => Promise<{ data: { topics: Topics } }>} */
-const fetchTopics = createStaticJsonRequest(URL_STATIC_TOPICS)
-
-const fetchPremiumSections = createStaticJsonRequest(
-  URL_STATIC_PREMIUM_SECTIONS
-)
-
-const fetchPodcastList = createStaticJsonRequest(URL_STATIC_PODCAST_LIST)
-
 const fetchHeaderDataInDefaultPageLayout = async () => {
   /** @type {HeadersData} */
   let sectionsData = []
@@ -142,8 +126,8 @@ const fetchHeaderDataInDefaultPageLayout = async () => {
 
   try {
     const responses = await Promise.allSettled([
-      fetchNormalSections(),
-      fetchTopics(),
+      fetchStaticJsonByUrl(URL_STATIC_HEADER_HEADERS),
+      fetchStaticJsonByUrl(URL_STATIC_TOPICS),
     ])
 
     const sectionsResponse = responses[0].status === 'fulfilled' && responses[0]
@@ -165,7 +149,7 @@ const fetchHeaderDataInDefaultPageLayout = async () => {
 const fetchHeaderDataInPremiumPageLayout = async () => {
   let sectionsData = []
   try {
-    const response = await fetchPremiumSections()
+    const response = await fetchStaticJsonByUrl(URL_STATIC_PREMIUM_SECTIONS)
     if (response?.data?.sections) {
       sectionsData = response?.data?.sections
     }
@@ -200,15 +184,9 @@ const fetchAnnoucementsByScope = (scope) => {
   })
 }
 
-/** @type {() => Promise<{ data: ColumnSectionResponse }>} */
-const fetchColumnSectionPosts = createStaticJsonRequest(
-  URL_STATIC_COLUMN_SECTION_POSTS
-)
-
 export {
+  fetchStaticJsonByUrl,
   fetchHeaderDataInDefaultPageLayout,
   fetchHeaderDataInPremiumPageLayout,
-  fetchPodcastList,
   fetchAnnoucementsByScope,
-  fetchColumnSectionPosts,
 }

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -77,10 +77,13 @@ import { fetchAnnoucements } from '../../apollo/query/announcements'
  * @typedef { (HeadersDataSection | HeadersDataCategory)[]} HeadersData
  */
 /**
- * Fetches static JSON by URL. It tries local GCS FUSE first, then falls back to HTTP.
+ * Fetches static JSON by URL. Tries local GCS FUSE first (server-side), then falls back to HTTP via axios.
+ * Returns `{ data }` where `data` is the parsed JSON body — callers should narrow the type at their own usage site.
  * @param {string} requestUrl - The URL to send the request to.
+ * @param {import('axios').AxiosRequestConfig} [requestConfig]
+ * @returns {Promise<{ data: any }>}
  */
-const fetchStaticJsonByUrl = async (requestUrl) => {
+const fetchStaticJsonByUrl = async (requestUrl, requestConfig) => {
   if (typeof window === 'undefined') {
     try {
       const mod = await import('../server-side-only/fetch-static-json.js')
@@ -93,7 +96,7 @@ const fetchStaticJsonByUrl = async (requestUrl) => {
       // Continue to fall through to unified axios fallback below
     }
   }
-  const axiosRes = await axiosInstance(requestUrl)
+  const axiosRes = await axiosInstance(requestUrl, requestConfig)
   return { data: axiosRes?.data }
 }
 

--- a/packages/mirror-media-next/utils/api/index.js
+++ b/packages/mirror-media-next/utils/api/index.js
@@ -76,12 +76,28 @@ import { fetchAnnoucements } from '../../apollo/query/announcements'
 /**
  * @typedef { (HeadersDataSection | HeadersDataCategory)[]} HeadersData
  */
+
+/**
+ * @typedef {Object} HeadersStaticJsonResponse
+ * @property {HeadersData} [headers]
+ */
+
+/**
+ * @typedef {Object} TopicsStaticJsonResponse
+ * @property {Topics} [topics]
+ */
+
+/**
+ * @typedef {Object} PremiumSectionsStaticJsonResponse
+ * @property {HeadersData} [sections]
+ */
 /**
  * Fetches static JSON by URL. Tries local GCS FUSE first (server-side), then falls back to HTTP via axios.
  * Returns `{ data }` where `data` is the parsed JSON body — callers should narrow the type at their own usage site.
+ * @template T
  * @param {string} requestUrl - The URL to send the request to.
  * @param {import('axios').AxiosRequestConfig} [requestConfig]
- * @returns {Promise<{ data: any }>}
+ * @returns {Promise<{ data: T }>}
  */
 const fetchStaticJsonByUrl = async (requestUrl, requestConfig) => {
   if (typeof window === 'undefined') {
@@ -90,14 +106,14 @@ const fetchStaticJsonByUrl = async (requestUrl, requestConfig) => {
       const res = await mod.fetchStaticJson(requestUrl)
       // Note: fetchStaticJson internally logs whether it's from GCS mount or HTTP
       // fetchStaticJson returns { data: ... } format
-      return res
+      return /** @type {{ data: T }} */ (res)
     } catch (err) {
       console.warn('[static-json] fallback to axios', err)
       // Continue to fall through to unified axios fallback below
     }
   }
   const axiosRes = await axiosInstance(requestUrl, requestConfig)
-  return { data: axiosRes?.data }
+  return /** @type {{ data: T }} */ ({ data: axiosRes?.data })
 }
 
 const errorLogger = (errorMessage) => {
@@ -129,19 +145,23 @@ const fetchHeaderDataInDefaultPageLayout = async () => {
 
   try {
     const responses = await Promise.allSettled([
-      fetchStaticJsonByUrl(URL_STATIC_HEADER_HEADERS),
-      fetchStaticJsonByUrl(URL_STATIC_TOPICS),
+      /** @type {Promise<{ data: HeadersStaticJsonResponse }>} */ (
+        fetchStaticJsonByUrl(URL_STATIC_HEADER_HEADERS)
+      ),
+      /** @type {Promise<{ data: TopicsStaticJsonResponse }>} */ (
+        fetchStaticJsonByUrl(URL_STATIC_TOPICS)
+      ),
     ])
 
-    const sectionsResponse = responses[0].status === 'fulfilled' && responses[0]
-    sectionsData = Array.isArray(sectionsResponse?.value?.data?.headers)
-      ? sectionsResponse?.value?.data?.headers
+    const sectionsResult =
+      responses[0].status === 'fulfilled' ? responses[0].value.data : undefined
+    sectionsData = Array.isArray(sectionsResult?.headers)
+      ? sectionsResult.headers
       : []
 
-    const topicsResponse = responses[1].status === 'fulfilled' && responses[1]
-    topicsData = Array.isArray(topicsResponse?.value?.data?.topics)
-      ? topicsResponse?.value?.data?.topics
-      : []
+    const topicsResult =
+      responses[1].status === 'fulfilled' ? responses[1].value.data : undefined
+    topicsData = Array.isArray(topicsResult?.topics) ? topicsResult.topics : []
 
     return { sectionsData, topicsData }
   } catch (err) {
@@ -150,12 +170,16 @@ const fetchHeaderDataInDefaultPageLayout = async () => {
 }
 
 const fetchHeaderDataInPremiumPageLayout = async () => {
+  /** @type {HeadersData} */
   let sectionsData = []
   try {
-    const response = await fetchStaticJsonByUrl(URL_STATIC_PREMIUM_SECTIONS)
-    if (response?.data?.sections) {
-      sectionsData = response?.data?.sections
-    }
+    const response =
+      /** @type {{ data: PremiumSectionsStaticJsonResponse }} */ (
+        await fetchStaticJsonByUrl(URL_STATIC_PREMIUM_SECTIONS)
+      )
+    sectionsData = Array.isArray(response.data.sections)
+      ? response.data.sections
+      : []
     return { sectionsData }
   } catch (err) {
     errorLogger(err)

--- a/packages/mirror-media-next/utils/server-side-only/fetch-static-json.js
+++ b/packages/mirror-media-next/utils/server-side-only/fetch-static-json.js
@@ -58,12 +58,14 @@ function mapUrlToLocalPath(requestUrl) {
  * Returns an axios-like response shape: { data }
  * Client-side will always fallback to HTTP.
  *
+ * @typedef {number | import('axios').AxiosRequestConfig} StaticJsonRequestConfig
+ *
  * @template T
  * @param {string} requestUrl
- * @param {number} [timeoutMs]
+ * @param {StaticJsonRequestConfig} [requestConfig]
  * @returns {Promise<{ data: T }>}
  */
-export async function fetchStaticJson(requestUrl, timeoutMs) {
+export async function fetchStaticJson(requestUrl, requestConfig) {
   const startTime = performance.now()
   // Only try local file on server
   if (typeof window === 'undefined') {
@@ -117,10 +119,15 @@ export async function fetchStaticJson(requestUrl, timeoutMs) {
   }
 
   const httpStartTime = performance.now()
+  const normalizedRequestConfig =
+    typeof requestConfig === 'number'
+      ? { timeout: requestConfig }
+      : requestConfig ?? {}
+
   const res = await axiosInstance({
+    ...normalizedRequestConfig,
     method: 'get',
     url: requestUrl,
-    timeout: timeoutMs,
   })
   const httpEndTime = performance.now()
   const httpLatency = (httpEndTime - httpStartTime).toFixed(2)

--- a/packages/mirror-media-next/utils/server-side-only/fetch-static-json.js
+++ b/packages/mirror-media-next/utils/server-side-only/fetch-static-json.js
@@ -65,7 +65,7 @@ function mapUrlToLocalPath(requestUrl) {
  * @param {StaticJsonRequestConfig} [requestConfig]
  * @returns {Promise<{ data: T }>}
  */
-export async function fetchStaticJson(requestUrl, requestConfig) {
+export async function fetchStaticJsonOnServer(requestUrl, requestConfig) {
   const startTime = performance.now()
   // Only try local file on server
   if (typeof window === 'undefined') {
@@ -83,7 +83,7 @@ export async function fetchStaticJson(requestUrl, requestConfig) {
         console.log(
           JSON.stringify({
             severity: 'INFO',
-            message: '[fetchStaticJson] GCS mount hit',
+            message: '[fetchStaticJsonOnServer] GCS mount hit',
             url: requestUrl,
             localPath: localPath,
             readLatency: `${readLatency}ms`,
@@ -98,7 +98,7 @@ export async function fetchStaticJson(requestUrl, requestConfig) {
         console.warn(
           JSON.stringify({
             severity: 'WARNING',
-            message: '[fetchStaticJson] GCS mount miss, fallback to HTTP',
+            message: '[fetchStaticJsonOnServer] GCS mount miss, fallback to HTTP',
             url: requestUrl,
             localPath: localPath,
             readLatency: `${readLatency}ms`,
@@ -111,7 +111,7 @@ export async function fetchStaticJson(requestUrl, requestConfig) {
       console.log(
         JSON.stringify({
           severity: 'INFO',
-          message: '[fetchStaticJson] No local path mapped, using HTTP',
+          message: '[fetchStaticJsonOnServer] No local path mapped, using HTTP',
           url: requestUrl,
         })
       )
@@ -136,7 +136,7 @@ export async function fetchStaticJson(requestUrl, requestConfig) {
   console.log(
     JSON.stringify({
       severity: 'INFO',
-      message: '[fetchStaticJson] HTTP fetch',
+      message: '[fetchStaticJsonOnServer] HTTP fetch',
       url: requestUrl,
       httpLatency: `${httpLatency}ms`,
       totalLatency: `${totalLatency}ms`,

--- a/packages/mirror-media-next/utils/server-side-only/fetch-static-json.js
+++ b/packages/mirror-media-next/utils/server-side-only/fetch-static-json.js
@@ -55,12 +55,13 @@ function mapUrlToLocalPath(requestUrl) {
 
 /**
  * Fetch JSON from local GCS FUSE mount first, fallback to HTTP GET via axios.
- * Returns an axios-like response shape: { data: any }
+ * Returns an axios-like response shape: { data }
  * Client-side will always fallback to HTTP.
  *
+ * @template T
  * @param {string} requestUrl
  * @param {number} [timeoutMs]
- * @returns {Promise<{ data: any }>}
+ * @returns {Promise<{ data: T }>}
  */
 export async function fetchStaticJson(requestUrl, timeoutMs) {
   const startTime = performance.now()
@@ -71,13 +72,12 @@ export async function fetchStaticJson(requestUrl, timeoutMs) {
       try {
         const readStartTime = performance.now()
         const content = await fs.readFile(localPath, 'utf8')
-        const parseStartTime = performance.now()
         const data = JSON.parse(content)
         const parseEndTime = performance.now()
-        
+
         const readLatency = (parseEndTime - readStartTime).toFixed(2)
         const totalLatency = (parseEndTime - startTime).toFixed(2)
-        
+
         console.log(
           JSON.stringify({
             severity: 'INFO',
@@ -89,8 +89,8 @@ export async function fetchStaticJson(requestUrl, timeoutMs) {
             source: 'local',
           })
         )
-        
-        return { data }
+
+        return /** @type {{ data: T }} */ ({ data })
       } catch (err) {
         const readLatency = (performance.now() - startTime).toFixed(2)
         console.warn(
@@ -115,7 +115,7 @@ export async function fetchStaticJson(requestUrl, timeoutMs) {
       )
     }
   }
-  
+
   const httpStartTime = performance.now()
   const res = await axiosInstance({
     method: 'get',
@@ -125,7 +125,7 @@ export async function fetchStaticJson(requestUrl, timeoutMs) {
   const httpEndTime = performance.now()
   const httpLatency = (httpEndTime - httpStartTime).toFixed(2)
   const totalLatency = (httpEndTime - startTime).toFixed(2)
-  
+
   console.log(
     JSON.stringify({
       severity: 'INFO',
@@ -136,6 +136,6 @@ export async function fetchStaticJson(requestUrl, timeoutMs) {
       source: 'http',
     })
   )
-  
-  return { data: res?.data }
+
+  return /** @type {{ data: T }} */ ({ data: res?.data })
 }


### PR DESCRIPTION
This PR introduces a new floating "Promote Topic" widget accessible across the site and significantly refactors the internal static JSON fetching utility to be more generic, type-safe, and robust. The new widget displays recommended topics in a swiper format, while the API refactor replaces specialized fetchers with a unified, generic function supporting AbortController and TypeScript-like JSDoc generics.

## Additions
- New `PromoteTopic` component suite (Index, Item, Swiper) in `components/promote-topic/`.
- `URL_STATIC_PROMOTE_TOPICS` configuration added to all environment configs.
- `Z_INDEX.promoteTopic` constant for layout management.
- `close.svg` asset for the widget.
- Generic type support (`@template T`) for `fetchStaticJsonByUrl` and `fetchStaticJson`.

## Removals
- Removed specialized API functions: `fetchNormalSections`, `fetchTopics`, `fetchPremiumSections`, `fetchPodcastList`, and `fetchColumnSectionPosts`.
- Removed manual `isMounted` flags in favor of `AbortController`.
- Removed widget-specific styles from `global-styles.js` (moved to scoped components).

## Changes
- Refactored `fetchStaticJsonByUrl` to accept axios config and return generic data structures.
- Updated `_app.js` to include the `PromoteTopic` widget globally.
- Migrated `podcasts` and `column` pages to use the unified `fetchStaticJsonByUrl`.
- Optimized `PromoteTopicSwiper` with shorter autoplay delay (10s) and encapsulated styles.
- Enhanced data normalization logic with robust validation and JSDoc typedefs.

## Testing
- Verified widget visibility and functionality on local development server.
- Tested swiper interaction and close button behavior.
- Confirmed API fallback logic (GCS FUSE to HTTP) remains functional with new generic implementation.
- Checked type safety and error handling for aborted requests.

- N/A

## Todos
- Monitor performance of static JSON fetching via GCS FUSE in production.

## Task Links
[前端抓取GCS中的JSON顯示在全站右側的專題 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1213799707742379?focus=true)