### PR TITLE
revert: remove FAQ JSON-LD from story page

### DIFF
--- a/packages/mirror-media-next/apollo/fragments/post.js
+++ b/packages/mirror-media-next/apollo/fragments/post.js
@@ -172,20 +172,6 @@ export const topicPost = gql`
  */
 
 /**
- * @typedef {Object} FaqAlgoItem
- * @property {number} score
- * @property {string} answer
- * @property {string} question
- */
-
-/**
- * Algorithm-generated FAQ bundle for a post.
- * @typedef {Object} FaqsAlgo
- * @property {FaqAlgoItem[]} faqs
- * @property {string} generated_at
- */
-
-/**
  * @typedef {Object} Post
  * @property {string} id - unique id of post
  * @property {string} slug - post slug
@@ -212,7 +198,6 @@ export const topicPost = gql`
  * @property {string} extend_byline - the field called '作者(其他)' in cms
  * @property {Tag[] } tags - tags of the post
  * @property {Tag[]} tags_algo - algorithmically generated tags
- * @property {FaqsAlgo | null} [faqs_algo] - algorithmically generated FAQs
  * @property {HeroVideo | null} heroVideo - hero video of the post
  * @property {HeroImage | null} heroImage - hero image of the post
  * @property {string} heroCaption - caption to explain hero video or image
@@ -279,7 +264,6 @@ export const post = gql`
     isAdult
     publishedDate
     updatedAt
-    faqs_algo
     sections(where: { state: { equals: "active" } }) {
       ...section
     }

--- a/packages/mirror-media-next/components/story/shared/json-lds-data.js
+++ b/packages/mirror-media-next/components/story/shared/json-lds-data.js
@@ -29,28 +29,7 @@ export const generateJsonLdsData = (postData, currentPage) => {
     tags = [],
     trimmedContent = null,
     content = null,
-    faqs_algo = null,
   } = postData
-
-  const faqEntities =
-    faqs_algo?.faqs?.filter((item) => item && item.question && item.answer) ??
-    []
-
-  const jsonLdFaqPage =
-    faqEntities.length > 0
-      ? {
-          '@context': 'https://schema.org',
-          '@type': 'FAQPage',
-          mainEntity: faqEntities.map((faq) => ({
-            '@type': 'Question',
-            name: faq.question.trim(),
-            acceptedAnswer: {
-              '@type': 'Answer',
-              text: faq.answer.trim(),
-            },
-          })),
-        }
-      : undefined
 
   const writersWithOrdered =
     writersInInputOrder && writersInInputOrder.length
@@ -144,12 +123,9 @@ export const generateJsonLdsData = (postData, currentPage) => {
     itemListElement: getBreadcrumbListElement(),
   }
 
-  return [
-    jsonLdNewsArticle,
-    jsonLdPerson,
-    jsonLdBreadcrumbList,
-    jsonLdFaqPage,
-  ].filter((jsonLd) => jsonLd)
+  return [jsonLdNewsArticle, jsonLdPerson, jsonLdBreadcrumbList].filter(
+    (jsonLd) => jsonLd
+  )
 
   function getBreadcrumbListElement() {
     const items = [


### PR DESCRIPTION
As per the decision documented in `docs/fyi_dev_staging_divergence.md`, this PR reverts the FAQ JSON-LD functionality added in PR #1468. This is a prerequisite step before syncing `dev` into `staging` to ensure the FAQ feature does not reach production prematurely while allowing other critical fixes (like promote-topic robustness) to proceed.

## Additions
- N/A

## Removals
- Removed `FaqAlgoItem` and `FaqsAlgo` typedefs from `apollo/fragments/post.js`.
- Removed `faqs_algo` field from `Post` typedef and `post` GraphQL fragment.
- Removed FAQ-related logic from `generateJsonLdsData` in `components/story/shared/json-lds-data.js`.
- Removed `jsonLdFaqPage` from the returned JSON-LD array in `components/story/shared/json-lds-data.js`.

## Changes
- Reverted code changes in `packages/mirror-media-next/apollo/fragments/post.js` to exclude algorithmically generated FAQs.
- Reverted code changes in `packages/mirror-media-next/components/story/shared/json-lds-data.js` to stop generating `FAQPage` schema.

## Testing
- Verified that the story page no longer contains the `FAQPage` JSON-LD schema in the `<script type="application/ld+json">` tag.
- Verified that the GraphQL query for the post page no longer requests the `faqs_algo` field.

## Screenshots
- N/A

## Todos
- Sync `dev` to `staging` after this PR is merged.

## Task Links
[在前端 SSR 中生成 FAQ JSONLD - Asana](https://app.asana.com/1/614399484723017/project/1199408264065173/task/1212314437939710?focus=true)