### PR TITLE
fix: use preview client in IS_PREVIEW_MODE to fetch draft posts

### DIFF
--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -10,6 +10,7 @@ import {
   URL_STATIC_POST_FLASH_NEWS,
   // TEST_GPT_AD_FEATURE_TOGGLE,
   STORY_GQL_ENDPOINT,
+  IS_PREVIEW_MODE,
 } from '../../config/index.mjs'
 import WineWarning from '../../components/shared/wine-warning'
 import AdultOnlyWarning from '../../components/story/shared/adult-only-warning'
@@ -421,7 +422,9 @@ export async function getServerSideProps({ params, req, res }) {
   const globalLogFields = getLogTraceObject(req)
 
   try {
-    const storyClient = getStoryClient(STORY_GQL_ENDPOINT) || client
+    const storyClient = IS_PREVIEW_MODE
+      ? client
+      : getStoryClient(STORY_GQL_ENDPOINT) || client
 
     const result = await storyClient.query({
       query: fetchPostBySlug,
@@ -487,7 +490,9 @@ export async function getServerSideProps({ params, req, res }) {
       try {
         const fetchStaticJsonSafe = async (url, timeout) => {
           try {
-            const mod = await import('../../utils/server-side-only/fetch-static-json.js')
+            const mod = await import(
+              '../../utils/server-side-only/fetch-static-json.js'
+            )
             const res = await mod.fetchStaticJsonOnServer(url, timeout)
             return res
           } catch (err) {


### PR DESCRIPTION
Task：[preview異常](https://app.asana.com/1/614399484723017/project/1214559748867622/task/1214624235470438?focus=true)

 ## 問題                                                                  
                                                                           
  dev / staging / prod 三個 preview 環境都「看不到 draft / scheduled / archived 文章」，點 Preview 按鈕只能看到已發布內容，未發布的回 404。    
      
                                                                         
  ## Root cause                                                            
                                                                         
  `pages/story/[slug].js` 的 `getServerSideProps` 用：                     
                                                                         
  ```js                                                               
  const storyClient = getStoryClient(STORY_GQL_ENDPOINT) || client         
  ```                                      
                                                                           
  `STORY_GQL_ENDPOINT` 在 `config/index.mjs` 有 fallback 預設值（指向 go-story-*），所以 `getStoryClient()` 永遠回傳 truthy，preview 模式下也不例外。        

結果：preview 站的 SSR 永遠去打 go-story（只同步已發布文章），不會用到 `client`（設定指向`mirror-cms-preview-*`）。draft slug 在 go-story 不存在 → `result.data.post` 為 null → `notFound: true`。 
                                                                                                              
  ## 主要修改                                                                  
  
  在 preview 模式時跳過 `storyClient`，直接用預設的 `client`：             
                                          
  ```js                                                               
  const storyClient = IS_PREVIEW_MODE ? client : getStoryClient(STORY_GQL_ENDPOINT) || client                                                         
```                                         
  - **正式模式**（`IS_PREVIEW_MODE === false`）→ 完全不變，走 go-story                            
  - **Preview 模式** → 走 `client`，apollo-client 的 preview endpoint 分支（`https://${PREVIEW_SERVER_ORIGIN}/api/graphql`）           
    
                                                                           
  ## 測試                                     
                                                                           
  本機驗證（單 Keystone 跑 preview 模式 + FE 跑 preview 模式）：
  - 建 draft post 並填內容 → preview URL 可正常渲染                   
                           
