### PR TITLE
fix: exclude `PromoteTopic` from AMP pages to resolve GSC validation errors

### DIFF
--- a/packages/mirror-media-next/pages/_app.js
+++ b/packages/mirror-media-next/pages/_app.js
@@ -31,6 +31,13 @@ function MyApp({ Component, pageProps }) {
   const { pathname } = router
   const isStoryPage = pathname.startsWith('/story/')
 
+  // PromoteTopic is loaded as a client-only dynamic component from _app, so it
+  // also runs through AMP routes. Next.js can emit client-only fallback markers
+  // such as `<template data-dgst="DYNAMIC_SERVER_USAGE">` during AMP SSR, which
+  // invalidates AMP pages.
+  const isAmpPage =
+    pathname.startsWith('/story/amp/') || pathname.startsWith('/external/amp/')
+
   //Temporarily enable google tag manager only in dev and local environment.
   useEffect(() => {
     import('react-gtm-module').then(({ default: TagManager }) => {
@@ -54,7 +61,7 @@ function MyApp({ Component, pageProps }) {
             In order to avoiding send log repeatedly, make sure not add UserBehaviorLogger components here when at story page. */}
               {!isStoryPage && <UserBehaviorLogger />}
               <Component {...pageProps} />
-              <PromoteTopic />
+              {!isAmpPage && <PromoteTopic />}
             </ThemeProvider>
           </Provider>
         </ApolloProvider>

--- a/packages/mirror-media-next/pages/_app.js
+++ b/packages/mirror-media-next/pages/_app.js
@@ -9,6 +9,7 @@ import WholeSiteScript from '../components/whole-site-script'
 import UserBehaviorLogger from '../components/shared/user-behavior-logger'
 import { useRouter } from 'next/router'
 import dynamic from 'next/dynamic'
+import { useAmp } from 'next/amp'
 
 import { MembershipProvider } from '../context/membership'
 import { Provider } from 'react-redux'
@@ -31,12 +32,10 @@ function MyApp({ Component, pageProps }) {
   const { pathname } = router
   const isStoryPage = pathname.startsWith('/story/')
 
-  // PromoteTopic is loaded as a client-only dynamic component from _app, so it
-  // also runs through AMP routes. Next.js can emit client-only fallback markers
-  // such as `<template data-dgst="DYNAMIC_SERVER_USAGE">` during AMP SSR, which
-  // invalidates AMP pages.
-  const isAmpPage =
-    pathname.startsWith('/story/amp/') || pathname.startsWith('/external/amp/')
+  // Skip this client-only dynamic widget on AMP pages because Next.js may emit
+  // React fallback markers (e.g. `<template data-dgst="DYNAMIC_SERVER_USAGE">`)
+  // that AMP treats as invalid `<template>` tags.
+  const isAmpPage = useAmp()
 
   //Temporarily enable google tag manager only in dev and local environment.
   useEffect(() => {


### PR DESCRIPTION
This PR fixes a regression introduced in PR #1491. In PR #1491, the `PromoteTopic` component was changed to a client-only dynamic component to optimize bundle size. However, this caused Google Search Console (GSC) to report validation errors on AMP pages because Next.js/React emits internal fallback markers (e.g., `<template data-dgst="DYNAMIC_SERVER_USAGE"></template>`) during AMP SSR. These markers are treated as invalid `amp-mustache` templates by the AMP validator.

The fix involves detecting AMP routes via URL pathnames and conditionally preventing the rendering of `PromoteTopic` on those pages, ensuring AMP compliance while retaining the optimization benefits for standard pages.

## Additions
- Added `isAmpPage` detection logic in `_app.js` using `router.pathname`.

## Removals
- N/A

## Changes
- Modified `_app.js` to conditionally render `<PromoteTopic />` only when `!isAmpPage`.

## Testing
- Verified that `isAmpPage` correctly identifies `/story/amp/[slug]` and `/external/amp/[slug]` routes.
- Manually checked that the `<template data-dgst="DYNAMIC_SERVER_USAGE">` marker is no longer present in the SSR output of AMP pages.

## Screenshots
- N/A

## Todos
- N/A

## Task Links
[[週刊AMP]AMP頁面異常處理 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1215185659581162?focus=true)