### PR TITLE
feat(shared): disable lazy loading for first image in article list

### DIFF
--- a/packages/mirror-media-next/components/shared/article-list-item.js
+++ b/packages/mirror-media-next/components/shared/article-list-item.js
@@ -114,9 +114,10 @@ const ItemBrief = styled.div`
  * @param {Object} props
  * @param {Article} props.item
  * @param {Section} [props.section]
+ * @param {boolean} [props.priority]
  * @returns {React.ReactElement}
  */
-export default function ArticleListItem({ item, section }) {
+export default function ArticleListItem({ item, section, priority }) {
   const { publishedDate } = item
   const formattedPublishedDate = transformTimeDataIntoDotFormat(publishedDate)
   const itemSection =
@@ -139,6 +140,7 @@ export default function ArticleListItem({ item, section }) {
           loadingImage="/images-next/loading.gif"
           defaultImage="/images-next/default-og-img.png"
           rwd={{ mobile: '400px', tablet: '400px', desktop: '400px' }}
+          priority={priority}
         />
         {itemSection && (
           <ItemSection sectionName={itemSection?.slug}>

--- a/packages/mirror-media-next/components/shared/article-list.js
+++ b/packages/mirror-media-next/components/shared/article-list.js
@@ -77,7 +77,11 @@ export default function ArticleList({ renderList, section }) {
       <ItemContainer>
         {renderListWithAd.map((item, index) => (
           <Fragment key={item.id}>
-            <ArticleListItem item={item} section={section} />
+            <ArticleListItem
+              item={item}
+              section={section}
+              priority={index === 0}
+            />
             {shouldShowAd && needInsertMicroAdAfter(index) && (
               <StyledMicroAd
                 unitId={getMicroAdUnitId(index, 'LISTING', 'RWD')}

--- a/packages/mirror-media-next/components/shared/premium-article-list-item.js
+++ b/packages/mirror-media-next/components/shared/premium-article-list-item.js
@@ -114,9 +114,10 @@ const ItemDate = styled.div`
  * @param {Object} props
  * @param {Article} props.item
  * @param {Section} [props.section]
+ * @param {boolean} [props.priority]
  * @returns {React.ReactElement}
  */
-export default function PremiumArticleListItem({ item, section }) {
+export default function PremiumArticleListItem({ item, section, priority }) {
   const itemSection =
     section || item.sections.find((section) => section.slug === 'member')
 
@@ -130,6 +131,7 @@ export default function PremiumArticleListItem({ item, section }) {
           loadingImage="/images-next/loading.gif"
           defaultImage="/images-next/default-og-img.png"
           rwd={{ desktop: '320px' }}
+          priority={priority}
         />
         {itemSection && (
           <ItemSection sectionName={itemSection?.slug}>

--- a/packages/mirror-media-next/components/shared/premium-article-list.js
+++ b/packages/mirror-media-next/components/shared/premium-article-list.js
@@ -54,8 +54,13 @@ export default function PremiumArticleList({ renderList, section }) {
   return (
     <>
       <ItemContainer>
-        {renderListBeforeAd.map((item) => (
-          <PremiumArticleListItem key={item.id} item={item} section={section} />
+        {renderListBeforeAd.map((item, index) => (
+          <PremiumArticleListItem
+            key={item.id}
+            item={item}
+            section={section}
+            priority={index === 0}
+          />
         ))}
       </ItemContainer>
 


### PR DESCRIPTION
# 描述

- 取消列表頁（author、tag 、category 和 section 頁）第一張圖片 lazy loading，調整範圍包括：
  - 使用 `ArticleList` 元件的列表頁（目前使用在 author、tag 、category 非會員頁和 section 非會員頁）
  - 使用 `PremiumArticleList` 元件的列表頁（目前使用在 category 會員頁和 section 會員頁）

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214694956420511