### PR TITLE
feat: add image preloading support in CustomHead component

### DIFF
--- a/packages/mirror-media-next/components/shared/custom-head.js
+++ b/packages/mirror-media-next/components/shared/custom-head.js
@@ -113,8 +113,14 @@ export default function CustomHead({
   return (
     <Head>
       {pageType && imageUrl && (
-        // eslint-disable-next-line react/no-unknown-property
-        <link rel="preload" as="image" href={imageUrl} fetchPriority="high" />
+        <link
+          rel="preload"
+          as="image"
+          href={imageUrl}
+          key="image-preload"
+          // eslint-disable-next-line react/no-unknown-property
+          fetchpriority="high"
+        />
       )}
       <title key="title">{siteInformation.title}</title>
       <meta

--- a/packages/mirror-media-next/components/shared/custom-head.js
+++ b/packages/mirror-media-next/components/shared/custom-head.js
@@ -112,6 +112,10 @@ export default function CustomHead({
 
   return (
     <Head>
+      {pageType && imageUrl && (
+        // eslint-disable-next-line react/no-unknown-property
+        <link rel="preload" as="image" href={imageUrl} fetchPriority="high" />
+      )}
       <title key="title">{siteInformation.title}</title>
       <meta
         name="description"


### PR DESCRIPTION
## 摘要 (Summary)
This PR improves the Largest Contentful Paint (LCP) performance on tag pages by ensuring the first post's image is loaded with high priority. It also includes refactoring to clarify component naming and removes redundant documentation comments.

## Additions
- Added   <link rel="preload" as="image" href={imageUrl} fetchPriority="high" /> to page store and external


## Task Links
- [[週刊]內文頁 LCP優化](https://app.asana.com/1/614399484723017/project/1213964110738437/task/1214050024641771?focus=true)