### PR TITLE
fix(promote-topic): enhance image data validation and UI component robustness

### DIFF
--- a/packages/mirror-media-next/components/promote-topic/index.js
+++ b/packages/mirror-media-next/components/promote-topic/index.js
@@ -44,12 +44,11 @@ function normalizePromoteTopic(item) {
   const resized = heroImage?.resized
   const resizedWebp = heroImage?.resizedWebp
 
-  // Guard against incomplete CMS data before it reaches UI components.
+  // Require complete CMS fields and at least one usable image source before reaching UI components.
   if (
     !topic?.slug ||
     !topic?.name ||
-    !resized ||
-    !hasAvailableImages(resized)
+    (!hasAvailableImages(resized) && !hasAvailableImages(resizedWebp))
   ) {
     return null
   }
@@ -60,7 +59,7 @@ function normalizePromoteTopic(item) {
     slug: topic.slug,
     name: topic.name,
     heroImage: {
-      resized,
+      resized: hasAvailableImages(resized) ? resized : undefined,
       resizedWebp: hasAvailableImages(resizedWebp) ? resizedWebp : undefined,
     },
   }

--- a/packages/mirror-media-next/components/promote-topic/promote-topic-item.js
+++ b/packages/mirror-media-next/components/promote-topic/promote-topic-item.js
@@ -49,7 +49,7 @@ const Title = styled.p`
 
 /**
  * @typedef {Object} PromoteTopicHeroImage
- * @property {Record<string, string>} resized
+ * @property {Record<string, string>} [resized]
  * @property {Record<string, string>} [resizedWebp]
  *
  * @typedef {Object} PromoteTopicData
@@ -66,12 +66,15 @@ const Title = styled.p`
  * @returns {React.ReactElement}
  */
 export default function PromoteTopicItem({ topic }) {
+  const images = topic.heroImage.resized ?? {}
+  const imagesWebP = topic.heroImage.resizedWebp ?? null
+
   return (
     <Card href={`/topic/${topic.slug}`} target="_blank" rel="noreferrer">
       <ImageFrame>
         <CustomImage
-          images={topic.heroImage.resized}
-          imagesWebP={topic.heroImage.resizedWebp}
+          images={images}
+          imagesWebP={imagesWebP}
           loadingImage="/images-next/loading.gif"
           defaultImage="/images-next/default-og-img.png"
           rwd={{


### PR DESCRIPTION
- Update `normalizePromoteTopic` to allow topics with at least one valid image source (resized or resizedWebp).
- Normalize missing or invalid image data to `undefined` during data processing.
- Add safe fallback values in `PromoteTopicItem` when passing images to `CustomImage`.
- Update JSDoc type definitions for optional image properties.

## Task Links
[前端抓取GCS中的JSON顯示在全站右側的專題 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1213799707742379?focus=true)