### PR TITLE
feat(header): remove 'warmlife' btn item from the navbar

### DIFF
--- a/packages/mirror-media-next/components/header/normal/header.js
+++ b/packages/mirror-media-next/components/header/normal/header.js
@@ -220,19 +220,6 @@ const formatSectionItem = (section) => {
           ...section.categories,
         ],
       }
-    } else if (section.slug === 'life') {
-      return {
-        ...section,
-        categories: [
-          ...section.categories,
-          {
-            id: '306dac073da6dc1ddb4e34c228035915', //hash for ensure it is unique from other category, no other usage.
-            slug: 'warmlife',
-            name: '暖流',
-            isMemberOnly: false,
-          },
-        ],
-      }
     }
     return { ...section }
   }
@@ -268,22 +255,17 @@ const formatSectionItem = (section) => {
       return categories.map((category) => {
         return {
           ...category,
-          href: getCategoryHref(section.slug, category.slug),
+          href: getCategoryHref(category.slug),
         }
       })
       /**
-       * @param {HeadersDataSection['slug']} sectionSlug
        * @param {import('./nav-sections').CategoryInHeadersDataSection['slug']} categorySlug
        * @returns {string}
        */
-      function getCategoryHref(sectionSlug, categorySlug) {
+      function getCategoryHref(categorySlug) {
         if (categorySlug === 'magazine') {
           return '/magazine/'
-        }
-        if (sectionSlug === 'life' && categorySlug === 'warmlife') {
-          return '/externals/warmlife'
-        }
-        if (categorySlug === 'daily_forum') {
+        } else if (categorySlug === 'daily_forum') {
           return '/externals/dailycolumn'
         }
         return `/category/${categorySlug}`

--- a/packages/mirror-media-next/components/header/normal/header.js
+++ b/packages/mirror-media-next/components/header/normal/header.js
@@ -265,7 +265,8 @@ const formatSectionItem = (section) => {
       function getCategoryHref(categorySlug) {
         if (categorySlug === 'magazine') {
           return '/magazine/'
-        } else if (categorySlug === 'daily_forum') {
+        }
+        if (categorySlug === 'daily_forum') {
           return '/externals/dailycolumn'
         }
         return `/category/${categorySlug}`


### PR DESCRIPTION
# 描述

- 移除 nvabar「生活」大分類標籤中的「暖流」標籤
- 移除 `header.js` 檔案中和「暖流」相關的程式碼，同時調整受影響的範圍

**參考資源**

- 任務卡
https://app.asana.com/1/614399484723017/project/1216190579632682/task/1216613353198514?focus=true