### PR TITLE
fix(story): standardize related article data contract and remove __typename dependency

### DIFF
--- a/packages/mirror-media-next/components/shared/article-right-arrow.js
+++ b/packages/mirror-media-next/components/shared/article-right-arrow.js
@@ -34,12 +34,18 @@ const rightArrow = '/images-next/right-arrow.svg'
  *
  * @param {Object} props
  * @param {Relateds} [props.relateds]
- * @returns {import('react').JSX.Element}
+ * @returns {import('react').JSX.Element | null}
  */
 export default function ArticleRightArrow({ relateds = [] }) {
+  const firstRelated = relateds[0]
+
+  if (!firstRelated?.url) {
+    return null
+  }
+
   return (
     <StyledLink
-      href={relateds[0].url}
+      href={firstRelated.url}
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/packages/mirror-media-next/components/shared/article-right-arrow.js
+++ b/packages/mirror-media-next/components/shared/article-right-arrow.js
@@ -26,7 +26,7 @@ const rightArrow = '/images-next/right-arrow.svg'
 
 /**
  * @typedef {(import('../../apollo/fragments/post').Related & {
- *  id: string, slug: string, title: string, heroImage: HeroImage, url: string, __typename: string})[]
+ *  id: string, slug: string, title: string, heroImage: HeroImage, url: string, type: 'story' | 'external'})[]
  * } Relateds
  */
 
@@ -39,12 +39,7 @@ const rightArrow = '/images-next/right-arrow.svg'
 export default function ArticleRightArrow({ relateds = [] }) {
   return (
     <StyledLink
-      href={
-        relateds[0].url ||
-        `${relateds[0].__typename === 'Post' ? '/story' : '/external'}/${
-          relateds[0].slug
-        }`
-      }
+      href={relateds[0].url}
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/packages/mirror-media-next/components/story/normal/article-content.js
+++ b/packages/mirror-media-next/components/story/normal/article-content.js
@@ -51,7 +51,7 @@ const StyledGPTAd = styled(GPTAd)`
 
 /**
  * @typedef {(import('../../../apollo/fragments/post').Related & {
- *  id: string, slug: string, title: string, heroImage: HeroImage, url: string, __typename: string})[]
+ *  id: string, slug: string, title: string, heroImage: HeroImage, url: string, type: 'story' | 'external'})[]
  * } Relateds
  */
 

--- a/packages/mirror-media-next/components/story/normal/article-content.js
+++ b/packages/mirror-media-next/components/story/normal/article-content.js
@@ -70,7 +70,6 @@ export default function ArticleContent({
   pageKeyForGptAd = '',
   relateds = [],
 }) {
-  const hasFirstRelatedArticle = relateds.length > 0
   const { shouldShowAd } = useDisplayAd(hiddenAdvertised)
   const windowDimensions = useWindowDimensions()
   const contentMarkedFirstImage = modifyFirstImageEntity(content)
@@ -113,7 +112,7 @@ export default function ArticleContent({
   //The GPT advertisement for the `mobile` version includes `AT1` & `AT2`
   const MB_contentJsx = (
     <Wrapper>
-      {hasFirstRelatedArticle && <ArticleRightArrow relateds={relateds} />}
+      <ArticleRightArrow relateds={relateds} />
       <DraftRenderBlock
         rawContentBlock={copyAndSliceDraftBlock(
           contentMarkedFirstImage,

--- a/packages/mirror-media-next/components/story/normal/related-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/related-article-list.js
@@ -31,7 +31,7 @@ const StyledPopInAdRelated = dynamic(
 
 /**
  * @typedef {(import('../../../apollo/fragments/post').Related & {
- *  id: string, slug: string, title: string, heroImage: HeroImage, url: string, __typename: string})[]
+ *  id: string, slug: string, title: string, heroImage: HeroImage, url: string, type: 'story' | 'external'})[]
  * } Relateds
  */
 
@@ -207,12 +207,7 @@ export default function RelatedArticleList({
         <li key={related.id}>
           <Article>
             <Link
-              href={
-                related.url ||
-                `${related.__typename === 'Post' ? '/story' : '/external'}/${
-                  related.slug
-                }`
-              }
+              href={related.url}
               target="_blank"
               className={`article-image GTM-story-related-list ${
                 related.isMesoRecommend
@@ -236,12 +231,7 @@ export default function RelatedArticleList({
 
             <StyledFigcaption className="article-title">
               <Link
-                href={
-                  related.url ||
-                  `${related.__typename === 'Post' ? '/story' : '/external'}/${
-                    related.slug
-                  }`
-                }
+                href={related.url}
                 className={`GTM-story-related-list ${
                   related.isMesoRecommend
                     ? 'GTM-story-related-miso'

--- a/packages/mirror-media-next/components/story/normal/related-article-list.js
+++ b/packages/mirror-media-next/components/story/normal/related-article-list.js
@@ -209,6 +209,7 @@ export default function RelatedArticleList({
             <Link
               href={related.url}
               target="_blank"
+              rel="noopener noreferrer"
               className={`article-image GTM-story-related-list ${
                 related.isMesoRecommend
                   ? 'GTM-story-related-miso'
@@ -238,6 +239,7 @@ export default function RelatedArticleList({
                     : 'GTM-story-related-editor'
                 }`}
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 {related.title}
               </Link>

--- a/packages/mirror-media-next/pages/external/[slug].js
+++ b/packages/mirror-media-next/pages/external/[slug].js
@@ -49,11 +49,9 @@ const MisoPageView = dynamic(() => import('../../components/miso-pageview'), {
 /**
  * Initializes and normalizes the related stories data.
  *
- * This function manually injects two key properties required by the `RelatedArticleList` component:
- * 1. `__typename: 'Post'`: Since `external.relateds` comes from a generic query, this field might be missing.
- *    The component uses it to determine the fallback URL path (e.g., `/story/` vs `/external/`).
- * 2. `url`: We explicitly construct the URL (`/story/${item.slug}`) to ensure the component navigates
- *    directly to the correct internal story page, bypassing the need for type inference.
+ * This function injects the route contract required by downstream related
+ * article components. `external.relateds` points to internal story posts, so
+ * each item should navigate to `/story/${item.slug}`.
  *
  * @param {Array} relateds - The raw related articles data from GraphQL
  * @returns {Array} - The normalized array with required fields
@@ -61,8 +59,8 @@ const MisoPageView = dynamic(() => import('../../components/miso-pageview'), {
 const initializeRelatedStories = (relateds) => {
   return (relateds ?? []).map((item) => ({
     ...item,
-    __typename: 'Post',
     url: `/story/${item.slug}`,
+    type: 'story',
   }))
 }
 
@@ -91,13 +89,14 @@ export default function External({ external, headerData, jsonLdData }) {
           if (result && result.data && result.data.products) {
             const formattedStories = result.data.products.map((product) => {
               const productId = product.product_id
-              const slug = productId.split('_').slice(2).join('_')
+              const relatedSlug = productId.split('_').slice(2).join('_')
 
               return {
                 id: productId,
-                slug: slug,
+                slug: relatedSlug,
                 title: product.title || '',
-                url: product.url || '',
+                url: product.url || `/external/${relatedSlug}`,
+                type: 'external',
                 heroImage: product.cover_image
                   ? {
                       resized: { original: product.cover_image },

--- a/packages/mirror-media-next/pages/story/[slug].js
+++ b/packages/mirror-media-next/pages/story/[slug].js
@@ -158,13 +158,14 @@ export default function Story({
             if (result && result.data && result.data.products) {
               const formattedStories = result.data.products.map((product) => {
                 const productId = product.product_id
-                const slug = productId.split('_').slice(2).join('_')
+                const relatedSlug = productId.split('_').slice(2).join('_')
 
                 return {
                   id: productId,
-                  slug: slug,
+                  slug: relatedSlug,
                   title: product.title || '',
-                  url: product.url || '',
+                  url: product.url || `/story/${relatedSlug}`,
+                  type: 'story',
                   heroImage: product.cover_image
                     ? {
                         resized: { original: product.cover_image },

--- a/packages/mirror-media-next/pages/story/amp/[slug].js
+++ b/packages/mirror-media-next/pages/story/amp/[slug].js
@@ -304,13 +304,14 @@ export async function getServerSideProps({ params, req, res }) {
         if (result && result.data && result.data.products) {
           const formattedStories = result.data.products.map((product) => {
             const productId = product.product_id
-            const slug = productId.split('_').slice(2).join('_')
+            const relatedSlug = productId.split('_').slice(2).join('_')
 
             return {
               id: productId,
-              slug: slug,
+              slug: relatedSlug,
               title: product.title || '',
-              url: product.url || '',
+              url: product.url || `/story/${relatedSlug}`,
+              type: 'story',
               heroImage: product.cover_image
                 ? {
                     resized: { original: product.cover_image },

--- a/packages/mirror-media-next/utils/story-page-props.mjs
+++ b/packages/mirror-media-next/utils/story-page-props.mjs
@@ -78,12 +78,15 @@ function normalizeRelatedStory(related) {
   }
 
   const type = related.__typename === 'External' ? 'external' : 'story'
+  const url =
+    related.url ||
+    `${type === 'story' ? '/story' : '/external'}/${related.slug}`
 
   return compactClientPayload({
     id: related.id,
     slug: related.slug,
     title: related.title,
-    url: related.url,
+    url,
     type,
     heroImage: related.heroImage,
     isMesoRecommend: related.isMesoRecommend,

--- a/packages/mirror-media-next/utils/story-page-props.test.mjs
+++ b/packages/mirror-media-next/utils/story-page-props.test.mjs
@@ -76,11 +76,12 @@ assert.equal(
 const initialRelatedStories = getInitialRelatedStories(postData)
 
 assert.deepEqual(
-  initialRelatedStories.map(({ id, slug, title, type }) => ({
+  initialRelatedStories.map(({ id, slug, title, type, url }) => ({
     id,
     slug,
     title,
     type,
+    url,
   })),
   [
     {
@@ -88,18 +89,21 @@ assert.deepEqual(
       slug: 'related-one',
       title: 'Related one',
       type: 'story',
+      url: '/story/related-one',
     },
     {
       id: 'related-2',
       slug: 'related-two',
       title: 'Related two',
       type: 'external',
+      url: '/external/related-two',
     },
     {
       id: 'related-3',
       slug: 'related-three',
       title: 'Related three',
       type: 'story',
+      url: '/story/related-three',
     },
   ]
 )


### PR DESCRIPTION
Following the regression analysis of PR #1491, this PR completes the transition of related article routing logic from the UI layer to the data normalization layer. By removing the dependency on GraphQL `__typename` metadata—which is stripped during client-side payload optimization—we ensure that all related article links (including those from Miso recommendations and external pages) have explicit, pre-computed URLs and type labels.

This change prevents 404 errors caused by incorrect route inference and simplifies the rendering components by providing a consistent data contract.

## Additions
- Explicit `type` property ('story' or 'external') to all normalized related article objects.
- Pre-computed `url` fallbacks for Miso-recommended products in both standard and AMP story pages.

## Removals
- Fragile inline routing logic in `ArticleRightArrow` and other shared components.
- Reliance on `__typename: 'Post'` for type inference in `external/[slug].js` and component JSDoc.

## Changes
- Standardized the `Relateds` JSDoc typedef across `article-right-arrow.js`, `article-content.js`, and `related-article-list.js`.
- Updated `initializeRelatedStories` in the external page to align with the new URL-first routing contract.
- Renamed local variables in Miso formatting loops (e.g., `slug` to `relatedSlug`) for better clarity and to avoid collision with pre-computed paths.

## Testing
- Verified through existing unit tests in `story-page-props.test.mjs` (updated in previous commits).
- Manual verification of "Related Article" links and Miso recommendations to ensure they no longer default to `/external/` paths for internal stories.