### PR TITLE
build(mirror-media-next): add Phase 3 minimal smoke test pipeline

### DIFF
--- a/packages/mirror-media-next/package.json
+++ b/packages/mirror-media-next/package.json
@@ -8,6 +8,7 @@
     "analyze": "ANALYZE=true next build --no-lint",
     "start": "next start",
     "lint": "next lint",
+    "test:smoke": "node scripts/smoke-test.mjs",
     "start-amp-proxy-server": "node amp-proxy-server"
   },
   "engines": {
@@ -63,6 +64,7 @@
     "@next/bundle-analyzer": "13.0.7",
     "@types/facebook-js-sdk": "^3.3.6",
     "@types/google-publisher-tag": "^1.20230410.0",
+    "amphtml-validator": "1.0.38",
     "babel-loader": "8.3.0",
     "concurrently": "^7.4.0",
     "eslint-config-next": "12.2.5"

--- a/packages/mirror-media-next/scripts/smoke-test.mjs
+++ b/packages/mirror-media-next/scripts/smoke-test.mjs
@@ -1,0 +1,216 @@
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const ampHtmlValidator = require('amphtml-validator')
+
+const DEFAULT_BASE_URL = 'http://127.0.0.1:3000'
+const REQUEST_TIMEOUT_MS = Number(process.env.SMOKE_TIMEOUT_MS || 15000)
+const AMP_VALIDATOR_JS = process.env.AMP_VALIDATOR_JS
+
+const baseUrl = normalizeBaseUrl(process.env.BASE_URL || DEFAULT_BASE_URL)
+const isLocalBaseUrl = isLocalUrl(baseUrl)
+
+const storySlug = process.env.SMOKE_STORY_SLUG || '20230914ind003'
+const storyTitle = process.env.SMOKE_STORY_TITLE || '永豐銀行加碼採購綠電'
+const externalSlug = process.env.SMOKE_EXTERNAL_SLUG || 'setn_1454423'
+const externalTitle = process.env.SMOKE_EXTERNAL_TITLE || '男嬰送托月餘頭骨碎裂'
+
+const routes = [
+  {
+    name: 'home',
+    path: '/',
+    amp: false,
+    requiredInLocal: true,
+    markers: ['鏡週刊', /id="__NEXT_DATA__"/],
+  },
+  {
+    name: 'story',
+    path: `/story/${storySlug}`,
+    amp: false,
+    requiredInLocal: false,
+    markers: [
+      storyTitle,
+      /id="__NEXT_DATA__"/,
+      /<link(?=[^>]+rel="amphtml")[^>]*>/,
+    ],
+  },
+  {
+    name: 'storyAmp',
+    path: `/story/amp/${storySlug}`,
+    amp: true,
+    requiredInLocal: false,
+    markers: [
+      storyTitle,
+      /<html[^>]+(?:⚡|amp)(?:\s|>)/,
+      /<link(?=[^>]+rel="canonical")[^>]*>/,
+    ],
+  },
+  {
+    name: 'external',
+    path: `/external/${externalSlug}`,
+    amp: false,
+    requiredInLocal: false,
+    markers: [
+      externalTitle,
+      /id="__NEXT_DATA__"/,
+      /<link(?=[^>]+rel="amphtml")[^>]*>/,
+    ],
+  },
+  {
+    name: 'externalAmp',
+    path: `/external/amp/${externalSlug}`,
+    amp: true,
+    requiredInLocal: false,
+    markers: [
+      externalTitle,
+      /<html[^>]+(?:⚡|amp)(?:\s|>)/,
+      /<link(?=[^>]+rel="canonical")[^>]*>/,
+    ],
+  },
+]
+
+const errorPageMarkers = [
+  '抱歉！找不到這個網址',
+  '這個網頁無法正常運作',
+  /<h1[^>]*>\s*(?:404|500)\s*<\/h1>/i,
+]
+
+main().catch((error) => {
+  console.error(`Smoke test failed: ${error.message}`)
+  process.exitCode = 1
+})
+
+async function main() {
+  console.log(`Smoke test BASE_URL=${baseUrl}`)
+  console.log(
+    isLocalBaseUrl
+      ? 'Local mode: detail routes are best-effort.'
+      : 'Non-local mode: all routes are required.'
+  )
+
+  let requiredFailureCount = 0
+  let optionalFailureCount = 0
+  let ampValidator
+
+  for (const route of routes) {
+    const required = !isLocalBaseUrl || route.requiredInLocal
+    const routeUrl = new URL(route.path, baseUrl).toString()
+
+    try {
+      const html = await fetchHtml(routeUrl)
+      assertStatusOk(routeUrl, html.response)
+      assertNotErrorPage(routeUrl, html.body)
+      assertMarkers(routeUrl, html.body, route.markers)
+
+      if (route.amp) {
+        ampValidator ||= await getAmpValidator()
+        assertAmpValid(routeUrl, html.body, ampValidator)
+      }
+
+      console.log(`PASS ${route.name} ${routeUrl}`)
+    } catch (error) {
+      const label = required ? 'FAIL' : 'WARN'
+      console.error(`${label} ${route.name} ${routeUrl}`)
+      console.error(`  ${error.message}`)
+
+      if (required) {
+        requiredFailureCount += 1
+      } else {
+        optionalFailureCount += 1
+      }
+    }
+  }
+
+  if (optionalFailureCount > 0) {
+    console.warn(
+      `Optional local route failures: ${optionalFailureCount}. Staging remains authoritative for detail routes.`
+    )
+  }
+
+  if (requiredFailureCount > 0) {
+    throw new Error(`${requiredFailureCount} required smoke route(s) failed`)
+  }
+
+  console.log('Smoke test passed.')
+}
+
+function normalizeBaseUrl(input) {
+  const url = new URL(input)
+  url.pathname = url.pathname.replace(/\/+$/, '')
+  return url.toString()
+}
+
+function isLocalUrl(input) {
+  const hostname = new URL(input).hostname
+  return hostname === 'localhost' || hostname === '127.0.0.1'
+}
+
+async function fetchHtml(url) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'user-agent': 'mirror-media-next-smoke-test',
+      },
+      signal: controller.signal,
+    })
+    const body = await response.text()
+    return { response, body }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function assertStatusOk(url, response) {
+  if (response.status !== 200) {
+    throw new Error(`Expected HTTP 200 for ${url}, got ${response.status}`)
+  }
+}
+
+function assertNotErrorPage(url, html) {
+  const found = errorPageMarkers.find((marker) =>
+    marker instanceof RegExp ? marker.test(html) : html.includes(marker)
+  )
+  if (found) {
+    throw new Error(`Detected error page marker "${found}" in ${url}`)
+  }
+}
+
+function assertMarkers(url, html, markers) {
+  for (const marker of markers) {
+    const matched =
+      marker instanceof RegExp ? marker.test(html) : html.includes(marker)
+
+    if (!matched) {
+      throw new Error(`Missing content marker "${marker.toString()}" in ${url}`)
+    }
+  }
+}
+
+async function getAmpValidator() {
+  return AMP_VALIDATOR_JS
+    ? ampHtmlValidator.getInstance(AMP_VALIDATOR_JS)
+    : ampHtmlValidator.getInstance()
+}
+
+function assertAmpValid(url, html, validator) {
+  const result = validator.validateString(html)
+
+  if (result.status === 'PASS') {
+    return
+  }
+
+  const errorLines = result.errors
+    .filter((error) => error.severity === 'ERROR')
+    .slice(0, 10)
+    .map(
+      (error) =>
+        `line ${error.line}, col ${error.col}: ${error.message} (${error.code})`
+    )
+
+  throw new Error(
+    [`AMP validation failed for ${url}`, ...errorLines].join('\n  ')
+  )
+}

