### PR TITLE
feat(app): contain client-side render errors with error boundaries

### DIFF
--- a/packages/mirror-media-next/components/shared/error-boundary.tsx
+++ b/packages/mirror-media-next/components/shared/error-boundary.tsx
@@ -1,0 +1,58 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+
+import { generateErrorReportInfo } from '../../utils/log/error-log'
+import { sendErrorLog } from '../../utils/log/send-log'
+
+type ErrorBoundaryProps = {
+  children: ReactNode
+  // Which boundary caught the error, sent as a top-level log field so reports can be filtered by source.
+  boundary: string
+  fallback?: ReactNode
+  // Clears the error whenever this changes. Only needed at the app level (see
+  // `pages/_app.js`): a client-side navigation swaps the page underneath without
+  // unmounting the boundary, so the error state survives onto a route that is
+  // perfectly fine. A boundary mounted inside a page unmounts along with it and
+  // can omit this.
+  resetKey?: string
+}
+
+type ErrorBoundaryState = {
+  hasError: boolean
+}
+
+export default class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  // Only on an actual `resetKey` change. Resetting unconditionally here would
+  // re-render the children while the cause is still present, throw again, and loop.
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false })
+    }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    try {
+      const errorLog = generateErrorReportInfo(error)
+      sendErrorLog({
+        ...errorLog,
+        boundary: this.props.boundary,
+        componentStack: errorInfo.componentStack,
+      })
+      // eslint-disable-next-line no-empty
+    } catch {}
+  }
+
+  render() {
+    if (this.state.hasError) return this.props.fallback ?? null
+
+    return this.props.children
+  }
+}

