### PR TITLE
chore(promote-topic): strengthen data integrity and refine type definitions

### DIFF
--- a/packages/mirror-media-next/components/promote-topic/index.js
+++ b/packages/mirror-media-next/components/promote-topic/index.js
@@ -45,6 +45,7 @@ function normalizePromoteTopic(item) {
   const resizedWebp = heroImage?.resizedWebp
   const hasImage = hasAvailableImages(resized)
 
+  // Guard against incomplete CMS data before it reaches UI components.
   if (!topic?.slug || !topic?.name || !hasImage) {
     return null
   }

--- a/packages/mirror-media-next/components/promote-topic/promote-topic-item.js
+++ b/packages/mirror-media-next/components/promote-topic/promote-topic-item.js
@@ -53,7 +53,7 @@ const Title = styled.p`
  * @property {Record<string, string>} [resizedWebp]
  *
  * @typedef {Object} PromoteTopicData
- * @property {string} [id]
+ * @property {string} id
  * @property {number | string | null} [order]
  * @property {string} slug
  * @property {string} name

--- a/packages/mirror-media-next/components/promote-topic/promote-topic-swiper.js
+++ b/packages/mirror-media-next/components/promote-topic/promote-topic-swiper.js
@@ -128,7 +128,7 @@ export default function PromoteTopicSwiper({ list }) {
         rewind={shouldLoop}
       >
         {list.map((topic) => (
-          <SwiperSlide key={topic.id || topic.slug}>
+          <SwiperSlide key={topic.id}>
             <PromoteTopicItem topic={topic} />
           </SwiperSlide>
         ))}


### PR DESCRIPTION
- Add guard clause in `normalizePromoteTopic` to filter out incomplete topic data.
- Update `PromoteTopicData` typedef to mark `id` as a required field.
- Simplify React `key` usage in `PromoteTopicSwiper` by exclusively using `topic.id`.