### PR TITLE
fix(robots): disallow indexing of _next/data/* path

### DIFF
--- a/packages/mirror-media-next/pages/api/robots.ts
+++ b/packages/mirror-media-next/pages/api/robots.ts
@@ -10,6 +10,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
       Disallow: /login
       Disallow: /subscribe/*
       Disallow: /search/*
+      Disallow: /_next/data/*
 
       User-agent: facebookexternalhit
         Allow: /


### PR DESCRIPTION
[優化 JSON 檢索](https://app.asana.com/1/614399484723017/project/1217056824510799/task/1216972466048192)

## 🎯 為什麼要這樣做

防止搜尋引擎爬蟲索引包含在此路徑下的資料，減少不必要的爬取負擔並保護 API 資料。

## ⚠️ 修改的內容

### robots.txt 路由設定
- **修改方向**：調整爬蟲限制規則
- **內容**：
  - 在 robots.txt 針對 Googlebot 新增排除限制，不允許其爬取下方的路徑

## 🧪 測試步驟

### 測試案例 1：驗證 robots.txt API 路由規則

1. 啟動本機開發伺服器
2. 以瀏覽器或使用 API 工具存取 robots.txt API 端點
3. 檢查回傳的內容中，在 Googlebot 規則區塊下是否包含排除特定路徑的規則
4. **預期結果**：回傳內容之 Googlebot 區塊下確實出現不允許存取 `/_next/data/*` 的規則
