### PR TITLE
fix(error-log): format client error payload for Error Reporting's grouping convention

### DIFF
--- a/packages/mirror-media-next/pages/api/error-report.ts
+++ b/packages/mirror-media-next/pages/api/error-report.ts
@@ -21,7 +21,8 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     monitorLoggingRequestBody('error-report', req.body)
     const query = req.body
     const log = loggingClient.log(GCP_STACKDRIVER_ERROR_LOG_NAME)
-    const metadata = { resource: { type: 'global' } }
+    // Error Reporting only picks up entries logged at ERROR or above.
+    const metadata = { resource: { type: 'global' }, severity: 'ERROR' }
     const clientIp = requestIp.getClientIp(req)
 
     query.clientInfo.ip = clientIp

--- a/packages/mirror-media-next/utils/log/error-log/index.js
+++ b/packages/mirror-media-next/utils/log/error-log/index.js
@@ -12,6 +12,25 @@ import {
 } from '../shared'
 
 /**
+ * Build the `message` field Error Reporting groups on.
+ * Error Reporting only looks at `stack_trace`, `exception` and `message`; when none of them
+ * exist it scans every field of the payload for something that looks like a stack trace, so we
+ * always hand it one `message`, formatted as `<Name>: <message>` followed by the stack frames —
+ * the shape it knows how to parse
+ * (see https://cloud.google.com/error-reporting/docs/formatting-error-messages).
+ * @param {Error} error
+ * @returns {string}
+ */
+const formatErrorMessage = (error) => {
+  const header = `${error.name || 'Error'}: ${error.message}`
+  const stack = typeof error.stack === 'string' ? error.stack.trim() : ''
+
+  if (!stack) return header
+  // V8 stacks already start with the header; Firefox/Safari stacks are frames only.
+  return stack.startsWith(header) ? stack : `${header}\n${stack}`
+}
+
+/**
  *
  * @typedef {import('../../../context/membership').MemberType} MemberType
  *
@@ -24,6 +43,11 @@ import {
 
 /**
  * Generate information for error report.
+ * The returned object is written to Cloud Logging as-is and becomes the entry's `jsonPayload`,
+ * so it follows the layout Error Reporting expects: a top-level `message` carrying the stack
+ * trace, plus `context`. `errorLog`, `clientInfo` and `pageInfo` are extra fields Error
+ * Reporting ignores; they are kept for querying in Logs Explorer.
+ *
  * Caution: Since this function have use Web API, such as `window.location.href`, `window.navigator.userAgent`,
  * this function should be ONLY executed at client-side.
  * @param {Error} error
@@ -53,7 +77,6 @@ const generateErrorReportInfo = (
     error: {
       name: error.name,
       message: error.message,
-      stack: error.stack,
     },
     datetime: transformTimeDataIntoSlashFormat(new Date().toISOString(), true),
   }
@@ -78,7 +101,20 @@ const generateErrorReportInfo = (
   if (pathname.startsWith('/story/')) {
     pageInfo['story-slug'] = pathname.split('/story/')?.[1] ?? ''
   }
-  return { errorLog, clientInfo, pageInfo }
+
+  return {
+    message: formatErrorMessage(error),
+    context: {
+      httpRequest: {
+        url: window.location.href,
+        userAgent,
+        referrer: document.referrer,
+      },
+    },
+    errorLog,
+    clientInfo,
+    pageInfo,
+  }
 }
 
 export { generateErrorReportInfo }


### PR DESCRIPTION
Error Reporting 只認 stack_trace、exception、message 三個欄位。舊的 payload 都沒有相關 key，Error Reporting 只好掃描整個 payload 尋找看起來像 stack trace 的欄位，這個 PR 補上 message，讓 Error Reporting 分組時可以更可控。

## Additions

  - `utils/log/error-log/index.js` 新增 `formatErrorMessage()`，產生 Error Reporting 用來分組的字串：`<Name>: <message>` 加上 stack frames。V8（Chrome/Edge）的 `error.stack` 本來就以標頭開頭，直接沿用，Firefox/Safari 的 stack 只有 frames，補上標頭前綴，讓同一個錯誤在不同瀏覽器產生一致的 group key。
  - `pages/api/error-report.ts` 的 log entry metadata 加上 `severity: 'ERROR'`。google 文件說明 Error Reporting 只收 ERROR 以上的 entry。（雖然看目前 Error Report 還是有收到 log，但這次就一併加上）

## Removals

  - 移除 `errorLog.error.stack`。現在 top-level `message` 已經帶著同一份 stack，故移除。`errorLog.error` 的 `name` 與 `message` 保留。雖然也包含在 `message` 第一行，但留成獨立欄位才方便在 Logs Explorer 直接查詢。

## Changes

  `generateErrorReportInfo()` 的回傳值從：
  ```js
  { errorLog, clientInfo, pageInfo }
  ```
  改為:
   ```js
  {
    message,                                               
    context: { httpRequest: { url, userAgent, referrer } },
    errorLog: { error: { name, message }, datetime },  
    clientInfo,                                             
    pageInfo,
  }
   ```

## Testing

- N/A

## Screenshots

- N/A

## Todos

- N/A

## Task Links

- [[週刊] Error report 分組](https://app.asana.com/1/614399484723017/inbox/1215270176146591/item/1217355055064420/story/1217356156090337?focus=true)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217355055064420