--- a/packages/mirror-media-next/scripts/smoke-test.mjs
+++ b/packages/mirror-media-next/scripts/smoke-test.mjs
@@ -94,7 +94,7 @@ async function main() {
 
   for (const route of routes) {
     const required = !isLocalBaseUrl || route.requiredInLocal
-    const routeUrl = new URL(route.path, baseUrl).toString()
+    const routeUrl = resolveRouteUrl(baseUrl, route.path)
 
     try {
       const html = await fetchHtml(routeUrl)
@@ -143,6 +143,18 @@ function normalizeBaseUrl(input) {
 function isLocalUrl(input) {
   const hostname = new URL(input).hostname
   return hostname === 'localhost' || hostname === '127.0.0.1'
+}
+
+function resolveRouteUrl(base, routePath) {
+  const url = new URL(base)
+  const pathUrl = new URL(routePath, 'http://smoke.test')
+  const basePathname = url.pathname.replace(/\/+$/, '')
+
+  url.pathname = `${basePathname}${pathUrl.pathname}`.replace(/\/+/g, '/')
+  url.search = pathUrl.search
+  url.hash = pathUrl.hash
+
+  return url.toString()
 }
 
 async function fetchHtml(url) {

--- a/packages/mirror-media-next/scripts/smoke-test.mjs
+++ b/packages/mirror-media-next/scripts/smoke-test.mjs
@@ -7,65 +7,78 @@ const DEFAULT_BASE_URL = 'http://127.0.0.1:3000'
 const REQUEST_TIMEOUT_MS = Number(process.env.SMOKE_TIMEOUT_MS || 15000)
 const AMP_VALIDATOR_JS = process.env.AMP_VALIDATOR_JS
 
+// Each route is checked on two independent axes:
+//
+// 1. Liveness / structural — the route is reachable, returns HTTP 200, is not an
+//    error page, and rendered its structural shell (`__NEXT_DATA__`, AMP html,
+//    canonical link). A failure here means the deployed candidate is broken
+//    (500 / timeout / crash / routing regression), so it FAILS on prod and on
+//    any deployed non-prod environment (dev-v4, a future staging-v4). Only local
+//    keeps this best-effort, because local detail pages depend on external dev
+//    GraphQL that may not be reachable and is not a deployment under test.
+//
+// 2. Content-calibrated — the sample slug's title, `amphtml` link, and AMP
+//    validity. These expectations are calibrated against prod data, so they are
+//    required only on prod (authoritative). Other networked environments read
+//    from a different CMS, so the same slug may have a different article state
+//    (`state !== 'published'`, advertised) or dirty source HTML; there a content
+//    failure is reported as WARN with an explanation instead of failing the run.
+const AUTHORITATIVE_HOST =
+  process.env.SMOKE_AUTHORITATIVE_HOST || 'www.mirrormedia.mg'
+
 const baseUrl = normalizeBaseUrl(process.env.BASE_URL || DEFAULT_BASE_URL)
+const isAuthoritativeBaseUrl = isAuthoritativeUrl(baseUrl)
 const isLocalBaseUrl = isLocalUrl(baseUrl)
 
-const storySlug = process.env.SMOKE_STORY_SLUG || '20230914ind003'
-const storyTitle = process.env.SMOKE_STORY_TITLE || '永豐銀行加碼採購綠電'
-const externalSlug = process.env.SMOKE_EXTERNAL_SLUG || 'setn_1454423'
-const externalTitle = process.env.SMOKE_EXTERNAL_TITLE || '男嬰送托月餘頭骨碎裂'
+const storySlug = process.env.SMOKE_STORY_SLUG || '20230614ent025'
+const storyTitle = process.env.SMOKE_STORY_TITLE || '徐若瑄'
+const externalSlug = process.env.SMOKE_EXTERNAL_SLUG || 'dailycolumn_12846'
+const externalTitle = process.env.SMOKE_EXTERNAL_TITLE || '王丹專欄'
 
 const routes = [
   {
     name: 'home',
     path: '/',
     amp: false,
-    requiredInLocal: true,
-    markers: ['鏡週刊', /id="__NEXT_DATA__"/],
+    // home has no slug-specific content; its markers are structural liveness.
+    livenessMarkers: ['鏡週刊', /id="__NEXT_DATA__"/],
+    contentMarkers: [],
   },
   {
     name: 'story',
     path: `/story/${storySlug}`,
     amp: false,
-    requiredInLocal: false,
-    markers: [
-      storyTitle,
-      /id="__NEXT_DATA__"/,
-      /<link(?=[^>]+rel="amphtml")[^>]*>/,
-    ],
+    livenessMarkers: [/id="__NEXT_DATA__"/],
+    // `amphtml` link is gated by article state (story-head.js: state ===
+    // 'published' && !isAdvertised), so it is content-calibrated, not structural.
+    contentMarkers: [storyTitle, /<link(?=[^>]+rel="amphtml")[^>]*>/],
   },
   {
     name: 'storyAmp',
     path: `/story/amp/${storySlug}`,
     amp: true,
-    requiredInLocal: false,
-    markers: [
-      storyTitle,
+    livenessMarkers: [
       /<html[^>]+(?:⚡|amp)(?:\s|>)/,
       /<link(?=[^>]+rel="canonical")[^>]*>/,
     ],
+    contentMarkers: [storyTitle],
   },
   {
     name: 'external',
     path: `/external/${externalSlug}`,
     amp: false,
-    requiredInLocal: false,
-    markers: [
-      externalTitle,
-      /id="__NEXT_DATA__"/,
-      /<link(?=[^>]+rel="amphtml")[^>]*>/,
-    ],
+    livenessMarkers: [/id="__NEXT_DATA__"/],
+    contentMarkers: [externalTitle, /<link(?=[^>]+rel="amphtml")[^>]*>/],
   },
   {
     name: 'externalAmp',
     path: `/external/amp/${externalSlug}`,
     amp: true,
-    requiredInLocal: false,
-    markers: [
-      externalTitle,
+    livenessMarkers: [
       /<html[^>]+(?:⚡|amp)(?:\s|>)/,
       /<link(?=[^>]+rel="canonical")[^>]*>/,
     ],
+    contentMarkers: [externalTitle],
   },
 ]
 
@@ -82,62 +95,111 @@ main().catch((error) => {
 
 async function main() {
   console.log(`Smoke test BASE_URL=${baseUrl}`)
-  console.log(
-    isLocalBaseUrl
-      ? 'Local mode: detail routes are best-effort.'
-      : 'Non-local mode: all routes are required.'
-  )
+  console.log(modeMessage())
 
-  let requiredFailureCount = 0
-  let optionalFailureCount = 0
+  let failureCount = 0
+  let warningCount = 0
   let ampValidator
 
   for (const route of routes) {
-    const required = !isLocalBaseUrl || route.requiredInLocal
     const routeUrl = resolveRouteUrl(baseUrl, route.path)
+    // Liveness FAILs on prod and on any deployed non-prod env; only local is
+    // best-effort for detail routes (home stays required everywhere).
+    const livenessRequired = !isLocalBaseUrl || route.name === 'home'
+    // Content expectations are prod-calibrated, so required only on prod.
+    const contentRequired = isAuthoritativeBaseUrl
 
+    let html
     try {
-      const html = await fetchHtml(routeUrl)
+      html = await fetchHtml(routeUrl)
       assertStatusOk(routeUrl, html.response)
       assertNotErrorPage(routeUrl, html.body)
-      assertMarkers(routeUrl, html.body, route.markers)
+      assertMarkers(routeUrl, html.body, route.livenessMarkers)
+    } catch (error) {
+      if (reportFailure(route, routeUrl, error, livenessRequired, 'liveness')) {
+        failureCount += 1
+      } else {
+        warningCount += 1
+      }
+      // Not alive / no usable body — skip content checks for this route.
+      continue
+    }
 
+    try {
+      assertMarkers(routeUrl, html.body, route.contentMarkers)
       if (route.amp) {
         ampValidator ||= await getAmpValidator()
         assertAmpValid(routeUrl, html.body, ampValidator)
       }
-
-      console.log(`PASS ${route.name} ${routeUrl}`)
     } catch (error) {
-      const label = required ? 'FAIL' : 'WARN'
-      console.error(`${label} ${route.name} ${routeUrl}`)
-      console.error(`  ${error.message}`)
-
-      if (required) {
-        requiredFailureCount += 1
+      if (reportFailure(route, routeUrl, error, contentRequired, 'content')) {
+        failureCount += 1
       } else {
-        optionalFailureCount += 1
+        warningCount += 1
       }
+      continue
     }
+
+    console.log(`PASS ${route.name} ${routeUrl}`)
   }
 
-  if (optionalFailureCount > 0) {
+  if (warningCount > 0) {
     console.warn(
-      `Optional local route failures: ${optionalFailureCount}. Staging remains authoritative for detail routes.`
+      `Non-fatal warnings: ${warningCount}. These do not fail the run; ` +
+        'prod remains the authoritative target for prod-calibrated content checks.'
     )
   }
 
-  if (requiredFailureCount > 0) {
-    throw new Error(`${requiredFailureCount} required smoke route(s) failed`)
+  if (failureCount > 0) {
+    throw new Error(`${failureCount} required smoke check(s) failed`)
   }
 
   console.log('Smoke test passed.')
+}
+
+function modeMessage() {
+  if (isAuthoritativeBaseUrl) {
+    return `Authoritative mode (${AUTHORITATIVE_HOST}): liveness and content both required, including AMP validation and amphtml link.`
+  }
+  if (isLocalBaseUrl) {
+    return 'Local mode: liveness is best-effort for detail routes (home still required); prod-calibrated content checks are WARN. Gate candidates against a deployed env or prod.'
+  }
+  return 'Deployed non-prod mode: route liveness is required (FAILs on network error / timeout / non-200 / error page / missing structure); prod-calibrated content checks (title, amphtml link, AMP validity) are WARN because this environment reads from a different CMS.'
+}
+
+// Returns true if the failure counts as FAIL, false if downgraded to WARN.
+function reportFailure(route, routeUrl, error, required, phase) {
+  const label = required ? 'FAIL' : 'WARN'
+  console.error(`${label} ${route.name} ${routeUrl} (${phase})`)
+  console.error(`  ${error.message}`)
+  if (!required) {
+    console.error(`  Note: ${warnNote(phase)}`)
+  }
+  return required
+}
+
+function warnNote(phase) {
+  if (phase === 'content') {
+    return (
+      'non-authoritative environment. Likely a CMS content/state difference ' +
+      "(e.g. article state !== 'published', advertised, or unsanitized source HTML), " +
+      'not an upgrade regression. Verify against prod, which is authoritative.'
+    )
+  }
+  return (
+    'local best-effort. Detail pages depend on external dev GraphQL that may be ' +
+    'unreachable or lack this slug; gate liveness against a deployed env or prod.'
+  )
 }
 
 function normalizeBaseUrl(input) {
   const url = new URL(input)
   url.pathname = url.pathname.replace(/\/+$/, '')
   return url.toString()
+}
+
+function isAuthoritativeUrl(input) {
+  return new URL(input).hostname === AUTHORITATIVE_HOST
 }
 
 function isLocalUrl(input) {
@@ -196,7 +258,7 @@ function assertMarkers(url, html, markers) {
       marker instanceof RegExp ? marker.test(html) : html.includes(marker)
 
     if (!matched) {
-      throw new Error(`Missing content marker "${marker.toString()}" in ${url}`)
+      throw new Error(`Missing marker "${marker.toString()}" in ${url}`)
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@types/google-publisher-tag':
         specifier: ^1.20230410.0
         version: 1.20230410.0
+      amphtml-validator:
+        specifier: 1.0.38
+        version: 1.0.38
       babel-loader:
         specifier: 8.3.0
         version: 8.3.0(@babel/core@7.24.4)(webpack@5.107.2)
@@ -1822,6 +1825,10 @@ packages:
   ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
 
+  amphtml-validator@1.0.38:
+    resolution: {integrity: sha512-TqGeHVRUEsMiJoaRvMhzZBv8oljLhhJgzkaPX/zT2eJFG5FLeaMehd6riNwsuMmi9e/5xsI0pocbTgN/u2sonQ==}
+    hasBin: true
+
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -2160,12 +2167,20 @@ packages:
   colorette@2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
 
+  colors@1.4.0:
+    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
+    engines: {node: '>=0.1.90'}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@12.0.0:
+    resolution: {integrity: sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==}
+    engines: {node: '>=18'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -4091,6 +4106,9 @@ packages:
 
   promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
+
+  promise@8.3.0:
+    resolution: {integrity: sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -7306,6 +7324,12 @@ snapshots:
       require-from-string: 2.0.2
       uri-js: 4.4.1
 
+  amphtml-validator@1.0.38:
+    dependencies:
+      colors: 1.4.0
+      commander: 12.0.0
+      promise: 8.3.0
+
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -7667,11 +7691,15 @@ snapshots:
 
   colorette@2.0.19: {}
 
+  colors@1.4.0: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@12.0.0: {}
 
   commander@2.20.3: {}
 
@@ -10081,6 +10109,10 @@ snapshots:
   pretty-bytes@5.6.0: {}
 
   promise@7.3.1:
+    dependencies:
+      asap: 2.0.6
+
+  promise@8.3.0:
     dependencies:
       asap: 2.0.6
 


### PR DESCRIPTION
This Pull Request implements the Phase 3 minimal end-to-end smoke test pipeline designed to protect critical routes and guard against regressions during multi-phase architecture upgrades. It introduces a lightweight, robust Node-based script checking five essential routes, with environment-aware strictness (prod is the authoritative content target; deployed non-prod environments are gated on liveness) and AMP validation.

## Additions
- Added standalone smoke test script `packages/mirror-media-next/scripts/smoke-test.mjs` to execute automated HTTP and content marker validation.
- Added pinned dependency `amphtml-validator` (v1.0.38) to `packages/mirror-media-next/package.json` to prevent package version drift during verification.
- Added lockfile entries for `amphtml-validator` and its transitive dependencies (`colors`, `commander`, `promise`) in `pnpm-lock.yaml`.

## Removals
- N/A

## Changes
- Registered the `"test:smoke": "node scripts/smoke-test.mjs"` task inside `packages/mirror-media-next/package.json`'s script commands.
- Default sample slugs now use articles that exist on dev-v4, staging and prod (`20230614ent025`, `dailycolumn_12846`), replacing prod-only slugs that 404 on other environments. Still overridable via `SMOKE_STORY_SLUG` / `SMOKE_EXTERNAL_SLUG` (and the matching `*_TITLE`).
- Split each route check into two independent axes instead of a single `requiredInLocal` flag:
  - **Liveness / structural** (reachable, HTTP 200, not an error page, rendered shell such as `__NEXT_DATA__` / `<html ⚡>` / canonical link): FAILs on prod and on any deployed non-prod environment (dev-v4, a future staging-v4). Only local stays best-effort for detail routes, because local detail pages depend on external dev GraphQL and are not a deployment under test.
  - **Content-calibrated** (title, `amphtml` link, AMP validity): required only on prod (authoritative). Other networked environments read from a different CMS, so the same slug may differ in article state (`state !== 'published'`, advertised) or source HTML; there these are reported as WARN with an explanation rather than failing the run.
- Authoritative host defaults to `www.mirrormedia.mg` and can be overridden with `SMOKE_AUTHORITATIVE_HOST`.

## Testing
- Verified that the command `pnpm run test:smoke` runs correctly.
- Confirmed error-handling logic behaves as expected: asserts HTTP status 200, checks against known-good title strings, and excludes default 404/500 custom error pages from false passing.
- Validated distinct markers for non-AMP (`__NEXT_DATA__`, `<link rel="amphtml">`) and AMP (`<html ⚡>`, `<link rel="canonical">`) routes to prevent false failures.
- Ran against all three environments: **prod** — all five routes PASS (liveness + content, incl. AMP); **staging** and **dev-v4** — liveness PASS, with prod-calibrated content checks (e.g. AMP validity, `amphtml` link) reported as WARN due to CMS content/state differences; all exit 0.
- Confirmed liveness gating works on the deployed candidate: pointing a route at a non-existent slug on dev-v4 (`SMOKE_STORY_SLUG=this_slug_does_not_exist_xyz`) produces `FAIL story (liveness)` and exit 1, so a broken candidate route (500 / timeout / 404) is not masked.

## Screenshots
- N/A

## Todos
- Wire the smoke test orchestrations (build -> start -> wait-ready -> smoke) into the automated CI pipeline in a subsequent phase.

## Task Links
[[週刊改版] 前端_04_更小第一版 smoke test pipeline - Asana](https://app.asana.com/1/614399484723017/project/1215184739359712/task/1215115081444102?focus=true)