### PR TITLE
Hotfix: cherry-pick robots.txt crawler allow rules to staging

### DIFF
--- a/packages/mirror-media-next/pages/api/robots.js
+++ b/packages/mirror-media-next/pages/api/robots.js
@@ -4,23 +4,22 @@ export default function handler(req, res) {
   res.setHeader('Content-Type', 'text/plain')
 
   if (ENV === 'prod') {
-    res.write(`User-agent: facebookexternalhit
-Allow: /
-
-User-agent: Facebot
-Allow: /
-
-User-agent: Meta-ExternalAgent
-Allow: /
-
-User-agent: Googlebot
+    res.write(`User-agent: Googlebot
       Disallow: /login
       Disallow: /subscribe/*
       Disallow: /search/*
       
       User-agent: *
         Allow: /
-        
+      User-agent: facebookexternalhit
+        Allow: /
+
+      User-agent: Facebot
+        Allow: /
+
+      User-agent: Meta-ExternalAgent
+        Allow: /
+
       Sitemap: https://www.mirrormedia.mg/rss/posts.xml
       Sitemap: https://www.mirrormedia.mg/rss/posts-news.xml
       Sitemap: https://www.mirrormedia.mg/rss/externals.xml

--- a/packages/mirror-media-next/pages/api/robots.js
+++ b/packages/mirror-media-next/pages/api/robots.js
@@ -4,7 +4,16 @@ export default function handler(req, res) {
   res.setHeader('Content-Type', 'text/plain')
 
   if (ENV === 'prod') {
-    res.write(`User-agent: Googlebot
+    res.write(`User-agent: facebookexternalhit
+Allow: /
+
+User-agent: Facebot
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: Googlebot
       Disallow: /login
       Disallow: /subscribe/*
       Disallow: /search/*

--- a/packages/mirror-media-next/pages/api/robots.js
+++ b/packages/mirror-media-next/pages/api/robots.js
@@ -8,9 +8,7 @@ export default function handler(req, res) {
       Disallow: /login
       Disallow: /subscribe/*
       Disallow: /search/*
-      
-      User-agent: *
-        Allow: /
+
       User-agent: facebookexternalhit
         Allow: /
 
@@ -19,7 +17,10 @@ export default function handler(req, res) {
 
       User-agent: Meta-ExternalAgent
         Allow: /
-
+      
+      User-agent: *
+        Allow: /
+      
       Sitemap: https://www.mirrormedia.mg/rss/posts.xml
       Sitemap: https://www.mirrormedia.mg/rss/posts-news.xml
       Sitemap: https://www.mirrormedia.mg/rss/externals.xml


### PR DESCRIPTION
## Summary

Cherry-pick the robots.txt hotfix into staging with a clean branch.

This applies the Facebook / Meta crawler allow rules to staging without
reusing the existing `hotfix/robotstxt` branch.

## Context

The original `hotfix/robotstxt` branch had been used for multiple PRs and was
later merged with `dev` while resolving conflicts. Because of that, reusing
the same branch for staging could include unrelated dev-side changes in the
staging PR.

To avoid polluting staging, this PR was created from the staging base branch
and only cherry-picks the robots.txt hotfix commit.

## Changes

- Add allow rules for:
  - `facebookexternalhit`
  - `Facebot`
  - `Meta-ExternalAgent`