### PR TITLE
feat(tag): set robots tag noindex and hide canonical tag when post count < 5

### DIFF
--- a/packages/mirror-media-next/components/shared/custom-head.js
+++ b/packages/mirror-media-next/components/shared/custom-head.js
@@ -74,11 +74,9 @@ export default function CustomHead({
   robotsMetaContent,
 }) {
   const router = useRouter()
-  const canonicalLink = skipCanonical ? (
-    <></>
-  ) : (
-    createCanonicalLink(router.asPath)
-  )
+  const canonicalLink = skipCanonical
+    ? null
+    : createCanonicalLink(router.asPath)
   /** @type {OGProperties} */
   const siteInformation = {
     title: title ? `${title} - ${SITE_TITLE}` : SITE_TITLE,

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -131,7 +131,7 @@ export default function Tag({ postsCount, posts, tag, headerData }) {
         description: metaDescription || undefined,
         ogDescription: metaDescription || undefined,
         robotsMetaContent: postsCount < 5 ? 'noindex' : undefined,
-        skipCanonical: postsCount < 5 ? true : false,
+        skipCanonical: postsCount < 5,
       }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -130,8 +130,8 @@ export default function Tag({ postsCount, posts, tag, headerData }) {
         title: `${tagName}相關報導`,
         description: metaDescription || undefined,
         ogDescription: metaDescription || undefined,
-        robotsMetaContent: postsCount < 5 ? 'noindex' : undefined,
-        skipCanonical: postsCount < 5,
+        robotsMetaContent: (postsCount ?? 0) < 5 ? 'noindex' : undefined,
+        skipCanonical: (postsCount ?? 0) < 5,
       }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -130,6 +130,7 @@ export default function Tag({ postsCount, posts, tag, headerData }) {
         title: `${tagName}相關報導`,
         description: metaDescription || undefined,
         ogDescription: metaDescription || undefined,
+        robotsMetaContent: postsCount < 5 ? 'noindex' : undefined,
         skipCanonical: postsCount < 5 ? true : false,
       }}
       header={{ type: 'default', data: headerData }}

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -130,7 +130,8 @@ export default function Tag({ postsCount, posts, tag, headerData }) {
         title: `${tagName}相關報導`,
         description: metaDescription || undefined,
         ogDescription: metaDescription || undefined,
-        robotsMetaContent: (postsCount ?? 0) < 5 ? 'noindex' : undefined,
+        robotsMetaContent:
+          (postsCount ?? 0) < 5 ? 'noindex' : 'index, max-image-preview:large',
         skipCanonical: (postsCount ?? 0) < 5,
       }}
       header={{ type: 'default', data: headerData }}

--- a/packages/mirror-media-next/pages/tag/[slug].js
+++ b/packages/mirror-media-next/pages/tag/[slug].js
@@ -130,6 +130,7 @@ export default function Tag({ postsCount, posts, tag, headerData }) {
         title: `${tagName}相關報導`,
         description: metaDescription || undefined,
         ogDescription: metaDescription || undefined,
+        skipCanonical: postsCount < 5 ? true : false,
       }}
       header={{ type: 'default', data: headerData }}
       footer={{ type: 'default' }}


### PR DESCRIPTION
# 描述

- 當 tag 頁文章數 < 5
  - 新增 content 屬性值為 noindex 的 robots meta tag
  - 隱藏 canonical meta tag
 
**參考資源**
- 任務卡
https://app.asana.com/1/614399484723017/project/1215184739359712/task/1215086527608150?focus=true