### PR TITLE
fix(story): align social network service breakpoints to prevent layout overlap

### DIFF
--- a/packages/mirror-media-next/components/external/external-normal-style.js
+++ b/packages/mirror-media-next/components/external/external-normal-style.js
@@ -215,7 +215,7 @@ const SocialNetworkServiceLarge = styled(SocialNetworkService)`
   display: flex;
   margin-top: 20px;
   margin-bottom: 24px;
-  ${({ theme }) => theme.breakpoint.xl} {
+  ${({ theme }) => theme.breakpoint.md} {
     display: none;
   }
 `

--- a/packages/mirror-media-next/components/story/normal/fb-page-plugin.js
+++ b/packages/mirror-media-next/components/story/normal/fb-page-plugin.js
@@ -1,7 +1,7 @@
 import Script from 'next/script'
 
 const FB_SDK_URL =
-  'https://connect.facebook.net/zh_TW/sdk.js#xfbml=1&version=v18.0'
+  'https://connect.facebook.net/zh_TW/sdk.js#xfbml=1&version=v25.0'
 const FB_PAGE_URL = 'https://www.facebook.com/mirrormediamg'
 
 /** @typedef {import('../../../type/theme').Theme} Theme */

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -293,7 +293,7 @@ const SocialNetworkServiceLarge = styled(SocialNetworkService)`
   display: flex;
   margin-top: 20px;
   margin-bottom: 24px;
-  ${({ theme }) => theme.breakpoint.xl} {
+  ${({ theme }) => theme.breakpoint.md} {
     display: none;
   }
 `


### PR DESCRIPTION
# 描述

- 將 FB SDK 升級至最新版本
- 修正 story 頁和 external 頁平板版社群區塊元件重複出現問題

**參考資源**

- 任務卡
https://app.asana.com/1/614399484723017/project/1216190579632682/task/1216057282111767?focus=true