--- a/packages/mirror-media-next/components/shared/error-page.tsx
+++ b/packages/mirror-media-next/components/shared/error-page.tsx
@@ -1,0 +1,121 @@
+import { type ReactNode } from 'react'
+import { useRouter } from 'next/router'
+import styled from 'styled-components'
+
+type ErrorPageProps = {
+  // An HTTP status code, so only for server-rendered error pages. A client-side
+  // error has no status: the response was already 200 by the time it happened.
+  code?: ReactNode
+  message: ReactNode
+  showRetry?: boolean
+  showGoHome?: boolean
+}
+
+const Page = styled.div`
+  height: 100vh;
+  background-color: #f2f2f2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`
+
+const MsgContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 260px;
+  margin-top: 140px;
+`
+
+const H1 = styled.h1`
+  font-weight: 400;
+  font-size: 128px;
+  line-height: 120%;
+  color: #61b8c6;
+`
+
+const Text = styled.p`
+  font-weight: 500;
+  font-size: 24px;
+  color: #61b8c6;
+`
+
+const Actions = styled.div`
+  display: flex;
+  gap: 12px;
+  margin-top: 24px;
+`
+
+const ActionButton = styled.button`
+  padding: 8px 20px;
+  border: 1px solid #61b8c6;
+  border-radius: 38px;
+  font-weight: 500;
+  font-size: 16px;
+  white-space: nowrap;
+
+  &:hover {
+    cursor: pointer;
+    transition: 0.1s ease-in;
+  }
+
+  &:focus {
+    outline: 0;
+  }
+`
+
+const PrimaryAction = styled(ActionButton)`
+  background-color: #61b8c6;
+  color: #ffffff;
+
+  &:hover {
+    background-color: #4c9aa6;
+    border-color: #4c9aa6;
+  }
+`
+
+const SecondaryAction = styled(ActionButton)`
+  background-color: transparent;
+  color: #61b8c6;
+
+  &:hover {
+    background-color: #ffffff;
+  }
+`
+
+export default function ErrorPage({
+  code,
+  message,
+  showRetry,
+  showGoHome,
+}: ErrorPageProps) {
+  const router = useRouter()
+  // Hidden on the home page, where it would just navigate to the same broken route.
+  const canGoHome = showGoHome && router.pathname !== '/'
+
+  return (
+    <Page>
+      <MsgContainer>
+        {code ? <H1>{code}</H1> : null}
+        <Text>{message}</Text>
+        {(showRetry || canGoHome) && (
+          <Actions>
+            {showRetry && (
+              <PrimaryAction
+                type="button"
+                onClick={() => window.location.reload()}
+              >
+                重新整理
+              </PrimaryAction>
+            )}
+            {canGoHome && (
+              <SecondaryAction type="button" onClick={() => router.push('/')}>
+                回首頁
+              </SecondaryAction>
+            )}
+          </Actions>
+        )}
+      </MsgContainer>
+    </Page>
+  )
+}

--- a/packages/mirror-media-next/pages/500.js
+++ b/packages/mirror-media-next/pages/500.js
@@ -1,41 +1,5 @@
-import styled from 'styled-components'
-
-const Page = styled.div`
-  height: 100vh;
-  background-color: #f2f2f2;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`
-
-const MsgContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 260px;
-  margin-top: 140px;
-`
-
-const H1 = styled.h1`
-  font-weight: 400;
-  font-size: 128px;
-  line-height: 120%;
-  color: #61b8c6;
-`
-
-const Text = styled.p`
-  font-weight: 500;
-  font-size: 24px;
-  color: #61b8c6;
-`
+import ErrorPage from '../components/shared/error-page'
 
 export default function Custom500() {
-  return (
-    <Page>
-      <MsgContainer>
-        <H1>500</H1>
-        <Text>這個網頁無法正常運作</Text>
-      </MsgContainer>
-    </Page>
-  )
+  return <ErrorPage code="500" message="這個網頁無法正常運作" />
 }

--- a/packages/mirror-media-next/pages/_app.js
+++ b/packages/mirror-media-next/pages/_app.js
@@ -10,6 +10,8 @@ import isPropValid from '@emotion/is-prop-valid'
 import { StyleSheetManager, ThemeProvider } from 'styled-components'
 
 import client from '../apollo/apollo-client'
+import ErrorBoundary from '../components/shared/error-boundary'
+import ErrorPage from '../components/shared/error-page'
 import UserBehaviorLogger from '../components/shared/user-behavior-logger'
 import WholeSiteScript from '../components/whole-site-script'
 import { GTM_ID } from '../config/index.mjs'
@@ -97,8 +99,31 @@ function MyApp({ Component, pageProps }) {
                 {/* Story page has its own UserBehaviorLogger.
             In order to avoiding send log repeatedly, make sure not add UserBehaviorLogger components here when at story page. */}
                 {!isStoryPage && <UserBehaviorLogger />}
-                <Component {...pageProps} />
-                {!isAmpPage && <PromoteTopic />}
+                {/* Catches errors thrown while rendering the page on the client,
+                    which would otherwise surface as a blank "Application error"
+                    page. */}
+                <ErrorBoundary
+                  boundary="mainpage"
+                  resetKey={router.asPath}
+                  fallback={
+                    <ErrorPage
+                      message="oops 發生了一些問題"
+                      showRetry
+                      showGoHome
+                    />
+                  }
+                >
+                  <Component {...pageProps} />
+                </ErrorBoundary>
+                {/* Sits outside the page boundary above, so this is the only
+                    thing catching it: without it, a failure in this secondary
+                    widget would take down the whole app. No fallback props, so it just
+                    disappears. */}
+                {!isAmpPage && (
+                  <ErrorBoundary boundary="promote-topic">
+                    <PromoteTopic />
+                  </ErrorBoundary>
+                )}
               </ThemeProvider>
             </StyleSheetManager>
           </Provider>


### PR DESCRIPTION
An uncaught error during client render replaced the entire page with Next.js's blank "Application error" screen. Wrap the page in an ErrorBoundary so it degrades to a styled error page instead, and report the error to /api/error-report for diagnosis.

## Additions

  - `components/shared/error-boundary.tsx` — reusable error boundary that reports caught errors to `/api/error-report`
  - `components/shared/error-page.tsx` — shared error page layout, extracted from `pages/500.js`

## Removals

  - N/A

## Changes

  - Wrap `<Component>` in `_app.js` with an error boundary, so a client-side render error degrades to a styled error page instead of Next.js's blank "Application error" screen
  - Give `PromoteTopic` its own boundary with no fallback, so a failure in that secondary widget disappears silently instead of taking down the whole app
  - Point `pages/500.js` at the shared `ErrorPage`; the client-side fallback omits the status code, since a client-side error has no HTTP status by the time it happens

## Testing

  - Verify `/500` still renders correctly through the shared `ErrorPage`
  - Verify the main routes still render normally (home, story, category, section, tag, search) — this change wraps every page, so a regression would be the main risk
  - Verify the promote-topic floating widget still appears and behaves as before

## Screenshots

  - N/A

## Todos

  - Root cause of the production "Application error" remains unknown. A missing chunk was ruled out by deleting one from a dev build — `next/dynamic` on the Pages Router swallows loader rejections and renders `null`, and a missing page chunk leaves the page static but intact rather than erroring. These boundaries make the real error observable in the error log rather than fix it.
  
## Task Links

- [[週刊] 全站 promote topic client-only 元件無錯誤隔離，元件炸掉會使整頁跳 Application error](https://app.asana.com/1/614399484723017/project/1217056824510799/task/1216935241686091?focus=true)