### PR TITLE
Fix(category/login): rm canonical & dynamic link

### DIFF
--- a/packages/mirror-media-next/pages/category/[slug].js
+++ b/packages/mirror-media-next/pages/category/[slug].js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import dynamic from 'next/dynamic'
 
 import CategoryArticles from '../../components/category/category-articles'
-import { ENV } from '../../config/index.mjs'
+import { ENV, SITE_URL } from '../../config/index.mjs'
 import {
   fetchHeaderDataInDefaultPageLayout,
   fetchHeaderDataInPremiumPageLayout,
@@ -218,7 +218,7 @@ export default function Category({
       position: index + 1 + '',
       item: {
         '@type': 'NewsArticle',
-        url: `https://www.mnews.tw/story/${post.slug}`,
+        url: `https://${SITE_URL}/story/${post.slug}`,
         headline: post.title,
         image: post.heroImage?.resized?.w1200 || '',
         dateCreated: post.publishedDate,

--- a/packages/mirror-media-next/pages/login/index.js
+++ b/packages/mirror-media-next/pages/login/index.js
@@ -152,7 +152,7 @@ export default function Login({ headerData, isWebview }) {
 
   return (
     <LayoutFull
-      head={{ robotsMetaContent: 'noindex, nofollow' }}
+      head={{ robotsMetaContent: 'noindex, nofollow', skipCanonical: true }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}
     >


### PR DESCRIPTION
add skipCanonical to login page
use dynamic link to category


[[週刊SEO]category/* 的itemlist JSONLD網址錯誤](https://app.asana.com/1/614399484723017/project/1214559748867622/task/1214271978618867?focus=true)

[[週刊SEO]/login頁面移除Canonical](https://app.asana.com/1/614399484723017/project/1214559748867622/task/1214271978618853?focus=true)