### PR TITLE
chore: sync remaining prod-approved changes to dev-v4 (round 2)

### DIFF
--- a/packages/mirror-media-next/components/external/external-normal-style.js
+++ b/packages/mirror-media-next/components/external/external-normal-style.js
@@ -654,7 +654,7 @@ export default function ExternalNormalStyle({ external, allRelatedStories }) {
               </Link>
               、
               <Link href="/subscribe" target="_blank">
-                鏡週刊數位訂閱
+                鏡週刊動態雜誌
               </Link>
               、
               <Link href="/story/webauthorize/" target="_blank">
@@ -732,7 +732,7 @@ export default function ExternalNormalStyle({ external, allRelatedStories }) {
             鏡週刊紙本雜誌
           </Link>
           <Link href="/subscribe" target="_blank">
-            鏡週刊數位訂閱
+            鏡週刊動態雜誌
           </Link>
           、
           <Link href="/story/webauthorize/" target="_blank">

--- a/packages/mirror-media-next/components/story/normal/index.js
+++ b/packages/mirror-media-next/components/story/normal/index.js
@@ -773,7 +773,7 @@ export default function StoryNormalStyle({
               </Link>
               、
               <Link href="/subscribe" target="_blank">
-                鏡週刊數位訂閱
+                鏡週刊動態雜誌
               </Link>
               、
               <Link href="/story/webauthorize/" target="_blank">
@@ -842,7 +842,7 @@ export default function StoryNormalStyle({
           </Link>
           、
           <Link href="/subscribe" target="_blank">
-            鏡週刊數位訂閱
+            鏡週刊動態雜誌
           </Link>
           、
           <Link href="/story/webauthorize/" target="_blank">

--- a/packages/mirror-media-next/config/index.mjs
+++ b/packages/mirror-media-next/config/index.mjs
@@ -79,7 +79,7 @@ switch (ENV) {
   case 'prod':
     SITE_URL = 'www.mirrormedia.mg'
     API_TIMEOUT = 1500
-    API_TIMEOUT_GRAPHQL = 4000
+    API_TIMEOUT_GRAPHQL = 8000
     WEEKLY_API_SERVER_ORIGIN =
       'adam-weekly-api-server-prod-ufaummkd5q-de.a.run.app'
     PREVIEW_SERVER_ORIGIN = 'mirror-cms-preview-prod-ufaummkd5q-de.a.run.app'
@@ -147,7 +147,7 @@ switch (ENV) {
   case 'staging':
     SITE_URL = 'staging.mirrormedia.mg'
     API_TIMEOUT = 1500
-    API_TIMEOUT_GRAPHQL = 4000
+    API_TIMEOUT_GRAPHQL = 8000
 
     WEEKLY_API_SERVER_ORIGIN =
       'adam-weekly-api-server-staging-ufaummkd5q-de.a.run.app'


### PR DESCRIPTION
This PR synchronizes the remaining approved business logic and bug fixes that have already been deployed to staging and prod back into the dev-v4 branch. It cherry-picks 2 specific PRs to ensure dev-v4 is fully up-to-date with the current production environment before proceeding with UI delivery. Note that the commits retain their original "Merge pull request #NNNN" subjects to preserve traceability back to their originating PRs, but they are single-parent commits on this branch, not actual merges.

## Additions
- N/A

## Removals
- N/A

## Changes
- **Config**: Increased `API_TIMEOUT_GRAPHQL` from 4000 to 8000 for `prod` and `staging` environments (fix: increase graphql timeout #1537).
- **Subscription Text**: Updated the subscription hyperlink text from "鏡週刊數位訂閱" to "鏡週刊動態雜誌" in story and external pages (feat(story, external): update subscription hyperlink text #1539).

## Testing
- Verified `lint`, `typecheck`, `codegen:check`, and `check:no-new-js` successfully.
- Verified config value (`API_TIMEOUT_GRAPHQL`) outputs correctly across `local`, `dev`, `staging`, and `prod` configurations.

## Screenshots
- N/A

## Todos
- N/A

## Task Links
[[週刊改版] 前端_Dev 任務同步到Dev-V4 - Asana](https://app.asana.com/1/614399484723017/project/1210724947067404/task/1216745349578335?focus=true)