### PR TITLE
fix(storage): guard localStorage access in GDPR and recover-password

### DIFF
--- a/packages/mirror-media-next/components/gdpr.js
+++ b/packages/mirror-media-next/components/gdpr.js
@@ -3,6 +3,11 @@ import styled, { css } from 'styled-components'
 
 import { Z_INDEX } from '../constants'
 import useFirstScrollDetector from '../hooks/useFirstScrollDetector'
+import {
+  getStorageItem,
+  isStorageAvailable,
+  setStorageItem,
+} from '../utils/safe-storage'
 
 const Wrapper = styled.div`
   position: relative;
@@ -96,7 +101,16 @@ export default function GDPRNotification() {
   const hasScrolled = useFirstScrollDetector()
 
   useEffect(() => {
-    const gdprSeen = localStorage.getItem('mirrormedia-gdprSeen')
+    /*
+      Reading `window.localStorage` can throw a SecurityError on the property
+      access itself. Without it the agreement can never be recorded, so hide the
+      notification instead of showing a button that remembers nothing.
+     */
+    if (!isStorageAvailable()) {
+      return
+    }
+
+    const gdprSeen = getStorageItem('mirrormedia-gdprSeen')
 
     if (!gdprSeen) {
       setShowNotification(true)
@@ -105,7 +119,7 @@ export default function GDPRNotification() {
 
   const handleAgree = () => {
     setShowNotification(false)
-    localStorage.setItem('mirrormedia-gdprSeen', 'true')
+    setStorageItem('mirrormedia-gdprSeen', 'true')
   }
 
   return (

--- a/packages/mirror-media-next/pages/recover-password/index.js
+++ b/packages/mirror-media-next/pages/recover-password/index.js
@@ -21,6 +21,11 @@ import { getSectionAndTopicFromDefaultHeaderData } from '../../utils/data-proces
 import { generateErrorReportInfo } from '../../utils/log/error-log'
 import { sendErrorLog } from '../../utils/log/send-log'
 import { processSettledResult } from '../../utils/response-processor'
+import {
+  getStorageItem,
+  removeStorageItem,
+  setStorageItem,
+} from '../../utils/safe-storage'
 import redirectToDestinationWhileAuthed from '../../utils/server-side-only/redirect-to-destination-while-authed'
 
 // following comments is required since these variables are used by comments but not codes.
@@ -142,7 +147,7 @@ export default function Login({ emailData, headerData }) {
       setAvoidSpanCooldown(AVOID_SPAM_COOLDOWN)
       /** @type {number} */
       const coolDownExpiredTime = Date.now() + AVOID_SPAM_COOLDOWN
-      localStorage.setItem(COOLDOWN_STORAGE_KEY, coolDownExpiredTime.toString())
+      setStorageItem(COOLDOWN_STORAGE_KEY, coolDownExpiredTime.toString())
     } catch (e) {
       if (
         e instanceof FirebaseError &&
@@ -161,9 +166,7 @@ export default function Login({ emailData, headerData }) {
   // load cooldown info while page loaded
   useEffect(() => {
     /** @type {number} */
-    const coolDownExpiredTime = Number(
-      localStorage.getItem(COOLDOWN_STORAGE_KEY)
-    )
+    const coolDownExpiredTime = Number(getStorageItem(COOLDOWN_STORAGE_KEY))
     const now = Date.now()
 
     if (Number.isNaN(coolDownExpiredTime)) return
@@ -173,7 +176,7 @@ export default function Login({ emailData, headerData }) {
       setAvoidSpanCooldown(cooldown)
       setHintState(HINT_STATE.SUCCESS)
     } else {
-      localStorage.removeItem(COOLDOWN_STORAGE_KEY)
+      removeStorageItem(COOLDOWN_STORAGE_KEY)
     }
   }, [])
 
@@ -184,7 +187,7 @@ export default function Login({ emailData, headerData }) {
       else {
         setHintState(HINT_STATE.DEFAULT)
         clearInterval(timer)
-        localStorage.removeItem(COOLDOWN_STORAGE_KEY)
+        removeStorageItem(COOLDOWN_STORAGE_KEY)
       }
     }, SECOND * 1)
 

--- a/packages/mirror-media-next/utils/safe-storage.ts
+++ b/packages/mirror-media-next/utils/safe-storage.ts
@@ -1,0 +1,36 @@
+/**
+ * Guarded `localStorage` access.
+ *
+ * Accessing `window.localStorage` can throw — the property access itself, not just
+ * the read or write — so every call has to be wrapped.
+ */
+
+export function isStorageAvailable(): boolean {
+  try {
+    return Boolean(window.localStorage)
+  } catch {
+    return false
+  }
+}
+
+export function getStorageItem(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+export function setStorageItem(key: string, value: string): void {
+  try {
+    window.localStorage.setItem(key, value)
+    // eslint-disable-next-line no-empty
+  } catch {}
+}
+
+export function removeStorageItem(key: string): void {
+  try {
+    window.localStorage.removeItem(key)
+    // eslint-disable-next-line no-empty
+  } catch {}
+}


### PR DESCRIPTION
## Additions

- 新增 `packages/mirror-media-next/utils/safe-storage.ts`，防止存取 `window.localStorage` 有丟出 Error 的可能，而且是在**取屬性本身**就丟，不是等到 `getItem` / `setItem` 才丟，所以不能只包讀寫、必須連取屬性一起包。

## Removals

- N/A

## Changes

  - `components/gdpr.js`：`localStorage.getItem` / `setItem` 改走 `safe-storage`，並在 mount effect 開頭加上 `isStorageAvailable()` 判斷——不可用時直接 return，不顯示 GDPR 提示。
  - `pages/recover-password/index.js`：四個呼叫點（送出成功後寫入冷卻到期時間、mount 時讀取、過期時清除、interval 歸零時清除）改走 `safe-storage`。

## Testing

- Chrome：`chrome://settings/content/siteData` → 選「不允許網站儲存資料」。查看主站是否仍正常運作（但不顯示 GDPR/忘記密碼不會跨 session 紀錄冷卻時間）

## Screenshots

- N/A

## Todos

- N/A

## Task Links

[[週刊] localStorage 的 Security Error](https://app.asana.com/1/614399484723017/project/1217056824510799/task/1217355055064423?focus=true)