### PR TITLE
fix: increase API_TIMEOUT_GRAPHQL from 4s to 8s (prod/staging)

### DIFF
--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -79,7 +79,7 @@ switch (ENV) {
   case 'prod':
     SITE_URL = 'www.mirrormedia.mg'
     API_TIMEOUT = 1500
-    API_TIMEOUT_GRAPHQL = 4000
+    API_TIMEOUT_GRAPHQL = 8000
     WEEKLY_API_SERVER_ORIGIN =
       'adam-weekly-api-server-prod-ufaummkd5q-de.a.run.app'
     PREVIEW_SERVER_ORIGIN = 'mirror-cms-preview-prod-ufaummkd5q-de.a.run.app'
@@ -147,7 +147,7 @@ switch (ENV) {
   case 'staging':
     SITE_URL = 'staging.mirrormedia.mg'
     API_TIMEOUT = 1500
-    API_TIMEOUT_GRAPHQL = 4000
+    API_TIMEOUT_GRAPHQL = 8000
 
     WEEKLY_API_SERVER_ORIGIN =
       'adam-weekly-api-server-staging-ufaummkd5q-de.a.run.app'


### PR DESCRIPTION
1. GraphQL timeout errors (~16k/30d, group `CNX_j9r1p7ST3QE`) occur in short bursts when traffic to `adam-weekly-api-server-prod` spikes 2-3x and autoscaling lags; queued requests exceed the 4s Apollo timeout.
2. Queries themselves are fast (0.2-0.6s measured); 8s lets requests survive the queueing peak. dev/local already use 5s.
3. Side effect: worst-case SSR wait doubles during bursts, but current behavior is an error page / 404 (tag pages), so waiting is strictly better.